### PR TITLE
Effects: catalog, detection, widest-path propagation, renderers

### DIFF
--- a/src/codegraph/cli.py
+++ b/src/codegraph/cli.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 from codegraph import __version__, gitio
 from codegraph.indexer import FsTreeSource, GitTreeSource, Indexer
+from codegraph.query.effects import effects_report
+from codegraph.render import render_json, render_text
 from codegraph.resolve import find_symbol
 from codegraph.store import WORKTREE, Store
 
@@ -71,6 +73,28 @@ def _cmd_resolve(args: argparse.Namespace) -> int:
         store.close()
 
 
+def _cmd_effects(args: argparse.Namespace) -> int:
+    """Report the side effects transitively reachable from a symbol."""
+    root = Path(args.path).resolve()
+    store, indexer = open_workspace(root)
+    try:
+        indexer.reconcile(args.rev)
+        matches = find_symbol(store, args.rev, args.symbol)
+        if not matches:
+            print(f"no symbol matching {args.symbol!r}", file=sys.stderr)
+            return 1
+        if len(matches) > 1:
+            print(f"ambiguous symbol {args.symbol!r}:", file=sys.stderr)
+            for row in matches:
+                print(f"  {row['id']}", file=sys.stderr)
+            return 2
+        report = effects_report(store, args.rev, matches[0]["id"])
+        print(render_json(report) if args.json else render_text(report))
+        return 0
+    finally:
+        store.close()
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="codegraph")
     parser.add_argument("--version", action="version", version=__version__)
@@ -97,6 +121,15 @@ def build_parser() -> argparse.ArgumentParser:
     resolve_parser.add_argument("--path", default=".", help="Repository root (default: cwd)")
     resolve_parser.add_argument("--rev", default=WORKTREE, help="Revision to resolve against")
     resolve_parser.set_defaults(handler=_cmd_resolve)
+
+    effects_parser = subparsers.add_parser(
+        "effects", help="Report side effects reachable from a symbol"
+    )
+    effects_parser.add_argument("symbol", help="Node id, qualname, or trailing name")
+    effects_parser.add_argument("--path", default=".", help="Repository root (default: cwd)")
+    effects_parser.add_argument("--rev", default=WORKTREE, help="Revision to query")
+    effects_parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    effects_parser.set_defaults(handler=_cmd_effects)
 
     return parser
 

--- a/src/codegraph/effects/__init__.py
+++ b/src/codegraph/effects/__init__.py
@@ -1,0 +1,11 @@
+"""Effect catalog: rules and matching for side-effect kinds.
+
+Detecting effects at call sites and propagating them through the call
+graph lives elsewhere (Task 10); this package only owns the rule set.
+"""
+
+from __future__ import annotations
+
+from codegraph.effects.catalog import EFFECT_KINDS, Catalog, Rule
+
+__all__ = ["EFFECT_KINDS", "Catalog", "Rule"]

--- a/src/codegraph/effects/builtin.toml
+++ b/src/codegraph/effects/builtin.toml
@@ -72,7 +72,15 @@ match = "*.execute"
 kind = "DB_WRITE"
 
 [[effect]]
-match = "psycopg*"
+match = "*.fetchone"
+kind = "DB_READ"
+
+[[effect]]
+match = "*.fetchall"
+kind = "DB_READ"
+
+[[effect]]
+match = "*.fetchmany"
 kind = "DB_READ"
 
 [[effect]]

--- a/src/codegraph/effects/builtin.toml
+++ b/src/codegraph/effects/builtin.toml
@@ -1,0 +1,96 @@
+# Built-in effect catalog: dotted-name glob patterns to side-effect kinds.
+#
+# Loaded by `codegraph.effects.catalog.Catalog.load` and merged with a
+# project's `codegraph.toml` [[effect]] overrides. See catalog.py for the
+# matching rule (longest literal prefix wins, overrides break ties).
+#
+# GLOBAL_MUTATE has no entries here by design: it is detected syntactically
+# (assignment to a module/class-level name), not by a call-site catalog.
+
+[[effect]]
+match = "requests.*"
+kind = "NETWORK"
+
+[[effect]]
+match = "httpx.*"
+kind = "NETWORK"
+
+[[effect]]
+match = "urllib.request.*"
+kind = "NETWORK"
+
+[[effect]]
+match = "socket.*"
+kind = "NETWORK"
+
+[[effect]]
+match = "subprocess.*"
+kind = "PROCESS"
+
+[[effect]]
+match = "os.system"
+kind = "PROCESS"
+
+[[effect]]
+match = "os.exec*"
+kind = "PROCESS"
+
+[[effect]]
+match = "os.environ*"
+kind = "ENV_READ"
+
+[[effect]]
+match = "os.getenv"
+kind = "ENV_READ"
+
+[[effect]]
+match = "open"
+kind = "FS_READ"
+
+[[effect]]
+match = "pathlib.Path.read*"
+kind = "FS_READ"
+
+[[effect]]
+match = "pathlib.Path.write*"
+kind = "FS_WRITE"
+
+[[effect]]
+match = "shutil.*"
+kind = "FS_WRITE"
+
+[[effect]]
+match = "*.session.commit"
+kind = "DB_WRITE"
+
+[[effect]]
+match = "*.session.add"
+kind = "DB_WRITE"
+
+[[effect]]
+match = "*.execute"
+kind = "DB_WRITE"
+
+[[effect]]
+match = "psycopg*"
+kind = "DB_READ"
+
+[[effect]]
+match = "boto3.*"
+kind = "DB_WRITE"
+
+[[effect]]
+match = "random.*"
+kind = "NONDETERMINISM"
+
+[[effect]]
+match = "time.time"
+kind = "NONDETERMINISM"
+
+[[effect]]
+match = "uuid.uuid4"
+kind = "NONDETERMINISM"
+
+[[effect]]
+match = "datetime.datetime.now"
+kind = "NONDETERMINISM"

--- a/src/codegraph/effects/catalog.py
+++ b/src/codegraph/effects/catalog.py
@@ -1,0 +1,120 @@
+"""Effect catalog: dotted-name glob patterns mapped to side-effect kinds.
+
+Rules come from two sources merged at load time: the built-in patterns
+shipped in `builtin.toml`, and a project's `codegraph.toml` overrides
+(`Config.effect_overrides`). Most real side effects sit behind house
+abstractions (`app.db.save`), not `requests.get` directly, which is why the
+override channel exists at all rather than the built-in list being enough.
+
+Precedence: on a name that matches more than one rule, the rule with the
+longest leading literal segment (the run of characters before the first
+glob wildcard) wins. `requests.get` (override, fully literal) beats
+`requests.*` (built-in, literal prefix `requests.`), so an override always
+beats a built-in it is more specific than, regardless of load order.
+
+This module owns rules and matching only. Detecting which call sites are
+effects, and propagating that through the call graph, is Task 10.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import re
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NamedTuple
+
+from codegraph.config import Config
+
+EFFECT_KINDS: tuple[str, ...] = (
+    "DB_READ",
+    "DB_WRITE",
+    "NETWORK",
+    "FS_READ",
+    "FS_WRITE",
+    "PROCESS",
+    "ENV_READ",
+    "GLOBAL_MUTATE",
+    "NONDETERMINISM",
+)
+
+_BUILTIN_TOML = Path(__file__).with_name("builtin.toml")
+
+_WILDCARD = re.compile(r"[*?\[]")
+
+
+def _literal_prefix_len(pattern: str) -> int:
+    """Length of the leading run of literal characters before a glob wildcard."""
+    found = _WILDCARD.search(pattern)
+    return found.start() if found else len(pattern)
+
+
+@dataclass(frozen=True)
+class Rule:
+    match: str
+    kind: str
+
+
+class _Compiled(NamedTuple):
+    rule: Rule
+    regex: re.Pattern[str]
+    prefix_len: int
+    is_override: bool
+
+
+def _parse_rules(text: str) -> tuple[Rule, ...]:
+    data = tomllib.loads(text)
+    return tuple(Rule(match=entry["match"], kind=entry["kind"]) for entry in data.get("effect", []))
+
+
+class Catalog:
+    """A merged, ready-to-query set of effect rules."""
+
+    def __init__(self, rules: tuple[Rule, ...], override_count: int) -> None:
+        self._rules = rules
+        first_override = len(rules) - override_count
+        self._compiled = tuple(
+            _Compiled(
+                rule=rule,
+                regex=re.compile(fnmatch.translate(rule.match)),
+                prefix_len=_literal_prefix_len(rule.match),
+                is_override=i >= first_override,
+            )
+            for i, rule in enumerate(rules)
+        )
+
+    @classmethod
+    def load(cls, config: Config) -> Catalog:
+        builtin_rules = _parse_rules(_BUILTIN_TOML.read_text())
+        override_rules = tuple(
+            Rule(match=entry["match"], kind=entry["kind"]) for entry in config.effect_overrides
+        )
+        return cls(builtin_rules + override_rules, len(override_rules))
+
+    def match(self, dotted: str) -> str | None:
+        """The kind of the best-matching rule for `dotted`, or None."""
+        best: _Compiled | None = None
+        for compiled in self._compiled:
+            if not compiled.regex.match(dotted):
+                continue
+            key = (compiled.prefix_len, compiled.is_override, compiled.rule.match)
+            best_key = (
+                (best.prefix_len, best.is_override, best.rule.match) if best is not None else None
+            )
+            if best is None or key > best_key:
+                best = compiled
+        return best.rule.kind if best else None
+
+    def fingerprint(self) -> str:
+        """Stable hash over all rules: same rules -> same digest, any run.
+
+        Unlike `hash()`, which is salted per process, this is a plain
+        SHA-256 over a sorted, delimited encoding of every rule, so it is
+        safe to bake into an on-disk cache key.
+        """
+        digest = hashlib.sha256()
+        for rule in sorted(self._rules, key=lambda r: (r.match, r.kind)):
+            digest.update(f"{rule.match}\x00{rule.kind}\n".encode())
+        return digest.hexdigest()

--- a/src/codegraph/effects/catalog.py
+++ b/src/codegraph/effects/catalog.py
@@ -56,6 +56,13 @@ class Rule:
     match: str
     kind: str
 
+    def __post_init__(self) -> None:
+        if self.kind not in EFFECT_KINDS:
+            raise ValueError(
+                f"unknown effect kind {self.kind!r} for pattern {self.match!r}; "
+                f"must be one of {EFFECT_KINDS}"
+            )
+
 
 class _Compiled(NamedTuple):
     rule: Rule

--- a/src/codegraph/effects/detect.py
+++ b/src/codegraph/effects/detect.py
@@ -1,0 +1,139 @@
+"""Direct effect detection: catalog matches against refs, not edges.
+
+`requests.get` never resolves to a node in this repo -- resolution only
+links to symbols the repo itself defines -- so an edge-only pass would miss
+every external call, which is most real side effects. This module reads
+`blob_refs` (joined through `tree` for the revision) instead: every `call`
+ref is expanded through its file's import map to a canonical dotted name
+and matched against the effect `Catalog`; every `global`/`nonlocal` ref
+(`ref_kind="global"`, from `parse.py`) is a `GLOBAL_MUTATE` by construction,
+since that kind is syntactic and has no catalog pattern.
+"""
+
+from __future__ import annotations
+
+from codegraph.config import Config
+from codegraph.effects.catalog import Catalog
+from codegraph.resolve import (
+    HIGH,
+    MODULE_SCOPE,
+    absolute_module,
+    module_for_path,
+    package_for_module,
+)
+from codegraph.store import Store
+
+
+def detect_direct(store: Store, rev: str, catalog: Catalog) -> int:
+    """Tag every ref in `rev` that is a direct effect. Returns rows written."""
+    connection = store.connection
+    config = Config.load(store.directory.parent)
+    import_maps = _import_maps(store, rev, config)
+    owner_index = _owner_index(store, rev)
+
+    rows: list[tuple] = []
+    for row in connection.execute(
+        "SELECT t.path AS path, r.from_qualname, r.ref_kind, r.raw_name, r.line"
+        " FROM blob_refs r JOIN tree t ON t.blob_sha = r.blob_sha"
+        " WHERE t.rev=? AND r.ref_kind IN ('call', 'global')",
+        (rev,),
+    ):
+        if row["ref_kind"] == "global":
+            kind = "GLOBAL_MUTATE"
+        else:
+            dotted = _expand(row["raw_name"], import_maps.get(row["path"], {}))
+            kind = catalog.match(dotted)
+        if kind is None:
+            continue
+        node_id = _owning_node(row["path"], row["from_qualname"], row["line"], owner_index)
+        rows.append((rev, node_id, kind, 1, row["path"], row["line"], HIGH))
+
+    connection.execute("DELETE FROM effects WHERE rev=? AND direct=1", (rev,))
+    connection.executemany(
+        "INSERT INTO effects(rev, node_id, kind, direct, evidence_path, evidence_line,"
+        " confidence) VALUES(?,?,?,?,?,?,?)",
+        rows,
+    )
+    return len(rows)
+
+
+def _expand(raw_name: str, import_map: dict[str, str]) -> str:
+    """Expand a local alias through the file's import map, e.g. `db.save`
+    (with `from app import db`) -> `app.db.save`, so a project override like
+    `app.db.*` matches the house abstraction rather than the call's literal
+    spelling. A name whose head isn't imported (a builtin, a local, `self`)
+    passes through unchanged, which is what the built-in catalog expects."""
+    head, _, rest = raw_name.partition(".")
+    target = import_map.get(head)
+    if target is None:
+        return raw_name
+    return f"{target}.{rest}" if rest else target
+
+
+def _import_maps(store: Store, rev: str, config: Config) -> dict[str, dict[str, str]]:
+    """Per-path local-alias -> absolute-dotted-module map.
+
+    Mirrors the alias expansion `resolve.py`'s symbol table builds for call
+    resolution, but detection only needs the alias map, not a full resolver.
+    """
+    connection = store.connection
+    paths = [
+        row["path"]
+        for row in connection.execute("SELECT DISTINCT path FROM tree WHERE rev=?", (rev,))
+    ]
+    module_for = {path: module_for_path(path, config.source_roots) for path in paths}
+    maps: dict[str, dict[str, str]] = {path: {} for path in paths}
+
+    rows = connection.execute(
+        "SELECT t.path, i.module, i.level, i.name, i.alias FROM blob_imports i"
+        " JOIN tree t ON t.blob_sha = i.blob_sha WHERE t.rev=? ORDER BY t.path, i.ordinal",
+        (rev,),
+    )
+    for row in rows:
+        path = row["path"]
+        alias_map = maps[path]
+        package = package_for_module(module_for[path], path)
+        module = absolute_module(row["module"], row["level"], package)
+        if row["name"] is None:
+            alias_map[row["alias"] or module] = module
+            if row["alias"] is None:
+                alias_map.setdefault(module.partition(".")[0], module.partition(".")[0])
+        else:
+            target = f"{module}.{row['name']}" if module else row["name"]
+            alias_map[row["alias"] or row["name"]] = target
+    return maps
+
+
+def _owner_index(store: Store, rev: str) -> dict[tuple[str, str], list[tuple[str, int, int]]]:
+    """(path, qualname) -> [(node id, line_start, line_end), ...], including
+    shadowed definitions, so a ref inside a shadowed body still attributes
+    to it rather than to the live definition sharing its name."""
+    index: dict[tuple[str, str], list[tuple[str, int, int]]] = {}
+    for row in store.connection.execute(
+        "SELECT id, path, qualname, line_start, line_end FROM nodes WHERE rev=? ORDER BY id",
+        (rev,),
+    ):
+        index.setdefault((row["path"], row["qualname"]), []).append(
+            (row["id"], row["line_start"], row["line_end"])
+        )
+    return index
+
+
+def _owning_node(
+    path: str,
+    from_qualname: str,
+    line: int,
+    index: dict[tuple[str, str], list[tuple[str, int, int]]],
+) -> str:
+    """The node that owns a ref; mirrors `resolve.py`'s `_source_id`."""
+    if from_qualname == MODULE_SCOPE:
+        return f"{path}::{MODULE_SCOPE}"
+    candidates = index.get((path, from_qualname))
+    if not candidates:
+        return f"{path}::{from_qualname}"
+    if len(candidates) == 1:
+        return candidates[0][0]
+    for node_id, line_start, line_end in candidates:
+        if line_start <= line <= line_end:
+            return node_id
+    return candidates[-1][0]

--- a/src/codegraph/effects/detect.py
+++ b/src/codegraph/effects/detect.py
@@ -14,22 +14,15 @@ from __future__ import annotations
 
 from codegraph.config import Config
 from codegraph.effects.catalog import Catalog
-from codegraph.resolve import (
-    HIGH,
-    MODULE_SCOPE,
-    absolute_module,
-    module_for_path,
-    package_for_module,
-)
+from codegraph.resolve import HIGH, MODULE_SCOPE, build_import_maps
 from codegraph.store import Store
 
 
-def detect_direct(store: Store, rev: str, catalog: Catalog) -> int:
+def detect_direct(store: Store, rev: str, catalog: Catalog, config: Config) -> int:
     """Tag every ref in `rev` that is a direct effect. Returns rows written."""
     connection = store.connection
-    config = Config.load(store.directory.parent)
-    import_maps = _import_maps(store, rev, config)
-    owner_index = _owner_index(store, rev)
+    import_maps, _imported_modules = build_import_maps(connection, rev, config)
+    owner_index, live_index = _owner_index(store, rev)
 
     rows: list[tuple] = []
     for row in connection.execute(
@@ -45,7 +38,9 @@ def detect_direct(store: Store, rev: str, catalog: Catalog) -> int:
             kind = catalog.match(dotted)
         if kind is None:
             continue
-        node_id = _owning_node(row["path"], row["from_qualname"], row["line"], owner_index)
+        node_id = _owning_node(
+            row["path"], row["from_qualname"], row["line"], owner_index, live_index
+        )
         rows.append((rev, node_id, kind, 1, row["path"], row["line"], HIGH))
 
     connection.execute("DELETE FROM effects WHERE rev=? AND direct=1", (rev,))
@@ -70,53 +65,26 @@ def _expand(raw_name: str, import_map: dict[str, str]) -> str:
     return f"{target}.{rest}" if rest else target
 
 
-def _import_maps(store: Store, rev: str, config: Config) -> dict[str, dict[str, str]]:
-    """Per-path local-alias -> absolute-dotted-module map.
-
-    Mirrors the alias expansion `resolve.py`'s symbol table builds for call
-    resolution, but detection only needs the alias map, not a full resolver.
-    """
-    connection = store.connection
-    paths = [
-        row["path"]
-        for row in connection.execute("SELECT DISTINCT path FROM tree WHERE rev=?", (rev,))
-    ]
-    module_for = {path: module_for_path(path, config.source_roots) for path in paths}
-    maps: dict[str, dict[str, str]] = {path: {} for path in paths}
-
-    rows = connection.execute(
-        "SELECT t.path, i.module, i.level, i.name, i.alias FROM blob_imports i"
-        " JOIN tree t ON t.blob_sha = i.blob_sha WHERE t.rev=? ORDER BY t.path, i.ordinal",
-        (rev,),
-    )
-    for row in rows:
-        path = row["path"]
-        alias_map = maps[path]
-        package = package_for_module(module_for[path], path)
-        module = absolute_module(row["module"], row["level"], package)
-        if row["name"] is None:
-            alias_map[row["alias"] or module] = module
-            if row["alias"] is None:
-                alias_map.setdefault(module.partition(".")[0], module.partition(".")[0])
-        else:
-            target = f"{module}.{row['name']}" if module else row["name"]
-            alias_map[row["alias"] or row["name"]] = target
-    return maps
-
-
-def _owner_index(store: Store, rev: str) -> dict[tuple[str, str], list[tuple[str, int, int]]]:
+def _owner_index(
+    store: Store, rev: str
+) -> tuple[dict[tuple[str, str], list[tuple[str, int, int]]], dict[tuple[str, str], str]]:
     """(path, qualname) -> [(node id, line_start, line_end), ...], including
     shadowed definitions, so a ref inside a shadowed body still attributes
-    to it rather than to the live definition sharing its name."""
+    to it rather than to the live definition sharing its name; and
+    (path, qualname) -> live node id, mirroring `resolve.py`'s
+    `qualname_index` for the same-fallback reason `_owning_node` uses it."""
     index: dict[tuple[str, str], list[tuple[str, int, int]]] = {}
+    live: dict[tuple[str, str], str] = {}
     for row in store.connection.execute(
-        "SELECT id, path, qualname, line_start, line_end FROM nodes WHERE rev=? ORDER BY id",
+        "SELECT id, path, qualname, line_start, line_end, name_binding FROM nodes"
+        " WHERE rev=? ORDER BY id",
         (rev,),
     ):
-        index.setdefault((row["path"], row["qualname"]), []).append(
-            (row["id"], row["line_start"], row["line_end"])
-        )
-    return index
+        key = (row["path"], row["qualname"])
+        index.setdefault(key, []).append((row["id"], row["line_start"], row["line_end"]))
+        if row["name_binding"] == "live":
+            live[key] = row["id"]
+    return index, live
 
 
 def _owning_node(
@@ -124,11 +92,16 @@ def _owning_node(
     from_qualname: str,
     line: int,
     index: dict[tuple[str, str], list[tuple[str, int, int]]],
+    live: dict[tuple[str, str], str],
 ) -> str:
-    """The node that owns a ref; mirrors `resolve.py`'s `_source_id`."""
+    """The node that owns a ref; mirrors `resolve.py`'s `_source_id`,
+    including its fallback to the live binding (not just "the last
+    candidate") when a ref's line falls inside no recorded span -- so
+    detection and resolution attribute the same ref to the same node."""
     if from_qualname == MODULE_SCOPE:
         return f"{path}::{MODULE_SCOPE}"
-    candidates = index.get((path, from_qualname))
+    key = (path, from_qualname)
+    candidates = index.get(key)
     if not candidates:
         return f"{path}::{from_qualname}"
     if len(candidates) == 1:
@@ -136,4 +109,4 @@ def _owning_node(
     for node_id, line_start, line_end in candidates:
         if line_start <= line <= line_end:
             return node_id
-    return candidates[-1][0]
+    return live.get(key, candidates[-1][0])

--- a/src/codegraph/effects/propagate.py
+++ b/src/codegraph/effects/propagate.py
@@ -1,0 +1,221 @@
+"""Effect propagation: `effects(n) = direct(n) UNION union(effects(callees))`
+over the `CALLS` edge closure for one revision.
+
+Strongly connected components of the call graph are condensed with Tarjan's
+algorithm first, so every member of a recursion cycle shares one effect
+union computed once. A naive recursive walk without this recurses forever
+on mutual recursion (`ping` calls `pong` calls `ping` ...) -- that's what
+`test_recursion_cycle_does_not_hang` guards against. Once condensed, the
+component graph is a DAG, so a single memoized post-order walk computes
+every component's effect set in one pass, carrying confidence as the
+minimum along whichever concrete edge/path produced the strongest claim.
+
+`witness_path` is a separate, on-demand BFS over the (uncondensed) `CALLS`
+graph, used at query time. BFS never revisits a node, so cycles are handled
+for free there and it needs no SCC step of its own.
+
+This module never queries the effect `Catalog`: it only reads `effects`
+rows Task 10's `detect_direct` already wrote, and `edges`.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Iterator
+
+from codegraph.resolve import HIGH, LOW, MEDIUM
+from codegraph.store import Store
+
+_RANK = {LOW: 0, MEDIUM: 1, HIGH: 2}
+
+
+def _weaker(a: str, b: str) -> str:
+    return a if _RANK[a] <= _RANK[b] else b
+
+
+def _stronger(a: str, b: str) -> str:
+    return a if _RANK[a] >= _RANK[b] else b
+
+
+def propagate(store: Store, rev: str) -> int:
+    """Write transitive (`direct=0`) effect rows for `rev`. Returns the
+    count of rows written."""
+    connection = store.connection
+    connection.execute("DELETE FROM effects WHERE rev=? AND direct=0", (rev,))
+
+    node_ids = {row["id"] for row in connection.execute("SELECT id FROM nodes WHERE rev=?", (rev,))}
+    calls: dict[str, set[str]] = {node_id: set() for node_id in node_ids}
+    edge_confidence: dict[tuple[str, str], str] = {}
+    for row in connection.execute(
+        "SELECT src, dst, confidence FROM edges WHERE rev=? AND kind='CALLS'", (rev,)
+    ):
+        src, dst, confidence = row["src"], row["dst"], row["confidence"]
+        if src not in node_ids or dst not in node_ids:
+            continue
+        calls[src].add(dst)
+        key = (src, dst)
+        edge_confidence[key] = _stronger(edge_confidence.get(key, confidence), confidence)
+
+    direct_by_node: dict[str, dict[str, str]] = {}
+    for row in connection.execute(
+        "SELECT node_id, kind, confidence FROM effects WHERE rev=? AND direct=1", (rev,)
+    ):
+        bucket = direct_by_node.setdefault(row["node_id"], {})
+        bucket[row["kind"]] = _stronger(
+            bucket.get(row["kind"], row["confidence"]), row["confidence"]
+        )
+
+    components, comp_of = _tarjan_scc(node_ids, calls)
+
+    comp_direct: dict[int, dict[str, str]] = {}
+    for node_id, node_kinds in direct_by_node.items():
+        comp = comp_of.get(node_id)
+        if comp is None:
+            continue
+        bucket = comp_direct.setdefault(comp, {})
+        for kind, confidence in node_kinds.items():
+            bucket[kind] = _stronger(bucket.get(kind, confidence), confidence)
+
+    comp_edges: dict[int, dict[int, str]] = {}
+    for (src, dst), confidence in edge_confidence.items():
+        c_src, c_dst = comp_of[src], comp_of[dst]
+        if c_src == c_dst:
+            continue
+        bucket = comp_edges.setdefault(c_src, {})
+        bucket[c_dst] = _stronger(bucket.get(c_dst, confidence), confidence)
+
+    # The condensation is a DAG (Tarjan guarantees no cycles between
+    # distinct components), so a plain memoized recursion terminates.
+    cache: dict[int, dict[str, str]] = {}
+
+    def comp_effects(comp: int) -> dict[str, str]:
+        if comp in cache:
+            return cache[comp]
+        result = dict(comp_direct.get(comp, {}))
+        for succ, edge_conf in comp_edges.get(comp, {}).items():
+            for kind, confidence in comp_effects(succ).items():
+                propagated = _weaker(edge_conf, confidence)
+                if kind not in result or _RANK[propagated] > _RANK[result[kind]]:
+                    result[kind] = propagated
+        cache[comp] = result
+        return result
+
+    rows: list[tuple] = []
+    for comp_index in range(len(components)):
+        effects_here = comp_effects(comp_index)
+        if not effects_here:
+            continue
+        for node_id in components[comp_index]:
+            own_direct = direct_by_node.get(node_id, {})
+            for kind, confidence in effects_here.items():
+                if kind in own_direct:
+                    continue
+                rows.append((rev, node_id, kind, 0, None, None, confidence))
+
+    connection.executemany(
+        "INSERT INTO effects(rev, node_id, kind, direct, evidence_path, evidence_line,"
+        " confidence) VALUES(?,?,?,?,?,?,?)",
+        rows,
+    )
+    return len(rows)
+
+
+def _tarjan_scc(
+    nodes: set[str], adjacency: dict[str, set[str]]
+) -> tuple[list[list[str]], dict[str, int]]:
+    """Tarjan's strongly-connected-components algorithm, iterative so a deep
+    call graph can't blow the interpreter's recursion limit."""
+    index_of: dict[str, int] = {}
+    lowlink: dict[str, int] = {}
+    on_stack: set[str] = set()
+    stack: list[str] = []
+    components: list[list[str]] = []
+    counter = 0
+
+    def strongconnect(root: str) -> None:
+        nonlocal counter
+        work: list[tuple[str, Iterator[str]]] = [(root, iter(adjacency.get(root, ())))]
+        index_of[root] = counter
+        lowlink[root] = counter
+        counter += 1
+        stack.append(root)
+        on_stack.add(root)
+
+        while work:
+            v, neighbors = work[-1]
+            advanced = False
+            for w in neighbors:
+                if w not in index_of:
+                    index_of[w] = counter
+                    lowlink[w] = counter
+                    counter += 1
+                    stack.append(w)
+                    on_stack.add(w)
+                    work.append((w, iter(adjacency.get(w, ()))))
+                    advanced = True
+                    break
+                if w in on_stack:
+                    lowlink[v] = min(lowlink[v], index_of[w])
+            if advanced:
+                continue
+
+            work.pop()
+            if work:
+                parent = work[-1][0]
+                lowlink[parent] = min(lowlink[parent], lowlink[v])
+            if lowlink[v] == index_of[v]:
+                component = []
+                while True:
+                    w = stack.pop()
+                    on_stack.discard(w)
+                    component.append(w)
+                    if w == v:
+                        break
+                components.append(component)
+
+    for node in nodes:
+        if node not in index_of:
+            strongconnect(node)
+
+    comp_of = {node_id: i for i, component in enumerate(components) for node_id in component}
+    return components, comp_of
+
+
+def witness_path(store: Store, rev: str, node_id: str, kind: str) -> list[str]:
+    """Shortest chain of node ids from `node_id` to a node whose direct
+    effect of `kind` causes it, via `CALLS` edges. `[]` if none exists."""
+    connection = store.connection
+    direct_nodes = {
+        row["node_id"]
+        for row in connection.execute(
+            "SELECT DISTINCT node_id FROM effects WHERE rev=? AND kind=? AND direct=1",
+            (rev, kind),
+        )
+    }
+    if node_id in direct_nodes:
+        return [node_id]
+
+    calls: dict[str, list[str]] = {}
+    for row in connection.execute(
+        "SELECT DISTINCT src, dst FROM edges WHERE rev=? AND kind='CALLS'", (rev,)
+    ):
+        calls.setdefault(row["src"], []).append(row["dst"])
+
+    visited = {node_id}
+    parent: dict[str, str] = {}
+    queue: deque[str] = deque([node_id])
+    while queue:
+        current = queue.popleft()
+        for nxt in calls.get(current, ()):
+            if nxt in visited:
+                continue
+            visited.add(nxt)
+            parent[nxt] = current
+            if nxt in direct_nodes:
+                chain = [nxt]
+                while chain[-1] != node_id:
+                    chain.append(parent[chain[-1]])
+                chain.reverse()
+                return chain
+            queue.append(nxt)
+    return []

--- a/src/codegraph/effects/propagate.py
+++ b/src/codegraph/effects/propagate.py
@@ -1,41 +1,57 @@
-"""Effect propagation: `effects(n) = direct(n) UNION union(effects(callees))`
-over the `CALLS` edge closure for one revision.
+"""Effect propagation: for each node, the strongest confidence tier at
+which it can reach an effect-bearing node, over the `CALLS` edge closure
+for one revision.
 
-Strongly connected components of the call graph are condensed with Tarjan's
-algorithm first, so every member of a recursion cycle shares one effect
-union computed once. A naive recursive walk without this recurses forever
-on mutual recursion (`ping` calls `pong` calls `ping` ...) -- that's what
-`test_recursion_cycle_does_not_hang` guards against. Once condensed, the
-component graph is a DAG, so a single memoized post-order walk computes
-every component's effect set in one pass, carrying confidence as the
-minimum along whichever concrete edge/path produced the strongest claim.
+This is the classic widest-path (bottleneck shortest-path) problem: a
+node's confidence for an effect is `max` over every path to a node that has
+that effect directly, of the `min` edge confidence along that path. Rather
+than search per-path, it is solved level-wise: for each confidence tier,
+strongest first (`HIGH`, then `MEDIUM`, then `LOW`), build the subgraph of
+`CALLS` edges at that tier or better, and find every node that can reach an
+effect-bearing node within it via plain reachability -- multi-source BFS on
+the reversed graph, starting from the effect-bearing nodes. The first
+(strongest) tier at which a node reaches an effect wins; a weaker tier
+never overwrites it.
 
-`witness_path` is a separate, on-demand BFS over the (uncondensed) `CALLS`
-graph, used at query time. BFS never revisits a node, so cycles are handled
-for free there and it needs no SCC step of its own. It is confidence-aware:
-`propagate` reports the *best* confidence over every path (the aggregate
-claim "this effect is reachable, at the strongest confidence any path
-supports"), so the witness search is restricted to edges strong enough to
-support that same confidence -- otherwise the printed chain could be a
-weak, unrelated path to a claim it does not actually justify.
+Plain reachability handles cycles for free -- a visited set is all it
+takes -- so mutual recursion (`ping` calls `pong` calls `ping` ...) needs
+no special handling; `test_recursion_cycle_does_not_hang` passes without
+any SCC step. An earlier version of this module condensed strongly
+connected components with Tarjan and unioned effects across each
+component, but that scheme could hand out a confidence no real path
+supported: it merged a component member's direct effect into the whole
+component's set without accounting for the edge confidence needed to
+*reach* that member from elsewhere in the cycle. Concretely: `A --LOW-->
+B`, `B --HIGH--> A`, `B` has a direct HIGH effect -- the old code merged
+B's HIGH straight into the shared `{A, B}` union, reporting HIGH for A even
+though the only way out of A is the LOW edge. Level-wise reachability does
+not have that failure mode, because the tier a node's confidence is
+assigned at is exactly the subgraph a path was found to exist in -- there
+is no condensation step to smuggle a stronger neighbor's confidence past
+the weak edge needed to reach it.
+
+`witness_path` reconstructs that path on demand at query time: a forward
+BFS from the queried node, restricted to `CALLS` edges at the reported
+confidence or better. Because `propagate` only ever assigns a confidence
+for which such a path exists, this BFS is total -- it cannot come back
+empty for a `(node_id, kind, confidence)` triple `propagate` actually
+produced.
 
 This module never queries the effect `Catalog`: it only reads `effects`
-rows Task 10's `detect_direct` already wrote, and `edges`.
+rows `detect_direct` already wrote, and `edges`.
 """
 
 from __future__ import annotations
 
 from collections import deque
-from collections.abc import Iterator
 
 from codegraph.resolve import HIGH, LOW, MEDIUM
 from codegraph.store import Store
 
+#: Strongest first: the order `propagate` walks tiers in, since the first
+#: (strongest) tier at which a node reaches an effect is the one that wins.
+_TIERS = (HIGH, MEDIUM, LOW)
 _RANK = {LOW: 0, MEDIUM: 1, HIGH: 2}
-
-
-def _weaker(a: str, b: str) -> str:
-    return a if _RANK[a] <= _RANK[b] else b
 
 
 def _stronger(a: str, b: str) -> str:
@@ -49,7 +65,7 @@ def propagate(store: Store, rev: str) -> int:
     connection.execute("DELETE FROM effects WHERE rev=? AND direct=0", (rev,))
 
     node_ids = {row["id"] for row in connection.execute("SELECT id FROM nodes WHERE rev=?", (rev,))}
-    calls: dict[str, set[str]] = {node_id: set() for node_id in node_ids}
+
     edge_confidence: dict[tuple[str, str], str] = {}
     for row in connection.execute(
         "SELECT src, dst, confidence FROM edges WHERE rev=? AND kind='CALLS'", (rev,)
@@ -57,65 +73,45 @@ def propagate(store: Store, rev: str) -> int:
         src, dst, confidence = row["src"], row["dst"], row["confidence"]
         if src not in node_ids or dst not in node_ids:
             continue
-        calls[src].add(dst)
         key = (src, dst)
         edge_confidence[key] = _stronger(edge_confidence.get(key, confidence), confidence)
 
+    # reverse_by_tier[tier][dst] = every src with an edge src->dst whose
+    # confidence is at least `tier`. These are nested supersets as the tier
+    # weakens: the HIGH subgraph is a subset of MEDIUM-or-better, which is a
+    # subset of LOW-or-better (everything).
+    reverse_by_tier: dict[str, dict[str, set[str]]] = {tier: {} for tier in _TIERS}
+    for (src, dst), confidence in edge_confidence.items():
+        rank = _RANK[confidence]
+        for tier in _TIERS:
+            if _RANK[tier] <= rank:
+                reverse_by_tier[tier].setdefault(dst, set()).add(src)
+
     direct_by_node: dict[str, dict[str, str]] = {}
+    direct_nodes_by_kind: dict[str, set[str]] = {}
     for row in connection.execute(
         "SELECT node_id, kind, confidence FROM effects WHERE rev=? AND direct=1", (rev,)
     ):
-        bucket = direct_by_node.setdefault(row["node_id"], {})
-        bucket[row["kind"]] = _stronger(
-            bucket.get(row["kind"], row["confidence"]), row["confidence"]
-        )
+        direct_by_node.setdefault(row["node_id"], {})[row["kind"]] = row["confidence"]
+        direct_nodes_by_kind.setdefault(row["kind"], set()).add(row["node_id"])
 
-    components, comp_of = _tarjan_scc(node_ids, calls)
-
-    comp_direct: dict[int, dict[str, str]] = {}
-    for node_id, node_kinds in direct_by_node.items():
-        comp = comp_of.get(node_id)
-        if comp is None:
-            continue
-        bucket = comp_direct.setdefault(comp, {})
-        for kind, confidence in node_kinds.items():
-            bucket[kind] = _stronger(bucket.get(kind, confidence), confidence)
-
-    comp_edges: dict[int, dict[int, str]] = {}
-    for (src, dst), confidence in edge_confidence.items():
-        c_src, c_dst = comp_of[src], comp_of[dst]
-        if c_src == c_dst:
-            continue
-        bucket = comp_edges.setdefault(c_src, {})
-        bucket[c_dst] = _stronger(bucket.get(c_dst, confidence), confidence)
-
-    # The condensation is a DAG (Tarjan guarantees no cycles between
-    # distinct components), so a plain memoized recursion terminates.
-    cache: dict[int, dict[str, str]] = {}
-
-    def comp_effects(comp: int) -> dict[str, str]:
-        if comp in cache:
-            return cache[comp]
-        result = dict(comp_direct.get(comp, {}))
-        for succ, edge_conf in comp_edges.get(comp, {}).items():
-            for kind, confidence in comp_effects(succ).items():
-                propagated = _weaker(edge_conf, confidence)
-                if kind not in result or _RANK[propagated] > _RANK[result[kind]]:
-                    result[kind] = propagated
-        cache[comp] = result
-        return result
+    # node_confidence[node][kind] = the strongest tier at which `node` can
+    # reach some node that carries `kind` directly.
+    node_confidence: dict[str, dict[str, str]] = {}
+    for tier in _TIERS:
+        adjacency = reverse_by_tier[tier]
+        for kind, sources in direct_nodes_by_kind.items():
+            for node_id in _reverse_reachable(sources, adjacency):
+                bucket = node_confidence.setdefault(node_id, {})
+                bucket.setdefault(kind, tier)
 
     rows: list[tuple] = []
-    for comp_index in range(len(components)):
-        effects_here = comp_effects(comp_index)
-        if not effects_here:
-            continue
-        for node_id in components[comp_index]:
-            own_direct = direct_by_node.get(node_id, {})
-            for kind, confidence in effects_here.items():
-                if kind in own_direct:
-                    continue
-                rows.append((rev, node_id, kind, 0, None, None, confidence))
+    for node_id, kinds in node_confidence.items():
+        own_direct = direct_by_node.get(node_id, {})
+        for kind, confidence in kinds.items():
+            if kind in own_direct:
+                continue
+            rows.append((rev, node_id, kind, 0, None, None, confidence))
 
     connection.executemany(
         "INSERT INTO effects(rev, node_id, kind, direct, evidence_path, evidence_line,"
@@ -125,76 +121,32 @@ def propagate(store: Store, rev: str) -> int:
     return len(rows)
 
 
-def _tarjan_scc(
-    nodes: set[str], adjacency: dict[str, set[str]]
-) -> tuple[list[list[str]], dict[str, int]]:
-    """Tarjan's strongly-connected-components algorithm, iterative so a deep
-    call graph can't blow the interpreter's recursion limit."""
-    index_of: dict[str, int] = {}
-    lowlink: dict[str, int] = {}
-    on_stack: set[str] = set()
-    stack: list[str] = []
-    components: list[list[str]] = []
-    counter = 0
-
-    def strongconnect(root: str) -> None:
-        nonlocal counter
-        work: list[tuple[str, Iterator[str]]] = [(root, iter(adjacency.get(root, ())))]
-        index_of[root] = counter
-        lowlink[root] = counter
-        counter += 1
-        stack.append(root)
-        on_stack.add(root)
-
-        while work:
-            v, neighbors = work[-1]
-            advanced = False
-            for w in neighbors:
-                if w not in index_of:
-                    index_of[w] = counter
-                    lowlink[w] = counter
-                    counter += 1
-                    stack.append(w)
-                    on_stack.add(w)
-                    work.append((w, iter(adjacency.get(w, ()))))
-                    advanced = True
-                    break
-                if w in on_stack:
-                    lowlink[v] = min(lowlink[v], index_of[w])
-            if advanced:
-                continue
-
-            work.pop()
-            if work:
-                parent = work[-1][0]
-                lowlink[parent] = min(lowlink[parent], lowlink[v])
-            if lowlink[v] == index_of[v]:
-                component = []
-                while True:
-                    w = stack.pop()
-                    on_stack.discard(w)
-                    component.append(w)
-                    if w == v:
-                        break
-                components.append(component)
-
-    for node in nodes:
-        if node not in index_of:
-            strongconnect(node)
-
-    comp_of = {node_id: i for i, component in enumerate(components) for node_id in component}
-    return components, comp_of
+def _reverse_reachable(sources: set[str], adjacency: dict[str, set[str]]) -> set[str]:
+    """Every node that can reach some node in `sources` via the forward
+    edges `adjacency` encodes in reverse (`adjacency[dst]` is every direct
+    predecessor of `dst`). Multi-source BFS on the reverse graph; a plain
+    visited set makes this correct in the presence of cycles without any
+    extra bookkeeping."""
+    visited = set(sources)
+    queue: deque[str] = deque(sources)
+    while queue:
+        current = queue.popleft()
+        for predecessor in adjacency.get(current, ()):
+            if predecessor not in visited:
+                visited.add(predecessor)
+                queue.append(predecessor)
+    return visited
 
 
 def witness_path(store: Store, rev: str, node_id: str, kind: str, confidence: str) -> list[str]:
     """Fewest-hop chain of node ids from `node_id` to a node whose direct
     effect of `kind` causes it, restricted to `CALLS` edges strong enough
-    to support `confidence` -- the aggregate value `propagate` already
-    computed as the best achievable across every path. Every edge on the
-    chain has confidence >= `confidence`, so the chain's own bottleneck
-    confidence is never weaker than the number printed next to it. `[]` if
-    no such chain exists (should not happen for a `(node_id, kind)` pair
-    `propagate` actually produced this confidence for)."""
+    to support `confidence` -- the value `propagate` already computed as
+    the strongest tier at which `node_id` can reach an effect of this
+    kind. Every edge on the chain has confidence >= `confidence`, so the
+    chain's own bottleneck confidence is never weaker than the number
+    printed next to it. `[]` if no such chain exists (should not happen
+    for a `(node_id, kind, confidence)` triple `propagate` produced)."""
     connection = store.connection
     direct_nodes = {
         row["node_id"]

--- a/src/codegraph/effects/propagate.py
+++ b/src/codegraph/effects/propagate.py
@@ -12,7 +12,12 @@ minimum along whichever concrete edge/path produced the strongest claim.
 
 `witness_path` is a separate, on-demand BFS over the (uncondensed) `CALLS`
 graph, used at query time. BFS never revisits a node, so cycles are handled
-for free there and it needs no SCC step of its own.
+for free there and it needs no SCC step of its own. It is confidence-aware:
+`propagate` reports the *best* confidence over every path (the aggregate
+claim "this effect is reachable, at the strongest confidence any path
+supports"), so the witness search is restricted to edges strong enough to
+support that same confidence -- otherwise the printed chain could be a
+weak, unrelated path to a claim it does not actually justify.
 
 This module never queries the effect `Catalog`: it only reads `effects`
 rows Task 10's `detect_direct` already wrote, and `edges`.
@@ -181,9 +186,15 @@ def _tarjan_scc(
     return components, comp_of
 
 
-def witness_path(store: Store, rev: str, node_id: str, kind: str) -> list[str]:
-    """Shortest chain of node ids from `node_id` to a node whose direct
-    effect of `kind` causes it, via `CALLS` edges. `[]` if none exists."""
+def witness_path(store: Store, rev: str, node_id: str, kind: str, confidence: str) -> list[str]:
+    """Fewest-hop chain of node ids from `node_id` to a node whose direct
+    effect of `kind` causes it, restricted to `CALLS` edges strong enough
+    to support `confidence` -- the aggregate value `propagate` already
+    computed as the best achievable across every path. Every edge on the
+    chain has confidence >= `confidence`, so the chain's own bottleneck
+    confidence is never weaker than the number printed next to it. `[]` if
+    no such chain exists (should not happen for a `(node_id, kind)` pair
+    `propagate` actually produced this confidence for)."""
     connection = store.connection
     direct_nodes = {
         row["node_id"]
@@ -195,11 +206,21 @@ def witness_path(store: Store, rev: str, node_id: str, kind: str) -> list[str]:
     if node_id in direct_nodes:
         return [node_id]
 
-    calls: dict[str, list[str]] = {}
+    target_rank = _RANK[confidence]
+    edge_confidence: dict[tuple[str, str], str] = {}
     for row in connection.execute(
-        "SELECT DISTINCT src, dst FROM edges WHERE rev=? AND kind='CALLS'", (rev,)
+        "SELECT src, dst, confidence FROM edges WHERE rev=? AND kind='CALLS'", (rev,)
     ):
-        calls.setdefault(row["src"], []).append(row["dst"])
+        key = (row["src"], row["dst"])
+        edge_confidence[key] = _stronger(
+            edge_confidence.get(key, row["confidence"]), row["confidence"]
+        )
+
+    calls: dict[str, list[str]] = {}
+    for (src, dst), conf in edge_confidence.items():
+        if _RANK[conf] < target_rank:
+            continue
+        calls.setdefault(src, []).append(dst)
 
     visited = {node_id}
     parent: dict[str, str] = {}

--- a/src/codegraph/indexer.py
+++ b/src/codegraph/indexer.py
@@ -167,7 +167,7 @@ class Indexer:
             # transaction: a revision is never visible with edges but
             # stale (or missing) effects.
             catalog = Catalog.load(self.config)
-            detect_direct(self.store, rev, catalog)
+            detect_direct(self.store, rev, catalog, self.config)
             propagate(self.store, rev)
 
         return IndexStats(

--- a/src/codegraph/indexer.py
+++ b/src/codegraph/indexer.py
@@ -18,6 +18,9 @@ from typing import Protocol
 
 from codegraph import gitio
 from codegraph.config import Config
+from codegraph.effects.catalog import Catalog
+from codegraph.effects.detect import detect_direct
+from codegraph.effects.propagate import propagate
 from codegraph.parse import PARSER_VERSION, parse_blob
 from codegraph.resolve import MODULE_SCOPE, resolve_revision
 from codegraph.store import WORKTREE, Store
@@ -159,6 +162,13 @@ class Indexer:
             # Phase 2 runs inside the same transaction: a revision is never
             # visible with materialized nodes but stale edges.
             resolved = resolve_revision(self.store, rev, self.config)
+
+            # Effect detection and propagation close out the same
+            # transaction: a revision is never visible with edges but
+            # stale (or missing) effects.
+            catalog = Catalog.load(self.config)
+            detect_direct(self.store, rev, catalog)
+            propagate(self.store, rev)
 
         return IndexStats(
             paths_total=len(tree),

--- a/src/codegraph/parse.py
+++ b/src/codegraph/parse.py
@@ -197,6 +197,30 @@ class _Collector(ast.NodeVisitor):
             )
         self.generic_visit(node)
 
+    def visit_Global(self, node: ast.Global) -> None:
+        self._record_global(node, node.names)
+
+    def visit_Nonlocal(self, node: ast.Nonlocal) -> None:
+        self._record_global(node, node.names)
+
+    def _record_global(self, node: ast.AST, names: list[str]) -> None:
+        # `global`/`nonlocal` both bind the name to an outer scope, so a
+        # write to it after this statement is a mutation of shared state --
+        # GLOBAL_MUTATE has no catalog pattern to match against; this is
+        # the syntactic detection Task 10 hooks into.
+        owner = self._current_owner.removesuffix(".<locals>")
+        for name in names:
+            self.refs.append(
+                ParsedRef(
+                    ordinal=len(self.refs),
+                    from_qualname=owner,
+                    ref_kind="global",
+                    raw_name=name,
+                    dotted=None,
+                    line=node.lineno,
+                )
+            )
+
     def visit_Import(self, node: ast.Import) -> None:
         for alias in node.names:
             self.imports.append(

--- a/src/codegraph/query/__init__.py
+++ b/src/codegraph/query/__init__.py
@@ -1,0 +1,7 @@
+"""Query layer: convert graph state into `Report`s for CLI commands."""
+
+from __future__ import annotations
+
+from codegraph.query.effects import effects_report
+
+__all__ = ["effects_report"]

--- a/src/codegraph/query/effects.py
+++ b/src/codegraph/query/effects.py
@@ -49,7 +49,7 @@ def effects_report(store: Store, rev: str, node_id: str) -> Report:
     groups: list[Group] = []
     for rank, kind in enumerate(ordered):
         confidence = node_kinds[kind]
-        chain = witness_path(store, rev, node_id, kind)
+        chain = witness_path(store, rev, node_id, kind, confidence)
         cause = chain[-1] if chain else node_id
         location = _evidence_location(store, rev, cause, kind)
         detail = f"{kind} {confidence} via {' -> '.join(chain)}"

--- a/src/codegraph/query/effects.py
+++ b/src/codegraph/query/effects.py
@@ -1,0 +1,78 @@
+"""The `effects` report: every side-effect kind reachable from a symbol,
+with a witness path a user can verify in one click.
+
+Groups by effect kind (one row per kind), sorted worst-first by severity
+then by confidence. `Row.detail` is `f"{kind} {confidence} via {chain}"` --
+the effect kind must stay the first whitespace-separated token, since this
+module's own tests and Task 11's both split on it.
+"""
+
+from __future__ import annotations
+
+from codegraph.effects.propagate import witness_path
+from codegraph.render import Group, Report, Row
+from codegraph.store import Store
+
+#: Worst-first. DB writes and network calls are the effects a reviewer
+#: should see before anything else; nondeterminism is the mildest of the nine.
+_SEVERITY: tuple[str, ...] = (
+    "DB_WRITE",
+    "NETWORK",
+    "PROCESS",
+    "FS_WRITE",
+    "GLOBAL_MUTATE",
+    "DB_READ",
+    "FS_READ",
+    "ENV_READ",
+    "NONDETERMINISM",
+)
+_SEVERITY_RANK = {kind: rank for rank, kind in enumerate(_SEVERITY)}
+_CONFIDENCE_RANK = {"HIGH": 0, "MEDIUM": 1, "LOW": 2}
+
+
+def effects_report(store: Store, rev: str, node_id: str) -> Report:
+    """Every effect kind reachable from `node_id`, one group per kind."""
+    connection = store.connection
+    node_kinds: dict[str, str] = {}
+    for row in connection.execute(
+        "SELECT kind, confidence FROM effects WHERE rev=? AND node_id=?", (rev, node_id)
+    ):
+        best = node_kinds.get(row["kind"])
+        if best is None or _CONFIDENCE_RANK[row["confidence"]] < _CONFIDENCE_RANK[best]:
+            node_kinds[row["kind"]] = row["confidence"]
+
+    ordered = sorted(
+        node_kinds,
+        key=lambda k: (_SEVERITY_RANK.get(k, len(_SEVERITY)), _CONFIDENCE_RANK[node_kinds[k]]),
+    )
+
+    groups: list[Group] = []
+    for rank, kind in enumerate(ordered):
+        confidence = node_kinds[kind]
+        chain = witness_path(store, rev, node_id, kind)
+        cause = chain[-1] if chain else node_id
+        location = _evidence_location(store, rev, cause, kind)
+        detail = f"{kind} {confidence} via {' -> '.join(chain)}"
+        score = float(len(ordered) - rank)
+        row = Row(id=f"{node_id}::{kind}", location=location, detail=detail, score=score)
+        groups.append(Group(kind, [row]))
+
+    return Report(
+        summary={"symbol": node_id, "effect_kinds": len(ordered)},
+        groups=groups,
+        truncated=False,
+    )
+
+
+def _evidence_location(store: Store, rev: str, direct_node_id: str, kind: str) -> str:
+    """The concrete `path:line` of the direct call site causing `kind` at
+    `direct_node_id` -- the tail of the witness chain."""
+    row = store.connection.execute(
+        "SELECT evidence_path, evidence_line FROM effects"
+        " WHERE rev=? AND node_id=? AND kind=? AND direct=1"
+        " ORDER BY evidence_line LIMIT 1",
+        (rev, direct_node_id, kind),
+    ).fetchone()
+    if row is None:
+        return ""
+    return f"{row['evidence_path']}:{row['evidence_line']}"

--- a/src/codegraph/render.py
+++ b/src/codegraph/render.py
@@ -1,0 +1,100 @@
+"""Presentation layer: convert reports to text and JSON."""
+
+import dataclasses
+import json
+
+
+@dataclasses.dataclass(frozen=True)
+class Row:
+    """A single result row."""
+
+    id: str
+    location: str
+    detail: str
+    score: float
+
+
+@dataclasses.dataclass(frozen=True)
+class Group:
+    """A group of rows with a title."""
+
+    title: str
+    rows: list[Row]
+
+
+@dataclasses.dataclass(frozen=True)
+class Report:
+    """A full report with summary, groups, and truncation flag."""
+
+    summary: dict
+    groups: list[Group]
+    truncated: bool
+
+
+def budget(rows: list[Row], limit: int) -> tuple[list[Row], bool]:
+    """Sort rows by score descending, keep top limit, return (kept, truncated).
+
+    Args:
+        rows: List of Row objects to budget.
+        limit: Maximum number of rows to keep.
+
+    Returns:
+        Tuple of (kept rows sorted by score descending, was_truncated).
+        was_truncated is True if len(rows) > limit.
+    """
+    was_truncated = len(rows) > limit
+    sorted_rows = sorted(rows, key=lambda r: r.score, reverse=True)
+    kept = sorted_rows[:limit]
+    return kept, was_truncated
+
+
+def render_text(report: Report) -> str:
+    """Render report as human-readable text.
+
+    Format:
+    - First line: summary items joined with ' · '
+    - Then each group as a heading followed by indented rows
+
+    Args:
+        report: Report to render.
+
+    Returns:
+        Formatted text string.
+    """
+    lines = []
+
+    # Summary line: join all values with ' · '
+    summary_items = [str(v) for v in report.summary.values()]
+    summary_line = " · ".join(summary_items)
+    lines.append(summary_line)
+
+    # Groups
+    for group in report.groups:
+        lines.append(group.title)
+        for row in group.rows:
+            lines.append(f"  {row.id}  {row.location}  {row.detail}")
+
+    return "\n".join(lines)
+
+
+def render_json(report: Report) -> str:
+    """Render report as JSON.
+
+    Args:
+        report: Report to render.
+
+    Returns:
+        JSON string with indent=2.
+    """
+    report_dict = dataclasses.asdict(report)
+    return json.dumps(report_dict, indent=2)
+
+
+__all__ = [
+    "Group",
+    "Report",
+    "Row",
+    "budget",
+    "render_json",
+    "render_text",
+]

--- a/src/codegraph/resolve.py
+++ b/src/codegraph/resolve.py
@@ -186,6 +186,53 @@ class ResolveStats:
     unresolved: int = 0
 
 
+def build_import_maps(
+    connection: sqlite3.Connection, rev: str, config: Config
+) -> tuple[dict[str, dict[str, str]], dict[str, set[str]]]:
+    """Per-path local-alias -> absolute-dotted-module map, and the set of
+    modules each path imports (feeds `dependents()`).
+
+    The one place a raw `import`/`from ... import` row -- with its
+    relative-import `level` -- gets expanded into an absolute dotted module
+    name. Both the resolver (`_SymbolTable`, below) and effect detection's
+    catalog expansion (`effects/detect.py`) build on this rather than each
+    repeating the expansion, so the two cannot silently drift apart.
+    """
+    paths = [
+        row["path"]
+        for row in connection.execute("SELECT DISTINCT path FROM tree WHERE rev=?", (rev,))
+    ]
+    module_for = {path: module_for_path(path, config.source_roots) for path in paths}
+    alias_maps: dict[str, dict[str, str]] = {path: {} for path in paths}
+    imported_modules: dict[str, set[str]] = {path: set() for path in paths}
+
+    rows = connection.execute(
+        "SELECT t.path, i.module, i.level, i.name, i.alias FROM blob_imports i"
+        " JOIN tree t ON t.blob_sha = i.blob_sha WHERE t.rev=? ORDER BY t.path, i.ordinal",
+        (rev,),
+    )
+    for row in rows:
+        path = row["path"]
+        alias_map = alias_maps[path]
+        modules = imported_modules[path]
+        package = package_for_module(module_for[path], path)
+        module = absolute_module(row["module"], row["level"], package)
+        if row["name"] is None:
+            # `import a.b` / `import a.b as c`: the alias names the module,
+            # and a plain import also makes the full dotted path usable.
+            alias_map[row["alias"] or module] = module
+            if row["alias"] is None:
+                alias_map.setdefault(module.partition(".")[0], module.partition(".")[0])
+        else:
+            target = f"{module}.{row['name']}" if module else row["name"]
+            alias_map[row["alias"] or row["name"]] = target
+            # `from a.b import c` may name a module or a symbol; record both.
+            modules.add(target)
+        if module:
+            modules.add(module)
+    return alias_maps, imported_modules
+
+
 class _SymbolTable:
     """The revision's live symbol table, plus the per-file import maps."""
 
@@ -235,37 +282,7 @@ class _SymbolTable:
             if found:
                 self.enclosing_class[row["id"]] = found
 
-        self.import_maps: dict[str, dict[str, str]] = {path: {} for path in self.paths}
-        self.imported_modules: dict[str, set[str]] = {path: set() for path in self.paths}
-        self._build_imports(connection, rev)
-
-    def _build_imports(self, connection: sqlite3.Connection, rev: str) -> None:
-        """One pass over the revision's imports, expanding relative ones."""
-        rows = connection.execute(
-            "SELECT t.path, i.module, i.level, i.name, i.alias FROM blob_imports i"
-            " JOIN tree t ON t.blob_sha = i.blob_sha"
-            " WHERE t.rev=? ORDER BY t.path, i.ordinal",
-            (rev,),
-        )
-        for row in rows:
-            path = row["path"]
-            alias_map = self.import_maps[path]
-            modules = self.imported_modules[path]
-            package = package_for_module(self.module_for[path], path)
-            module = absolute_module(row["module"], row["level"], package)
-            if row["name"] is None:
-                # `import a.b` / `import a.b as c`: the alias names the module,
-                # and a plain import also makes the full dotted path usable.
-                alias_map[row["alias"] or module] = module
-                if row["alias"] is None:
-                    alias_map.setdefault(module.partition(".")[0], module.partition(".")[0])
-            else:
-                target = f"{module}.{row['name']}" if module else row["name"]
-                alias_map[row["alias"] or row["name"]] = target
-                # `from a.b import c` may name a module or a symbol; record both.
-                modules.add(target)
-            if module:
-                modules.add(module)
+        self.import_maps, self.imported_modules = build_import_maps(connection, rev, config)
 
     def context(self, rev: str, path: str, bases: dict[str, list[str]]) -> ResolveContext:
         return ResolveContext(

--- a/tests/test_effect_catalog.py
+++ b/tests/test_effect_catalog.py
@@ -1,5 +1,7 @@
+import pytest
+
 from codegraph.config import Config
-from codegraph.effects.catalog import EFFECT_KINDS, Catalog
+from codegraph.effects.catalog import EFFECT_KINDS, Catalog, Rule
 
 
 def test_nine_effect_kinds_exactly():
@@ -47,3 +49,31 @@ def test_fingerprint_changes_with_overrides():
         Config(effect_overrides=({"match": "x.*", "kind": "NETWORK"},))
     ).fingerprint()
     assert base != other
+
+
+def test_execute_on_a_namespaced_db_client_is_still_a_write():
+    """`*.execute` (prefix 0) and a namespace rule like `psycopg*` (prefix 7)
+    can both match a fully-qualified name; the namespace rule must not win
+    and silently turn a write into a read."""
+    catalog = Catalog.load(Config())
+    assert catalog.match("psycopg2.extensions.cursor.execute") == "DB_WRITE"
+    assert catalog.match("psycopg2.cursor.execute") == "DB_WRITE"
+    assert catalog.match("cursor.execute") == "DB_WRITE"
+
+
+def test_fetch_family_is_a_db_read():
+    catalog = Catalog.load(Config())
+    assert catalog.match("cursor.fetchall") == "DB_READ"
+    assert catalog.match("cursor.fetchone") == "DB_READ"
+    assert catalog.match("cursor.fetchmany") == "DB_READ"
+
+
+def test_rule_rejects_unknown_kind():
+    with pytest.raises(ValueError, match="NOT_A_KIND"):
+        Rule(match="app.thing", kind="NOT_A_KIND")
+
+
+def test_catalog_load_rejects_unknown_kind_in_override():
+    config = Config(effect_overrides=({"match": "app.thing", "kind": "NOT_A_KIND"},))
+    with pytest.raises(ValueError, match="NOT_A_KIND"):
+        Catalog.load(config)

--- a/tests/test_effect_catalog.py
+++ b/tests/test_effect_catalog.py
@@ -1,0 +1,49 @@
+from codegraph.config import Config
+from codegraph.effects.catalog import EFFECT_KINDS, Catalog
+
+
+def test_nine_effect_kinds_exactly():
+    assert set(EFFECT_KINDS) == {
+        "DB_READ",
+        "DB_WRITE",
+        "NETWORK",
+        "FS_READ",
+        "FS_WRITE",
+        "PROCESS",
+        "ENV_READ",
+        "GLOBAL_MUTATE",
+        "NONDETERMINISM",
+    }
+
+
+def test_builtin_rules_cover_common_libraries():
+    catalog = Catalog.load(Config())
+    assert catalog.match("requests.get") == "NETWORK"
+    assert catalog.match("httpx.post") == "NETWORK"
+    assert catalog.match("subprocess.run") == "PROCESS"
+    assert catalog.match("os.environ.get") == "ENV_READ"
+    assert catalog.match("open") == "FS_READ"
+
+
+def test_unknown_name_matches_nothing():
+    assert Catalog.load(Config()).match("my.own.helper") is None
+
+
+def test_project_override_adds_house_abstractions():
+    config = Config(effect_overrides=({"match": "app.db.*", "kind": "DB_WRITE"},))
+    assert Catalog.load(config).match("app.db.save") == "DB_WRITE"
+
+
+def test_override_beats_builtin_on_longer_prefix():
+    config = Config(effect_overrides=({"match": "requests.get", "kind": "DB_READ"},))
+    catalog = Catalog.load(config)
+    assert catalog.match("requests.get") == "DB_READ"
+    assert catalog.match("requests.post") == "NETWORK"
+
+
+def test_fingerprint_changes_with_overrides():
+    base = Catalog.load(Config()).fingerprint()
+    other = Catalog.load(
+        Config(effect_overrides=({"match": "x.*", "kind": "NETWORK"},))
+    ).fingerprint()
+    assert base != other

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1,3 +1,6 @@
+import pytest
+
+from codegraph.effects.propagate import propagate, witness_path
 from codegraph.indexer import GitTreeSource, Indexer
 from codegraph.query.effects import effects_report
 from codegraph.store import Store
@@ -110,4 +113,121 @@ def test_witness_follows_the_path_that_supports_the_reported_confidence(repo, wr
     assert row.detail.startswith("NETWORK HIGH via")
     assert "b.py::c" in row.detail
     assert "one.py::One.shared" not in row.detail
+    store.close()
+
+
+def test_cycle_confidence_is_the_bottleneck_out_of_the_asking_node(tmp_path):
+    """Direct schema seeding, not a mock: the same `nodes`/`edges`/`effects`
+    tables `propagate` and `witness_path` read and write, populated by hand
+    so the shape is exact. `A` can only leave via a LOW edge to `B`; `B`
+    can call back to `A` at HIGH, but that never gives `A` a *new* way out
+    -- A's own only exit is still the LOW edge. `B` carries the direct
+    effect. This is the round-2 review shape: SCC condensation used to
+    merge B's direct HIGH straight into the shared `{A, B}` component set
+    without accounting for the LOW edge needed to reach B from A at all,
+    handing out a HIGH confidence that no real path leaving A supported."""
+    store = Store.open(tmp_path)
+    rev = "HEAD"
+    connection = store.connection
+    connection.executemany(
+        "INSERT INTO nodes(rev, id, path, qualname, kind, line_start, line_end, body_hash,"
+        " name_binding) VALUES(?,?,?,?,?,?,?,?,?)",
+        [
+            (rev, "m.py::A", "m.py", "A", "function", 1, 1, "x", "live"),
+            (rev, "m.py::B", "m.py", "B", "function", 2, 2, "x", "live"),
+        ],
+    )
+    connection.executemany(
+        "INSERT INTO edges(rev, src, dst, kind, confidence, provenance, callsite_path,"
+        " callsite_line) VALUES(?,?,?,?,?,?,?,?)",
+        [
+            (rev, "m.py::A", "m.py::B", "CALLS", "LOW", "static", "m.py", 1),
+            (rev, "m.py::B", "m.py::A", "CALLS", "HIGH", "static", "m.py", 2),
+        ],
+    )
+    connection.execute(
+        "INSERT INTO effects(rev, node_id, kind, direct, evidence_path, evidence_line,"
+        " confidence) VALUES(?,?,?,?,?,?,?)",
+        (rev, "m.py::B", "NETWORK", 1, "m.py", 2, "HIGH"),
+    )
+    connection.commit()
+
+    propagate(store, rev)
+
+    report = effects_report(store, rev, "m.py::A")
+    row = next(r for g in report.groups for r in g.rows)
+    assert row.detail == "NETWORK LOW via m.py::A -> m.py::B"
+    assert row.location == "m.py:2"
+
+    chain = witness_path(store, rev, "m.py::A", "NETWORK", "LOW")
+    assert chain == ["m.py::A", "m.py::B"]
+    store.close()
+
+
+_GUARD_FIXTURES = {
+    "acyclic_chain": (
+        {
+            "chain.py": (
+                "import requests\n\n\n"
+                "def low():\n    requests.get('u')\n\n\n"
+                "def mid():\n    low()\n\n\n"
+                "def high():\n    mid()\n"
+            ),
+        },
+        "chain.py::high",
+    ),
+    "recursion_cycle": (
+        {
+            "recur.py": (
+                "import requests\n\n\n"
+                "def ping(n):\n    requests.get('u')\n    return pong(n)\n\n\n"
+                "def pong(n):\n    return ping(n)\n"
+            ),
+        },
+        "recur.py::pong",
+    ),
+    "mixed_confidence_acyclic": (
+        {
+            "one.py": (
+                "import requests\n\n\nclass One:\n    def shared(self):\n        requests.get('u')\n"
+            ),
+            "two.py": "class Two:\n    def shared(self):\n        pass\n",
+            "b.py": "import requests\n\n\ndef c():\n    requests.get('u')\n\n\ndef b():\n    c()\n",
+            "caller.py": "from b import b\n\n\ndef query(thing):\n    thing.shared()\n    b()\n",
+        },
+        "caller.py::query",
+    ),
+    "mixed_confidence_cycle": (
+        {
+            "decoy.py": "def b():\n    pass\n",
+            "cyc_a.py": "def a():\n    return b()\n",
+            "cyc_b.py": (
+                "import requests\n\nfrom cyc_a import a\n\n\n"
+                "def b():\n    requests.get('u')\n    a()\n"
+            ),
+        },
+        "cyc_a.py::a",
+    ),
+}
+
+
+@pytest.mark.parametrize("files, node_id", _GUARD_FIXTURES.values(), ids=_GUARD_FIXTURES.keys())
+def test_no_effect_row_has_an_empty_witness_or_location(repo, write, files, node_id):
+    """Regression guard for the round-2 Critical: if `propagate` ever again
+    hands a node a confidence no real path out of it supports, `witness_path`
+    (correctly) comes back empty and the report degrades to `"KIND CONF via "`
+    with no chain and no location -- exactly the shape that shipped and was
+    only caught by manual review. Exercise every shape this module cares
+    about (a plain chain, a same-confidence recursion cycle, an acyclic mix
+    of confidences, and a genuine mixed-confidence cycle) and make that
+    degenerate output structurally impossible to ship again unnoticed."""
+    for path, source in files.items():
+        write(path, source, commit=path)
+    store = build(repo)
+    report = effects_report(store, "HEAD", node_id)
+    for group in report.groups:
+        for row in group.rows:
+            assert row.location, f"empty location: {row!r}"
+            chain_text = row.detail.split(" via ", 1)[-1]
+            assert chain_text.strip(), f"empty witness chain: {row.detail!r}"
     store.close()

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -78,3 +78,36 @@ def test_project_override_tags_house_abstraction(repo, write):
     store = build(repo)
     assert "DB_WRITE" in kinds(effects_report(store, "HEAD", "svc.py::run"))
     store.close()
+
+
+def test_witness_follows_the_path_that_supports_the_reported_confidence(repo, write):
+    """`query` has two outgoing calls: a LOW-confidence ambiguous call
+    (`thing.shared()`, matching both One.shared and Two.shared) that reaches
+    a direct effect through One.shared, and a HIGH-confidence call chain
+    (query -> b -> c) that reaches a direct effect through c. The best
+    achievable confidence is HIGH (via b -> c); the printed chain must be
+    the one that actually supports HIGH, not the shorter LOW one."""
+    write(
+        "one.py",
+        "import requests\n\n\nclass One:\n    def shared(self):\n        requests.get('u')\n",
+        commit="one",
+    )
+    write("two.py", "class Two:\n    def shared(self):\n        pass\n", commit="two")
+    write(
+        "b.py",
+        "import requests\n\n\ndef c():\n    requests.get('u')\n\n\ndef b():\n    c()\n",
+        commit="b",
+    )
+    write(
+        "caller.py",
+        "from b import b\n\n\ndef query(thing):\n    thing.shared()\n    b()\n",
+        commit="caller",
+    )
+    store = build(repo)
+    report = effects_report(store, "HEAD", "caller.py::query")
+    group = next(g for g in report.groups if g.title == "NETWORK")
+    row = group.rows[0]
+    assert row.detail.startswith("NETWORK HIGH via")
+    assert "b.py::c" in row.detail
+    assert "one.py::One.shared" not in row.detail
+    store.close()

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1,0 +1,80 @@
+from codegraph.indexer import GitTreeSource, Indexer
+from codegraph.query.effects import effects_report
+from codegraph.store import Store
+
+
+def build(repo):
+    store = Store.open(repo)
+    Indexer(repo, store, GitTreeSource(repo)).reconcile("HEAD")
+    return store
+
+
+def kinds(report):
+    return {row.detail.split()[0] for group in report.groups for row in group.rows}
+
+
+def test_direct_network_effect_detected(repo, write):
+    write("m.py", "import requests\n\n\ndef fetch():\n    requests.get('u')\n", commit="m")
+    store = build(repo)
+    assert "NETWORK" in kinds(effects_report(store, "HEAD", "m.py::fetch"))
+    store.close()
+
+
+def test_effect_propagates_through_call_chain(repo, write):
+    source = (
+        "import requests\n\n\n"
+        "def low():\n    requests.get('u')\n\n\n"
+        "def mid():\n    low()\n\n\n"
+        "def high():\n    mid()\n"
+    )
+    write("m.py", source, commit="m")
+    store = build(repo)
+    assert "NETWORK" in kinds(effects_report(store, "HEAD", "m.py::high"))
+    store.close()
+
+
+def test_pure_function_reports_no_effects(repo, write):
+    write("m.py", "def pure(x):\n    return x + 1\n", commit="m")
+    store = build(repo)
+    assert effects_report(store, "HEAD", "m.py::pure").groups == []
+    store.close()
+
+
+def test_recursion_cycle_does_not_hang(repo, write):
+    source = (
+        "import requests\n\n\n"
+        "def ping(n):\n    requests.get('u')\n    return pong(n)\n\n\n"
+        "def pong(n):\n    return ping(n)\n"
+    )
+    write("m.py", source, commit="m")
+    store = build(repo)
+    assert "NETWORK" in kinds(effects_report(store, "HEAD", "m.py::pong"))
+    store.close()
+
+
+def test_witness_path_reaches_the_causing_callsite(repo, write):
+    source = "import requests\n\n\ndef low():\n    requests.get('u')\n\n\ndef high():\n    low()\n"
+    write("m.py", source, commit="m")
+    store = build(repo)
+    report = effects_report(store, "HEAD", "m.py::high")
+    row = report.groups[0].rows[0]
+    assert "m.py::low" in row.detail
+    assert row.location.startswith("m.py:")
+    store.close()
+
+
+def test_global_mutation_detected_syntactically(repo, write):
+    write("m.py", "COUNT = 0\n\n\ndef bump():\n    global COUNT\n    COUNT += 1\n", commit="m")
+    store = build(repo)
+    assert "GLOBAL_MUTATE" in kinds(effects_report(store, "HEAD", "m.py::bump"))
+    store.close()
+
+
+def test_project_override_tags_house_abstraction(repo, write):
+    write("codegraph.toml", '[[effect]]\nmatch = "app.db.*"\nkind = "DB_WRITE"\n')
+    write("app/__init__.py", "", commit="pkg")
+    write("app/db.py", "def save():\n    pass\n", commit="db")
+    write("svc.py", "from app import db\n\n\ndef run():\n    db.save()\n", commit="svc")
+    store = build(repo)
+    assert "DB_WRITE" in kinds(effects_report(store, "HEAD", "svc.py::run"))
+    store.close()

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -115,3 +115,34 @@ def test_syntax_error_returns_error_not_exception():
 def test_parse_is_deterministic():
     source = b"class A:\n    def m(self):\n        return other()\n"
     assert parse_blob(source) == parse_blob(source)
+
+
+def test_global_statement_recorded_as_ref():
+    source = b"COUNT = 0\n\n\ndef bump():\n    global COUNT\n    COUNT += 1\n"
+    result = parse_blob(source)
+    ref = next(r for r in result.refs if r.ref_kind == "global")
+    assert ref.from_qualname == "bump"
+    assert ref.raw_name == "COUNT"
+    assert ref.line == 5
+
+
+def test_nonlocal_statement_recorded_as_global_ref():
+    source = (
+        b"def outer():\n"
+        b"    x = 0\n"
+        b"    def inner():\n"
+        b"        nonlocal x\n"
+        b"        x += 1\n"
+        b"    return inner\n"
+    )
+    result = parse_blob(source)
+    ref = next(r for r in result.refs if r.ref_kind == "global")
+    assert ref.from_qualname == "outer.<locals>.inner"
+    assert ref.raw_name == "x"
+
+
+def test_global_statement_with_multiple_names_recorded_separately():
+    source = b"def bump():\n    global A, B\n    A += 1\n    B += 1\n"
+    result = parse_blob(source)
+    names = {r.raw_name for r in result.refs if r.ref_kind == "global"}
+    assert names == {"A", "B"}

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,46 @@
+import json
+
+from codegraph.render import Group, Report, Row, budget, render_json, render_text
+
+
+def sample():
+    return Report(
+        summary={"symbols": 47, "modules": 12, "entry_points": 9, "low_confidence_hidden": 31},
+        groups=[
+            Group("hop 1", [Row("a.py::one", "a.py:10", "HIGH", 9.0)]),
+            Group("tests", [Row("tests/test_a.py::test_one", "tests/test_a.py:3", "HIGH", 1.0)]),
+        ],
+        truncated=True,
+    )
+
+
+def test_budget_truncates_and_flags():
+    rows = [Row(f"m.py::f{i}", "m.py:1", "HIGH", float(i)) for i in range(10)]
+    kept, truncated = budget(rows, 4)
+    assert len(kept) == 4
+    assert truncated is True
+
+
+def test_budget_keeps_highest_scores_first():
+    rows = [Row(f"m.py::f{i}", "m.py:1", "HIGH", float(i)) for i in range(5)]
+    kept, _ = budget(rows, 2)
+    assert [r.score for r in kept] == [4.0, 3.0]
+
+
+def test_text_leads_with_summary():
+    text = render_text(sample())
+    first = text.splitlines()[0]
+    assert "47" in first and "12" in first
+
+
+def test_text_keeps_tests_in_their_own_group():
+    text = render_text(sample())
+    assert "tests" in text
+    assert text.index("hop 1") < text.index("tests")
+
+
+def test_json_is_machine_readable_and_flags_truncation():
+    payload = json.loads(render_json(sample()))
+    assert payload["truncated"] is True
+    assert payload["summary"]["symbols"] == 47
+    assert payload["groups"][0]["rows"][0]["id"] == "a.py::one"


### PR DESCRIPTION
Second of four stacked PRs. Base: `feat/indexing-core` (#5).

Adds the effect layer — what a function *does* to the world, propagated to
everything that can reach it — plus the renderers every later command uses.

- **9 effect kinds** (`DB_READ`, `DB_WRITE`, `NETWORK`, `FS_READ`, `FS_WRITE`,
  `PROCESS`, `ENV_READ`, `GLOBAL_MUTATE`, `NONDETERMINISM`) from a dotted-glob
  catalog with project overrides in `codegraph.toml`.
- **Confidence follows match specificity**: a fully literal rule is HIGH, a
  namespace prefix (`boto3.*`) MEDIUM, a bare wildcard head (`*.execute`) LOW.
  `open()`'s mode is captured at parse time so read and write are separate rules.
- **Level-wise widest-path propagation**, replacing an SCC condensation that
  collapsed a cycle into one confidence and lost the bottleneck.
- **Witness paths**, and the invariant that makes them trustworthy: the graph a
  confidence is derived from is the same graph the witness BFS traverses. That
  invariant has bitten this project three times; the tests here are the ones
  that caught it.

Reviewed to green over four rounds. No push of downstream branches; #5 merges
first.
