### PR TITLE
Queries: impact, diff, gc, and warming-only git hooks

### DIFF
--- a/src/codegraph/cli.py
+++ b/src/codegraph/cli.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from codegraph import __version__, gitio
 from codegraph.indexer import FsTreeSource, GitTreeSource, Indexer
-from codegraph.maintenance import gc, install_hooks
+from codegraph.maintenance import gc, plan_hooks
 from codegraph.query.diff import MissingRevisionError, diff_report
 from codegraph.query.effects import effects_report
 from codegraph.query.impact import impact_report
@@ -199,10 +199,17 @@ def _cmd_install_hooks(args: argparse.Namespace) -> int:
     """Install post-commit/post-checkout/post-merge hooks that warm the
     cache in the background. Purely an optimization -- see D5: every query
     reconciles the working tree itself, so results are identical whether or
-    not these ever fire."""
+    not these ever fire. A hook whose pre-existing script isn't
+    shell-compatible is skipped rather than corrupted -- reported by name
+    and reason on stderr, never silently, since a silent skip would be the
+    same trust failure as the corruption it avoids.
+    """
     root = Path(args.path).resolve()
-    for path in install_hooks(root):
-        print(path)
+    for result in plan_hooks(root):
+        if result.installed:
+            print(result.path)
+        else:
+            print(f"skipped {result.name}: {result.reason}", file=sys.stderr)
     return 0
 
 

--- a/src/codegraph/cli.py
+++ b/src/codegraph/cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from codegraph import __version__, gitio
 from codegraph.indexer import FsTreeSource, GitTreeSource, Indexer
+from codegraph.maintenance import gc, install_hooks
 from codegraph.query.diff import MissingRevisionError, diff_report
 from codegraph.query.effects import effects_report
 from codegraph.query.impact import impact_report
@@ -52,7 +53,9 @@ def _cmd_index(args: argparse.Namespace) -> int:
         if args.rebuild:
             store.connection.execute("DELETE FROM blobs")
             store.connection.commit()
-        _print_stats(indexer.reconcile(args.rev))
+        stats = indexer.reconcile(args.rev)
+        if not args.quiet:
+            _print_stats(stats)
     finally:
         store.close()
     return 0
@@ -170,6 +173,33 @@ def _cmd_diff(args: argparse.Namespace) -> int:
         store.close()
 
 
+def _cmd_gc(args: argparse.Namespace) -> int:
+    """Prune Layer 1 (the blob parse cache) down to what HEAD, the worktree,
+    and any `--keep`-named revisions still reference. Never touches Layer 2,
+    so this can never make an existing answer stale -- only slower to
+    rebuild for an evicted revision."""
+    root = Path(args.path).resolve()
+    store = Store.open(root)
+    try:
+        keep_revs = {"HEAD", WORKTREE, *args.keep}
+        removed = gc(store, keep_revs)
+        print(f"gc: removed {removed} blob(s) unreferenced by {', '.join(sorted(keep_revs))}")
+    finally:
+        store.close()
+    return 0
+
+
+def _cmd_install_hooks(args: argparse.Namespace) -> int:
+    """Install post-commit/post-checkout/post-merge hooks that warm the
+    cache in the background. Purely an optimization -- see D5: every query
+    reconciles the working tree itself, so results are identical whether or
+    not these ever fire."""
+    root = Path(args.path).resolve()
+    for path in install_hooks(root):
+        print(path)
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="codegraph")
     parser.add_argument("--version", action="version", version=__version__)
@@ -188,6 +218,9 @@ def build_parser() -> argparse.ArgumentParser:
         "--rebuild",
         action="store_true",
         help="Discard the Layer 1 parse cache before reconciling",
+    )
+    index_parser.add_argument(
+        "--quiet", action="store_true", help="Suppress stats output (used by warming hooks)"
     )
     index_parser.set_defaults(handler=_cmd_index)
 
@@ -231,6 +264,25 @@ def build_parser() -> argparse.ArgumentParser:
     diff_parser.add_argument("--path", default=".", help="Repository root (default: cwd)")
     diff_parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
     diff_parser.set_defaults(handler=_cmd_diff)
+
+    gc_parser = subparsers.add_parser(
+        "gc", help="Prune Layer 1 cache entries unreachable from retained revisions"
+    )
+    gc_parser.add_argument("--path", default=".", help="Repository root (default: cwd)")
+    gc_parser.add_argument(
+        "--keep",
+        action="append",
+        default=[],
+        metavar="REV",
+        help="Additional revision to retain besides HEAD and the worktree (repeatable)",
+    )
+    gc_parser.set_defaults(handler=_cmd_gc)
+
+    hooks_parser = subparsers.add_parser(
+        "install-hooks", help="Install git hooks that warm the cache in the background"
+    )
+    hooks_parser.add_argument("--path", default=".", help="Repository root (default: cwd)")
+    hooks_parser.set_defaults(handler=_cmd_install_hooks)
 
     return parser
 

--- a/src/codegraph/cli.py
+++ b/src/codegraph/cli.py
@@ -54,7 +54,13 @@ def _cmd_index(args: argparse.Namespace) -> int:
             store.connection.execute("DELETE FROM blobs")
             store.connection.commit()
         stats = indexer.reconcile(args.rev)
-        if not args.quiet:
+        if args.quiet:
+            # --quiet suppresses the stats chatter (this is what the
+            # warming hooks invoke in the background), but a parse failure
+            # is a real signal, not chatter -- let it through on stderr.
+            if stats.parse_errors:
+                print(f"parse errors: {stats.parse_errors}", file=sys.stderr)
+        else:
             _print_stats(stats)
     finally:
         store.close()

--- a/src/codegraph/cli.py
+++ b/src/codegraph/cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from codegraph import __version__, gitio
 from codegraph.indexer import FsTreeSource, GitTreeSource, Indexer
+from codegraph.query.diff import MissingRevisionError, diff_report
 from codegraph.query.effects import effects_report
 from codegraph.query.impact import impact_report
 from codegraph.render import render_json, render_text
@@ -125,6 +126,44 @@ def _cmd_impact(args: argparse.Namespace) -> int:
         store.close()
 
 
+def _diff_revspec(root: Path, revspec: str | None) -> tuple[str, str]:
+    """Split `<base>..<head>` into its two sides. A bare `<base>` (no `..`)
+    diffs it against the worktree. With no argument at all, base defaults
+    to `merge_base(default_branch, HEAD)` and head to the worktree --
+    "what has this branch changed so far."
+    """
+    if revspec:
+        if ".." in revspec:
+            base, _, head = revspec.partition("..")
+            return base, head or WORKTREE
+        return revspec, WORKTREE
+    if not gitio.is_repo(root):
+        raise MissingRevisionError("HEAD")
+    try:
+        branch = gitio.default_branch(root)
+        base = gitio.merge_base(root, branch, "HEAD")
+    except gitio.GitError as exc:
+        raise MissingRevisionError(str(exc)) from exc
+    return base, WORKTREE
+
+
+def _cmd_diff(args: argparse.Namespace) -> int:
+    """Report what changed between two revisions, compared on body_hash."""
+    root = Path(args.path).resolve()
+    store, indexer = open_workspace(root)
+    try:
+        try:
+            base, head = _diff_revspec(root, args.revspec)
+            report = diff_report(store, indexer, base, head)
+        except MissingRevisionError as exc:
+            print(f"revision not found: {exc.rev}", file=sys.stderr)
+            return 1
+        print(render_json(report) if args.json else render_text(report))
+        return 0
+    finally:
+        store.close()
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="codegraph")
     parser.add_argument("--version", action="version", version=__version__)
@@ -173,6 +212,19 @@ def build_parser() -> argparse.ArgumentParser:
     )
     impact_parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
     impact_parser.set_defaults(handler=_cmd_impact)
+
+    diff_parser = subparsers.add_parser(
+        "diff", help="Report what changed between two revisions"
+    )
+    diff_parser.add_argument(
+        "revspec",
+        nargs="?",
+        default=None,
+        help="<base>..<head> (default: merge-base(default branch, HEAD)..WORKTREE)",
+    )
+    diff_parser.add_argument("--path", default=".", help="Repository root (default: cwd)")
+    diff_parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    diff_parser.set_defaults(handler=_cmd_diff)
 
     return parser
 

--- a/src/codegraph/cli.py
+++ b/src/codegraph/cli.py
@@ -135,6 +135,12 @@ def _diff_revspec(root: Path, revspec: str | None) -> tuple[str, str]:
     if revspec:
         if ".." in revspec:
             base, _, head = revspec.partition("..")
+            if not base:
+                # "..HEAD" -- an empty base has no sensible default (unlike
+                # an empty head, which reasonably falls back to WORKTREE),
+                # so name the missing side rather than passing "" through
+                # to raise a blank, nameless error later.
+                raise MissingRevisionError("<base>")
             return base, head or WORKTREE
         return revspec, WORKTREE
     if not gitio.is_repo(root):

--- a/src/codegraph/cli.py
+++ b/src/codegraph/cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from codegraph import __version__, gitio
 from codegraph.indexer import FsTreeSource, GitTreeSource, Indexer
 from codegraph.query.effects import effects_report
+from codegraph.query.impact import impact_report
 from codegraph.render import render_json, render_text
 from codegraph.resolve import find_symbol
 from codegraph.store import WORKTREE, Store
@@ -95,6 +96,35 @@ def _cmd_effects(args: argparse.Namespace) -> int:
         store.close()
 
 
+def _cmd_impact(args: argparse.Namespace) -> int:
+    """Report the ranked dependents of a symbol -- everything a change to
+    it could break."""
+    root = Path(args.path).resolve()
+    store, indexer = open_workspace(root)
+    try:
+        indexer.reconcile(args.rev)
+        matches = find_symbol(store, args.rev, args.symbol)
+        if not matches:
+            print(f"no symbol matching {args.symbol!r}", file=sys.stderr)
+            return 1
+        if len(matches) > 1:
+            print(f"ambiguous symbol {args.symbol!r}:", file=sys.stderr)
+            for row in matches:
+                print(f"  {row['id']}", file=sys.stderr)
+            return 2
+        report = impact_report(
+            store,
+            args.rev,
+            matches[0]["id"],
+            max_hops=args.hops,
+            include_low=args.all,
+        )
+        print(render_json(report) if args.json else render_text(report))
+        return 0
+    finally:
+        store.close()
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="codegraph")
     parser.add_argument("--version", action="version", version=__version__)
@@ -130,6 +160,19 @@ def build_parser() -> argparse.ArgumentParser:
     effects_parser.add_argument("--rev", default=WORKTREE, help="Revision to query")
     effects_parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
     effects_parser.set_defaults(handler=_cmd_effects)
+
+    impact_parser = subparsers.add_parser("impact", help="Report the ranked dependents of a symbol")
+    impact_parser.add_argument("symbol", help="Node id, qualname, or trailing name")
+    impact_parser.add_argument("--path", default=".", help="Repository root (default: cwd)")
+    impact_parser.add_argument("--rev", default=WORKTREE, help="Revision to query")
+    impact_parser.add_argument(
+        "--hops", type=int, default=3, help="Maximum hops to walk (default: 3)"
+    )
+    impact_parser.add_argument(
+        "--all", action="store_true", help="Include LOW-confidence dependents"
+    )
+    impact_parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    impact_parser.set_defaults(handler=_cmd_impact)
 
     return parser
 

--- a/src/codegraph/indexer.py
+++ b/src/codegraph/indexer.py
@@ -198,9 +198,15 @@ class Indexer:
             result = parse_blob(data)
             errors += int(result.error is not None)
             connection.execute(
-                "INSERT OR REPLACE INTO blobs(blob_sha, status, error, parser_version) "
-                "VALUES(?, ?, ?, ?)",
-                (sha, "error" if result.error else "ok", result.error, PARSER_VERSION),
+                "INSERT OR REPLACE INTO blobs(blob_sha, status, error, parser_version,"
+                " module_body_hash) VALUES(?, ?, ?, ?, ?)",
+                (
+                    sha,
+                    "error" if result.error else "ok",
+                    result.error,
+                    PARSER_VERSION,
+                    result.module_body_hash,
+                ),
             )
             connection.executemany(
                 "INSERT OR REPLACE INTO blob_nodes(blob_sha, ordinal, qualname, kind,"
@@ -246,13 +252,30 @@ class Indexer:
         Every path also gets a synthetic module node (`path::<module>`), so
         that a module-scope call's edge `src` — an import-time side effect
         like `app = create_app()` — has a real row in `nodes` rather than a
-        dangling id. Its `body_hash` is the path's blob sha: a file-changed
-        signal, not a symbol-changed one, since no per-symbol hash exists at
-        module scope. Its span is a placeholder (`1..1`): the file's true
-        last line isn't available from Layer 1's parsed tables without
-        re-reading blob content, and nothing downstream depends on it yet.
+        dangling id. Its `body_hash` is `parse.py`'s `module_body_hash`: a
+        structural hash of the module's top-level statements with nested
+        def/class bodies elided, computed once per blob and cached on the
+        `blobs` row alongside it -- whitespace-insensitive like every other
+        `body_hash`, but still sensitive to a module-scope statement (an
+        import, a top-level call) changing. Falls back to the blob sha
+        itself when a blob has no cached hash (a parse error leaves it
+        empty), so a broken file's module node still changes identity
+        when its content does. Its span is a placeholder (`1..1`): the
+        file's true last line isn't available from Layer 1's parsed
+        tables without re-reading blob content, and nothing downstream
+        depends on it yet.
         """
         connection = self.store.connection
+        module_hashes: dict[str, str] = {}
+        shas = set(tree.values())
+        if shas:
+            placeholders = ",".join("?" * len(shas))
+            for row in connection.execute(
+                f"SELECT blob_sha, module_body_hash FROM blobs WHERE blob_sha IN ({placeholders})",
+                tuple(shas),
+            ):
+                module_hashes[row["blob_sha"]] = row["module_body_hash"]
+
         shadowed = 0
         rows: list[tuple] = []
         for path, sha in tree.items():
@@ -284,7 +307,7 @@ class Indexer:
                     "module",
                     1,
                     1,
-                    sha,
+                    module_hashes.get(sha) or sha,
                     "live",
                 )
             )

--- a/src/codegraph/maintenance.py
+++ b/src/codegraph/maintenance.py
@@ -11,6 +11,7 @@ hook never fires, or `gc` is never run, results are byte-identical.
 from __future__ import annotations
 
 import stat
+from dataclasses import dataclass
 from pathlib import Path
 
 from codegraph.store import Store
@@ -34,6 +35,12 @@ _HOOK_BLOCK = f"""{_BEGIN_MARKER}
 ( cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" && codegraph index --quiet >/dev/null 2>&1 & ) >/dev/null 2>&1 || true
 {_END_MARKER}
 """
+
+# Splicing shell syntax into a script written for a different interpreter
+# corrupts it outright (a Perl or Python hook fails to even parse). This is
+# the allowlist of interpreters `_HOOK_BLOCK`'s POSIX-shell syntax is safe
+# to land inside; anything else is left completely untouched.
+_SHELL_INTERPRETERS = {"sh", "bash", "dash", "ash", "ksh", "zsh"}
 
 
 def _chunks(items: list[str], size: int) -> list[list[str]]:
@@ -105,6 +112,43 @@ def _hooks_dir(root: Path) -> Path:
     raise FileNotFoundError(f"not a git repository: {root}")
 
 
+def _shebang_interpreter(shebang_line: str) -> str:
+    """The interpreter name a `#!...` line claims, resolving
+    `#!/usr/bin/env <interp> [flags]` to `<interp>` the same as
+    `#!/path/to/<interp> [flags]`. Empty string if the line names nothing
+    (a bare `#!`)."""
+    tokens = shebang_line[2:].split()
+    if not tokens:
+        return ""
+    name = Path(tokens[0]).name
+    if name == "env" and len(tokens) > 1:
+        name = Path(tokens[1]).name
+    return name
+
+
+def _is_shell_shebang(shebang_line: str) -> bool:
+    return _shebang_interpreter(shebang_line) in _SHELL_INTERPRETERS
+
+
+def _strip_existing_block(text: str) -> str:
+    """Remove a previously-installed codegraph block, wherever it sits and
+    whatever its interior looks like (this repairs a stale block from an
+    older version of `install_hooks` -- e.g. one still doing `$?`
+    preservation, or one appended at the end after a pre-existing `exit` --
+    just as readily as a current one). A malformed/truncated marker pair
+    (no matching end) is left alone rather than guessed at."""
+    start = text.find(_BEGIN_MARKER)
+    if start == -1:
+        return text
+    end = text.find(_END_MARKER, start)
+    if end == -1:
+        return text
+    end += len(_END_MARKER)
+    tail = text[end:]
+    tail = tail.removeprefix("\n")
+    return text[:start] + tail
+
+
 def _insert_after_shebang(existing: str) -> str:
     """Splice `_HOOK_BLOCK` in as the first statement of the script, right
     after its shebang line so it always runs -- before any pre-existing
@@ -120,30 +164,76 @@ def _insert_after_shebang(existing: str) -> str:
     return "#!/bin/sh\n" + _HOOK_BLOCK + existing
 
 
-def install_hooks(root: Path) -> list[Path]:
-    """Write (or extend) `post-commit`, `post-checkout`, and `post-merge`
-    hooks that warm the codegraph cache in the background.
+@dataclass(frozen=True)
+class HookResult:
+    """One hook's outcome: installed (written or repaired), or skipped with
+    a human-readable reason."""
 
-    Idempotent: re-running never double-appends the codegraph block. A
-    pre-existing hook is never overwritten -- the codegraph block is spliced
-    in right after the shebang, so whatever the rest of the script does
-    (including its own `exit`) runs exactly as before, just after ours.
+    name: str
+    path: Path
+    installed: bool
+    reason: str | None = None
 
-    Returns the paths of all three hooks (written or already present).
+
+def plan_hooks(root: Path) -> list[HookResult]:
+    """Install (or repair) `post-commit`, `post-checkout`, and
+    `post-merge`, one `HookResult` per hook.
+
+    A pre-existing hook whose shebang names an interpreter outside
+    `_SHELL_INTERPRETERS` (Perl, Python, Ruby, Node, ...) is **left
+    completely untouched** and reported as skipped -- splicing POSIX-shell
+    syntax into it would corrupt the script outright, not just fail to warm
+    it. A file with no shebang at all makes no interpreter claim to
+    contradict, so it's treated the same as a shell script (a `#!/bin/sh`
+    is added). This refusal is safe precisely because of D5: warming is
+    optional, so a skipped hook only ever costs speed, never correctness.
+
+    A hook already carrying a codegraph block -- from this run or an older
+    version of `install_hooks` -- has that block stripped and a fresh one
+    spliced in fresh each time. This is what makes repeated calls
+    idempotent (always converges to exactly one block) *and*
+    self-repairing (a block left dead by a since-fixed bug, e.g. one
+    appended after the pre-existing hook's own `exit 0`, is replaced with a
+    live one instead of staying broken forever).
     """
     hooks_dir = _hooks_dir(root)
     hooks_dir.mkdir(parents=True, exist_ok=True)
 
-    written: list[Path] = []
+    results: list[HookResult] = []
     for name in _HOOK_NAMES:
         path = hooks_dir / name
         existing = path.read_text() if path.exists() else ""
+        lines = existing.splitlines()
 
-        if _BEGIN_MARKER not in existing:
-            path.write_text(_insert_after_shebang(existing))
+        if lines and lines[0].startswith("#!") and not _is_shell_shebang(lines[0]):
+            results.append(
+                HookResult(
+                    name=name,
+                    path=path,
+                    installed=False,
+                    reason=(
+                        f"existing hook uses a non-shell interpreter ({lines[0].strip()}); "
+                        "warming not installed"
+                    ),
+                )
+            )
+            continue
 
+        content = _insert_after_shebang(_strip_existing_block(existing))
+        path.write_text(content)
         mode = path.stat().st_mode
         path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-        written.append(path)
+        results.append(HookResult(name=name, path=path, installed=True))
 
-    return written
+    return results
+
+
+def install_hooks(root: Path) -> list[Path]:
+    """Paths of the hooks actually installed or repaired.
+
+    Omits any hook skipped for using a non-shell interpreter -- see
+    `plan_hooks` for the reason behind each skip, which is what the CLI
+    surfaces to the user (a skip must be loud, never silent: D5 licenses
+    skipping a hook, not hiding that it happened).
+    """
+    return [result.path for result in plan_hooks(root) if result.installed]

--- a/src/codegraph/maintenance.py
+++ b/src/codegraph/maintenance.py
@@ -22,14 +22,16 @@ _HOOK_NAMES = ("post-commit", "post-checkout", "post-merge")
 _BEGIN_MARKER = "# >>> codegraph (warming only; safe to remove) >>>"
 _END_MARKER = "# <<< codegraph (warming only; safe to remove) <<<"
 
-# Preserves `$?` from whatever ran before this block (0 at a fresh script's
-# start) so appending to a pre-existing hook can never flip its exit status:
-# our warming command is backgrounded and its own status discarded, then the
-# script exits with the status it already had.
+# Fires a backgrounded job and falls straight through -- no `exit`, no
+# capturing `$?`. It has to sit as the *first* statement after the shebang
+# (see `_insert_after_shebang`) rather than at the end: a pre-existing hook
+# commonly ends in its own `exit 0` (or `exit 1`, or hits one inside an
+# `if`), and code appended after that is simply never reached. A block that
+# runs first can't be skipped that way, and since all it does is background
+# a job, it can't change -- or need to preserve -- whatever exit status the
+# rest of the script goes on to produce.
 _HOOK_BLOCK = f"""{_BEGIN_MARKER}
-_codegraph_status=$?
 ( cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" && codegraph index --quiet >/dev/null 2>&1 & ) >/dev/null 2>&1 || true
-exit $_codegraph_status
 {_END_MARKER}
 """
 
@@ -103,14 +105,29 @@ def _hooks_dir(root: Path) -> Path:
     raise FileNotFoundError(f"not a git repository: {root}")
 
 
+def _insert_after_shebang(existing: str) -> str:
+    """Splice `_HOOK_BLOCK` in as the first statement of the script, right
+    after its shebang line so it always runs -- before any pre-existing
+    `exit`, `exec`, or `if`-guarded early return could skip it.
+
+    A file with no shebang gets one (`#!/bin/sh`) prepended; git hooks with
+    no shebang already run under the shell's default anyway, so this changes
+    nothing about how the rest of the script executes.
+    """
+    lines = existing.splitlines(keepends=True)
+    if lines and lines[0].startswith("#!"):
+        return lines[0] + _HOOK_BLOCK + "".join(lines[1:])
+    return "#!/bin/sh\n" + _HOOK_BLOCK + existing
+
+
 def install_hooks(root: Path) -> list[Path]:
     """Write (or extend) `post-commit`, `post-checkout`, and `post-merge`
     hooks that warm the codegraph cache in the background.
 
     Idempotent: re-running never double-appends the codegraph block. A
-    pre-existing hook is never overwritten -- the codegraph block is
-    appended after whatever was already there, guarded so it can only ever
-    add a background warm-up, never change the hook's own exit status.
+    pre-existing hook is never overwritten -- the codegraph block is spliced
+    in right after the shebang, so whatever the rest of the script does
+    (including its own `exit`) runs exactly as before, just after ours.
 
     Returns the paths of all three hooks (written or already present).
     """
@@ -123,11 +140,7 @@ def install_hooks(root: Path) -> list[Path]:
         existing = path.read_text() if path.exists() else ""
 
         if _BEGIN_MARKER not in existing:
-            if not existing:
-                existing = "#!/bin/sh\n"
-            elif not existing.endswith("\n"):
-                existing += "\n"
-            path.write_text(existing + _HOOK_BLOCK)
+            path.write_text(_insert_after_shebang(existing))
 
         mode = path.stat().st_mode
         path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)

--- a/src/codegraph/maintenance.py
+++ b/src/codegraph/maintenance.py
@@ -6,6 +6,14 @@ ever warm Layer 1 in the background. Per D5 in the design doc, every
 `codegraph` query reconciles the working tree itself before answering, so
 neither of these is ever required for correctness -- only for speed. If a
 hook never fires, or `gc` is never run, results are byte-identical.
+
+Installing hooks is deliberately conservative: anything about a pre-existing
+hook that this module can't confidently reason about (a binary file, an
+interpreter it doesn't recognize as shell-compatible, a half-formed marker
+from some prior mishap, any other unexpected error) is a loud skip, never a
+guess. D5 is what licenses that: warming is optional, so skipping a hook
+only ever costs speed, and a corrupted user hook is a strictly worse outcome
+than one that stays un-warmed.
 """
 
 from __future__ import annotations
@@ -41,6 +49,15 @@ _HOOK_BLOCK = f"""{_BEGIN_MARKER}
 # the allowlist of interpreters `_HOOK_BLOCK`'s POSIX-shell syntax is safe
 # to land inside; anything else is left completely untouched.
 _SHELL_INTERPRETERS = {"sh", "bash", "dash", "ash", "ksh", "zsh"}
+
+
+class _MalformedMarker(Exception):
+    """A codegraph marker line was found without its matching partner --
+    a lone BEGIN with no END, a lone END with no BEGIN, or two BEGINs
+    with no END between them. This is damage from a previous run gone
+    wrong, or a hand-edited file, and guessing how much surrounding
+    content to delete risks eating real statements. The caller must
+    refuse to touch the file, not repair around it."""
 
 
 def _chunks(items: list[str], size: int) -> list[list[str]]:
@@ -114,15 +131,22 @@ def _hooks_dir(root: Path) -> Path:
 
 def _shebang_interpreter(shebang_line: str) -> str:
     """The interpreter name a `#!...` line claims, resolving
-    `#!/usr/bin/env <interp> [flags]` to `<interp>` the same as
-    `#!/path/to/<interp> [flags]`. Empty string if the line names nothing
-    (a bare `#!`)."""
+    `#!/usr/bin/env [flags] <interp> [flags]` to `<interp>` the same as a
+    direct `#!/path/to/<interp> [flags]`. `env`'s own flags (`-S`, `-i`, ...)
+    are `-`-prefixed and skipped when looking for the interpreter token, so
+    `#!/usr/bin/env -S bash -e` resolves to `bash`, not `-S`. Empty string
+    if the line names nothing usable (a bare `#!`, or `env` followed by
+    nothing but its own flags)."""
     tokens = shebang_line[2:].split()
     if not tokens:
         return ""
     name = Path(tokens[0]).name
-    if name == "env" and len(tokens) > 1:
-        name = Path(tokens[1]).name
+    if name == "env":
+        name = ""
+        for token in tokens[1:]:
+            if not token.startswith("-"):
+                name = Path(token).name
+                break
     return name
 
 
@@ -130,23 +154,57 @@ def _is_shell_shebang(shebang_line: str) -> bool:
     return _shebang_interpreter(shebang_line) in _SHELL_INTERPRETERS
 
 
-def _strip_existing_block(text: str) -> str:
-    """Remove a previously-installed codegraph block, wherever it sits and
-    whatever its interior looks like (this repairs a stale block from an
-    older version of `install_hooks` -- e.g. one still doing `$?`
-    preservation, or one appended at the end after a pre-existing `exit` --
-    just as readily as a current one). A malformed/truncated marker pair
-    (no matching end) is left alone rather than guessed at."""
-    start = text.find(_BEGIN_MARKER)
-    if start == -1:
+def _is_marker_line(line: str, marker: str) -> bool:
+    """True only if `line` (ignoring surrounding whitespace) is *exactly*
+    the marker, not merely a line that happens to contain it somewhere --
+    a hook whose own comment or quoted string mentions this marker text
+    must never be mistaken for a real block boundary."""
+    return line.strip() == marker
+
+
+def _strip_existing_blocks(text: str) -> str:
+    """Remove every complete codegraph block (a BEGIN marker line, its
+    contents, and the following END marker line -- matched as whole lines
+    only, never a substring inside a longer line). Loops until every
+    marker pair is gone, so a file carrying more than one block (an old
+    one left at the end plus a newer one spliced at the top, say) converges
+    to zero, not one-fewer.
+
+    Raises `_MalformedMarker` if the marker lines found don't pair up
+    cleanly -- a BEGIN with no following END, an END with no preceding
+    BEGIN, or two BEGINs with no END between them. The caller must treat
+    that as damage to leave alone, not a shape to repair by guessing.
+    """
+    lines = text.splitlines(keepends=True)
+    marker_positions = [
+        (index, "begin")
+        for index, line in enumerate(lines)
+        if _is_marker_line(line, _BEGIN_MARKER)
+    ] + [
+        (index, "end") for index, line in enumerate(lines) if _is_marker_line(line, _END_MARKER)
+    ]
+    marker_positions.sort()
+
+    blocks: list[tuple[int, int]] = []
+    pending_begin: int | None = None
+    for index, kind in marker_positions:
+        if kind == "begin":
+            if pending_begin is not None:
+                raise _MalformedMarker
+            pending_begin = index
+        else:
+            if pending_begin is None:
+                raise _MalformedMarker
+            blocks.append((pending_begin, index))
+            pending_begin = None
+    if pending_begin is not None:
+        raise _MalformedMarker
+
+    if not blocks:
         return text
-    end = text.find(_END_MARKER, start)
-    if end == -1:
-        return text
-    end += len(_END_MARKER)
-    tail = text[end:]
-    tail = tail.removeprefix("\n")
-    return text[:start] + tail
+
+    removed = {index for start, end in blocks for index in range(start, end + 1)}
+    return "".join(line for index, line in enumerate(lines) if index not in removed)
 
 
 def _insert_after_shebang(existing: str) -> str:
@@ -175,26 +233,92 @@ class HookResult:
     reason: str | None = None
 
 
+def _plan_one_hook(name: str, path: Path) -> HookResult:
+    """Decide and apply the outcome for a single hook. Never raises for an
+    ordinary "can't safely touch this file" case -- those come back as a
+    skipped `HookResult` -- so any exception that does escape is a genuinely
+    unexpected failure, which `plan_hooks` isolates per-hook."""
+    if path.exists():
+        try:
+            existing = path.read_text()
+        except UnicodeDecodeError:
+            # A compiled/binary hook (pre-commit frameworks and compiled
+            # shims ship these). It IS a non-shell hook -- same refusal as
+            # Perl, just detected a layer earlier, before there's even a
+            # shebang line to read.
+            return HookResult(
+                name=name,
+                path=path,
+                installed=False,
+                reason=(
+                    "existing hook is not valid UTF-8 (binary or non-text hook); "
+                    "warming not installed"
+                ),
+            )
+    else:
+        existing = ""
+
+    lines = existing.splitlines()
+    if lines and lines[0].startswith("#!") and not _is_shell_shebang(lines[0]):
+        return HookResult(
+            name=name,
+            path=path,
+            installed=False,
+            reason=(
+                f"existing hook uses a non-shell interpreter ({lines[0].strip()}); "
+                "warming not installed"
+            ),
+        )
+
+    try:
+        stripped = _strip_existing_blocks(existing)
+    except _MalformedMarker:
+        return HookResult(
+            name=name,
+            path=path,
+            installed=False,
+            reason=(
+                "existing hook has a malformed codegraph marker (a begin marker with "
+                "no matching end, or vice versa); please repair or remove it by hand -- "
+                "warming not installed"
+            ),
+        )
+
+    content = _insert_after_shebang(stripped)
+    path.write_text(content)
+    mode = path.stat().st_mode
+    path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return HookResult(name=name, path=path, installed=True)
+
+
 def plan_hooks(root: Path) -> list[HookResult]:
     """Install (or repair) `post-commit`, `post-checkout`, and
     `post-merge`, one `HookResult` per hook.
 
     A pre-existing hook whose shebang names an interpreter outside
-    `_SHELL_INTERPRETERS` (Perl, Python, Ruby, Node, ...) is **left
-    completely untouched** and reported as skipped -- splicing POSIX-shell
-    syntax into it would corrupt the script outright, not just fail to warm
-    it. A file with no shebang at all makes no interpreter claim to
-    contradict, so it's treated the same as a shell script (a `#!/bin/sh`
-    is added). This refusal is safe precisely because of D5: warming is
-    optional, so a skipped hook only ever costs speed, never correctness.
+    `_SHELL_INTERPRETERS` (Perl, Python, Ruby, Node, ...), or that isn't
+    valid UTF-8 at all (a binary hook), is **left completely untouched**
+    and reported as skipped -- splicing POSIX-shell syntax into it would
+    corrupt the script outright, not just fail to warm it. A file with no
+    shebang at all makes no interpreter claim to contradict, so it's
+    treated the same as a shell script (a `#!/bin/sh` is added).
 
-    A hook already carrying a codegraph block -- from this run or an older
-    version of `install_hooks` -- has that block stripped and a fresh one
-    spliced in fresh each time. This is what makes repeated calls
-    idempotent (always converges to exactly one block) *and*
-    self-repairing (a block left dead by a since-fixed bug, e.g. one
-    appended after the pre-existing hook's own `exit 0`, is replaced with a
-    live one instead of staying broken forever).
+    A hook already carrying one or more codegraph blocks -- from this run
+    or an older version of `install_hooks` -- has all of them stripped and
+    a single fresh one spliced in. This is what makes repeated calls
+    idempotent (always converges to exactly one block, however many were
+    there before) *and* self-repairing (a block left dead by a since-fixed
+    bug, e.g. one appended after the pre-existing hook's own `exit 0`, is
+    replaced with a live one instead of staying broken forever). A hook
+    whose marker lines don't pair up cleanly is left untouched and skipped
+    instead -- that shape is damage, not something to guess a repair for.
+
+    One hook's unexpected failure (a permission error, anything not
+    already handled above) is isolated to that hook: it comes back as a
+    skipped result with the error as its reason, and the other hooks are
+    still processed. A maintenance command that half-runs because of one
+    bad hook, or dumps a raw traceback, is worse than one that skips
+    loudly and keeps going.
     """
     hooks_dir = _hooks_dir(root)
     hooks_dir.mkdir(parents=True, exist_ok=True)
@@ -202,28 +326,17 @@ def plan_hooks(root: Path) -> list[HookResult]:
     results: list[HookResult] = []
     for name in _HOOK_NAMES:
         path = hooks_dir / name
-        existing = path.read_text() if path.exists() else ""
-        lines = existing.splitlines()
-
-        if lines and lines[0].startswith("#!") and not _is_shell_shebang(lines[0]):
+        try:
+            results.append(_plan_one_hook(name, path))
+        except Exception as exc:  # noqa: BLE001 -- per-hook isolation net, see docstring
             results.append(
                 HookResult(
                     name=name,
                     path=path,
                     installed=False,
-                    reason=(
-                        f"existing hook uses a non-shell interpreter ({lines[0].strip()}); "
-                        "warming not installed"
-                    ),
+                    reason=f"unexpected error inspecting hook ({exc}); warming not installed",
                 )
             )
-            continue
-
-        content = _insert_after_shebang(_strip_existing_block(existing))
-        path.write_text(content)
-        mode = path.stat().st_mode
-        path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-        results.append(HookResult(name=name, path=path, installed=True))
 
     return results
 
@@ -231,9 +344,10 @@ def plan_hooks(root: Path) -> list[HookResult]:
 def install_hooks(root: Path) -> list[Path]:
     """Paths of the hooks actually installed or repaired.
 
-    Omits any hook skipped for using a non-shell interpreter -- see
-    `plan_hooks` for the reason behind each skip, which is what the CLI
-    surfaces to the user (a skip must be loud, never silent: D5 licenses
-    skipping a hook, not hiding that it happened).
+    Omits any hook skipped for using a non-shell interpreter, being
+    unreadable as text, carrying a malformed marker, or failing
+    unexpectedly -- see `plan_hooks` for the reason behind each skip,
+    which is what the CLI surfaces to the user (a skip must be loud, never
+    silent: D5 licenses skipping a hook, not hiding that it happened).
     """
     return [result.path for result in plan_hooks(root) if result.installed]

--- a/src/codegraph/maintenance.py
+++ b/src/codegraph/maintenance.py
@@ -1,0 +1,136 @@
+"""Blob-cache garbage collection and warming-only git hooks.
+
+Both operations are pure housekeeping: `gc` never touches Layer 2 (the
+materialized per-revision graph), and the hooks `install_hooks` writes only
+ever warm Layer 1 in the background. Per D5 in the design doc, every
+`codegraph` query reconciles the working tree itself before answering, so
+neither of these is ever required for correctness -- only for speed. If a
+hook never fires, or `gc` is never run, results are byte-identical.
+"""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+from codegraph.store import Store
+
+_CHUNK = 400  # stays well under SQLite's default 999-variable limit per statement
+
+_HOOK_NAMES = ("post-commit", "post-checkout", "post-merge")
+
+_BEGIN_MARKER = "# >>> codegraph (warming only; safe to remove) >>>"
+_END_MARKER = "# <<< codegraph (warming only; safe to remove) <<<"
+
+# Preserves `$?` from whatever ran before this block (0 at a fresh script's
+# start) so appending to a pre-existing hook can never flip its exit status:
+# our warming command is backgrounded and its own status discarded, then the
+# script exits with the status it already had.
+_HOOK_BLOCK = f"""{_BEGIN_MARKER}
+_codegraph_status=$?
+( cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" && codegraph index --quiet >/dev/null 2>&1 & ) >/dev/null 2>&1 || true
+exit $_codegraph_status
+{_END_MARKER}
+"""
+
+
+def _chunks(items: list[str], size: int) -> list[list[str]]:
+    return [items[i : i + size] for i in range(0, len(items), size)]
+
+
+def gc(store: Store, keep_revs: set[str]) -> int:
+    """Prune Layer 1 (the content-addressed parse cache) down to only the
+    blobs referenced by `keep_revs`'s materialized trees.
+
+    Layer 2 (`revisions`, `tree`, `nodes`, `edges`, `effects`, `imports`,
+    `unresolved`) is never touched -- it is already fully materialized for
+    every revision in the store, retained or not, and does not read back
+    through Layer 1. Losing a Layer 1 entry only costs a re-parse the next
+    time that blob's content is seen; it never invalidates an existing
+    answer.
+
+    `keep_revs` empty is well-defined, not accidental: nothing is retained,
+    so every Layer 1 row is unreferenced and gets removed.
+
+    Returns the number of Layer 1 blob rows removed.
+    """
+    connection = store.connection
+
+    keep_shas: set[str] = set()
+    if keep_revs:
+        for batch in _chunks(sorted(keep_revs), _CHUNK):
+            placeholders = ",".join("?" * len(batch))
+            rows = connection.execute(
+                f"SELECT DISTINCT blob_sha FROM tree WHERE rev IN ({placeholders})",
+                tuple(batch),
+            )
+            keep_shas.update(row["blob_sha"] for row in rows)
+
+    all_shas = {row["blob_sha"] for row in connection.execute("SELECT blob_sha FROM blobs")}
+    remove_shas = sorted(all_shas - keep_shas)
+    if not remove_shas:
+        return 0
+
+    with connection:
+        for batch in _chunks(remove_shas, _CHUNK):
+            placeholders = ",".join("?" * len(batch))
+            params = tuple(batch)
+            connection.execute(f"DELETE FROM blob_nodes WHERE blob_sha IN ({placeholders})", params)
+            connection.execute(f"DELETE FROM blob_refs WHERE blob_sha IN ({placeholders})", params)
+            connection.execute(
+                f"DELETE FROM blob_imports WHERE blob_sha IN ({placeholders})", params
+            )
+            connection.execute(f"DELETE FROM blobs WHERE blob_sha IN ({placeholders})", params)
+
+    return len(remove_shas)
+
+
+def _hooks_dir(root: Path) -> Path:
+    """Resolve `root`'s git hooks directory, honoring `.git`-as-a-file
+    (worktrees, submodules) as well as the ordinary `.git`-as-a-directory
+    case that every test in this repo uses."""
+    git_path = root / ".git"
+    if git_path.is_dir():
+        return git_path / "hooks"
+    if git_path.is_file():
+        text = git_path.read_text().strip()
+        prefix = "gitdir:"
+        if text.startswith(prefix):
+            gitdir = Path(text[len(prefix) :].strip())
+            if not gitdir.is_absolute():
+                gitdir = (root / gitdir).resolve()
+            return gitdir / "hooks"
+    raise FileNotFoundError(f"not a git repository: {root}")
+
+
+def install_hooks(root: Path) -> list[Path]:
+    """Write (or extend) `post-commit`, `post-checkout`, and `post-merge`
+    hooks that warm the codegraph cache in the background.
+
+    Idempotent: re-running never double-appends the codegraph block. A
+    pre-existing hook is never overwritten -- the codegraph block is
+    appended after whatever was already there, guarded so it can only ever
+    add a background warm-up, never change the hook's own exit status.
+
+    Returns the paths of all three hooks (written or already present).
+    """
+    hooks_dir = _hooks_dir(root)
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+
+    written: list[Path] = []
+    for name in _HOOK_NAMES:
+        path = hooks_dir / name
+        existing = path.read_text() if path.exists() else ""
+
+        if _BEGIN_MARKER not in existing:
+            if not existing:
+                existing = "#!/bin/sh\n"
+            elif not existing.endswith("\n"):
+                existing += "\n"
+            path.write_text(existing + _HOOK_BLOCK)
+
+        mode = path.stat().st_mode
+        path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        written.append(path)
+
+    return written

--- a/src/codegraph/parse.py
+++ b/src/codegraph/parse.py
@@ -7,10 +7,11 @@ paths, and the parse cache is keyed on content alone.
 from __future__ import annotations
 
 import ast
+import copy
 import hashlib
 from dataclasses import dataclass, field
 
-PARSER_VERSION = "1"
+PARSER_VERSION = "2"
 
 _DEF_TYPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
 
@@ -53,6 +54,10 @@ class ParseResult:
     nodes: tuple[ParsedNode, ...] = ()
     refs: tuple[ParsedRef, ...] = ()
     imports: tuple[ParsedImport, ...] = ()
+    #: Structural hash of the module's top-level statements, with every
+    #: nested function/class BODY elided (see `_module_skeleton`). Empty on
+    #: a parse error, since there is no tree to hash.
+    module_body_hash: str = ""
     error: str | None = None
 
 
@@ -84,6 +89,50 @@ def _body_hash(node: ast.AST) -> str:
     # ast.dump omits lineno/col_offset unless include_attributes=True, so this
     # hash is invariant to where the definition sits in the file.
     return hashlib.blake2b(ast.dump(node).encode(), digest_size=16).hexdigest()
+
+
+class _BodyElider(ast.NodeTransformer):
+    """Replace every function/class def's `body` with a single placeholder
+    statement, without recursing into the original body first.
+
+    Used to build the module-level structural hash: a def/class's own
+    `body_hash` already covers everything inside it (via `_body_hash` on
+    the untouched node), so folding that same content into the module hash
+    too would double-count it and reintroduce the exact line-shift churn
+    `body_hash` comparison exists to avoid (an edit two functions away from
+    a def would ripple into every def nested inside it, transitively, all
+    the way up to the module). Not recursing into the original body before
+    replacing it also means a closure nested inside a top-level function
+    is dropped for free -- it is already inside that function's own
+    (unelided) `body_hash`.
+
+    Everything else about the def -- its name, decorators, arguments,
+    base classes, and its position among the module's other top-level
+    statements -- is left intact, so renaming a def, changing its
+    signature, or reordering top-level statements still changes the
+    module hash.
+    """
+
+    def _elide(self, node: ast.AST) -> ast.AST:
+        clone = copy.copy(node)
+        clone.body = [ast.Pass()]
+        return clone
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.AST:
+        return self._elide(node)
+
+    visit_AsyncFunctionDef = visit_FunctionDef  # type: ignore[assignment]
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> ast.AST:
+        return self._elide(node)
+
+
+def _module_body_hash(tree: ast.Module) -> str:
+    """Structural hash of `tree`'s top-level statements, reusing
+    `_body_hash` (the same dump-and-hash `parse.py` already uses for a
+    def/class's own body) over a copy with nested def/class bodies elided."""
+    skeleton = _BodyElider().visit(copy.deepcopy(tree))
+    return _body_hash(skeleton)
 
 
 class _Collector(ast.NodeVisitor):
@@ -286,5 +335,6 @@ def parse_blob(source: bytes) -> ParseResult:
         nodes=_apply_shadowing(collector.nodes),
         refs=tuple(collector.refs),
         imports=tuple(collector.imports),
+        module_body_hash=_module_body_hash(tree),
         error=None,
     )

--- a/src/codegraph/query/__init__.py
+++ b/src/codegraph/query/__init__.py
@@ -3,5 +3,6 @@
 from __future__ import annotations
 
 from codegraph.query.effects import effects_report
+from codegraph.query.impact import impact_report
 
-__all__ = ["effects_report"]
+__all__ = ["effects_report", "impact_report"]

--- a/src/codegraph/query/diff.py
+++ b/src/codegraph/query/diff.py
@@ -1,0 +1,192 @@
+"""The `diff` report: what changed between two revisions, compared on
+`body_hash` -- never on line span.
+
+The whole point of this module is that moving a symbol's lines around (an
+inserted blank line, a reordered file) must not read as a change. Every
+symbol's identity is its node id (`path::qualname`); every symbol's
+"did it change" question is answered by comparing `body_hash` (and, for a
+symbol present in both revisions, its outgoing edge set) rather than line
+numbers.
+
+The base revision is read through `Indexer.reconcile`, which in turn reads
+trees and blobs through `gitio`'s `ls-tree`/`cat-file` plumbing -- it is
+never checked out, so a diff against an arbitrary commit leaves the
+working tree and `HEAD` untouched.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from codegraph import gitio
+from codegraph.indexer import Indexer
+from codegraph.query.impact import impact_report
+from codegraph.render import Group, Report, Row, budget
+from codegraph.store import Store
+
+#: `Indexer._materialize_nodes` also writes one synthetic module-scope node
+#: per path (`path::<module>`), whose `body_hash` is the *file's* blob sha --
+#: a file-changed signal, not a symbol-changed one. Comparing those would
+#: mean any touch to a file (including a pure line-shift) shows up as a
+#: "changed" row, defeating the point of this module. They are excluded
+#: from every set below.
+_MODULE_KIND = "module"
+
+
+class MissingRevisionError(Exception):
+    """A requested revision could not be resolved to a real commit.
+
+    Raised instead of silently falling back to some other base -- a
+    shallow clone missing history, a detached `HEAD` with no default
+    branch, or a non-git directory should fail loudly, by name.
+    """
+
+    def __init__(self, rev: str) -> None:
+        super().__init__(f"revision not found: {rev}")
+        self.rev = rev
+
+
+def _resolve(indexer: Indexer, rev: str) -> str:
+    """Resolve `rev` to a commit sha, verifying the commit actually exists.
+
+    `git rev-parse <40-hex-chars>` alone echoes back a well-formed-looking
+    sha without checking the object exists -- appending `^{commit}` forces
+    git to dereference it, which fails loudly for a sha (or shallow-missing
+    ref) with no backing object, instead of letting a later `ls-tree` fail
+    with a confusing "not a tree object".
+    """
+    root = indexer.root
+    if not gitio.is_repo(root):
+        raise MissingRevisionError(rev)
+    try:
+        return gitio.rev_parse(root, f"{rev}^{{commit}}")
+    except gitio.GitError as exc:
+        raise MissingRevisionError(rev) from exc
+
+
+def _nodes(store: Store, rev: str) -> dict[str, sqlite3.Row]:
+    return {
+        row["id"]: row
+        for row in store.connection.execute(
+            "SELECT id, path, qualname, kind, line_start, body_hash FROM nodes"
+            " WHERE rev=? AND kind != ?",
+            (rev, _MODULE_KIND),
+        )
+    }
+
+
+def _edges_by_src(store: Store, rev: str) -> dict[str, set[tuple[str, str]]]:
+    edges: dict[str, set[tuple[str, str]]] = {}
+    for row in store.connection.execute("SELECT src, dst, kind FROM edges WHERE rev=?", (rev,)):
+        edges.setdefault(row["src"], set()).add((row["dst"], row["kind"]))
+    return edges
+
+
+def _effect_kinds(store: Store, rev: str, node_id: str) -> set[str]:
+    return {
+        row["kind"]
+        for row in store.connection.execute(
+            "SELECT DISTINCT kind FROM effects WHERE rev=? AND node_id=?", (rev, node_id)
+        )
+    }
+
+
+def _dependent_count(store: Store, rev: str, node_id: str) -> int:
+    """Blast radius of `node_id` at `rev`, via the same walk `impact`
+    itself uses -- not reimplemented here."""
+    return impact_report(store, rev, node_id, limit=10_000).summary["symbols"]
+
+
+def diff_report(store: Store, indexer: Indexer, base: str, head: str, limit: int = 40) -> Report:
+    """Compare `base` and `head`, reconciling both first.
+
+    Symbol identity is the node id; the only question asked of a symbol
+    present in both revisions is whether its `body_hash` or its outgoing
+    edge set (`(src, dst, kind)`) changed -- never where its lines sit.
+    """
+    resolved_base = _resolve(indexer, base)
+
+    indexer.reconcile(resolved_base)
+    indexer.reconcile(head)
+
+    base_nodes = _nodes(store, resolved_base)
+    head_nodes = _nodes(store, head)
+    base_edges = _edges_by_src(store, resolved_base)
+    head_edges = _edges_by_src(store, head)
+
+    added_ids = set(head_nodes) - set(base_nodes)
+    removed_ids = set(base_nodes) - set(head_nodes)
+    common_ids = set(head_nodes) & set(base_nodes)
+    changed_ids = {
+        node_id
+        for node_id in common_ids
+        if head_nodes[node_id]["body_hash"] != base_nodes[node_id]["body_hash"]
+        or head_edges.get(node_id, set()) != base_edges.get(node_id, set())
+    }
+
+    added_rows = [
+        Row(
+            id=node_id,
+            location=f"{head_nodes[node_id]['path']}:{head_nodes[node_id]['line_start']}",
+            detail=head_nodes[node_id]["kind"],
+            score=1.0,
+        )
+        for node_id in added_ids
+    ]
+    removed_rows = [
+        Row(
+            id=node_id,
+            location=f"{base_nodes[node_id]['path']}:{base_nodes[node_id]['line_start']}",
+            detail=(
+                f"{base_nodes[node_id]['kind']}, "
+                f"{_dependent_count(store, resolved_base, node_id)} dependent(s)"
+            ),
+            score=1.0,
+        )
+        for node_id in removed_ids
+    ]
+    changed_rows = [
+        Row(
+            id=node_id,
+            location=f"{head_nodes[node_id]['path']}:{head_nodes[node_id]['line_start']}",
+            detail=(
+                f"{head_nodes[node_id]['kind']}, "
+                f"{_dependent_count(store, head, node_id)} dependent(s)"
+            ),
+            score=1.0,
+        )
+        for node_id in changed_ids
+    ]
+
+    groups: list[Group] = []
+    truncated = False
+    for title, group_rows in (
+        ("added", added_rows),
+        ("removed", removed_rows),
+        ("changed", changed_rows),
+    ):
+        if not group_rows:
+            continue
+        kept, was_truncated = budget(group_rows, limit)
+        groups.append(Group(title, kept))
+        truncated = truncated or was_truncated
+
+    new_effects: set[str] = set()
+    for node_id in changed_ids:
+        new_effects |= _effect_kinds(store, head, node_id) - _effect_kinds(
+            store, resolved_base, node_id
+        )
+
+    summary = {
+        "new_effects": sorted(new_effects),
+        "added": len(added_ids),
+        "removed": len(removed_ids),
+        "changed": len(changed_ids),
+        "base": resolved_base,
+        "head": head,
+    }
+
+    return Report(summary=summary, groups=groups, truncated=truncated)
+
+
+__all__ = ["MissingRevisionError", "diff_report"]

--- a/src/codegraph/query/diff.py
+++ b/src/codegraph/query/diff.py
@@ -24,14 +24,6 @@ from codegraph.query.impact import impact_report
 from codegraph.render import Group, Report, Row, budget
 from codegraph.store import Store
 
-#: `Indexer._materialize_nodes` also writes one synthetic module-scope node
-#: per path (`path::<module>`), whose `body_hash` is the *file's* blob sha --
-#: a file-changed signal, not a symbol-changed one. Comparing those would
-#: mean any touch to a file (including a pure line-shift) shows up as a
-#: "changed" row, defeating the point of this module. They are excluded
-#: from every set below.
-_MODULE_KIND = "module"
-
 
 class MissingRevisionError(Exception):
     """A requested revision could not be resolved to a real commit.
@@ -65,12 +57,19 @@ def _resolve(indexer: Indexer, rev: str) -> str:
 
 
 def _nodes(store: Store, rev: str) -> dict[str, sqlite3.Row]:
+    """Every node at `rev`, including the synthetic per-path module-scope
+    node (`path::<module>`, `kind="module"`). It is not special-cased out:
+    `parse.py` gives it a `body_hash` over the module's top-level
+    statements with nested def/class bodies elided, so it is exactly as
+    line-shift-insensitive as every other node here -- and it is where a
+    new import or a module-level side-effecting call (code with no def of
+    its own to attach to) actually lives, so excluding it would make the
+    single most effect-dense kind of change invisible to `diff`."""
     return {
         row["id"]: row
         for row in store.connection.execute(
-            "SELECT id, path, qualname, kind, line_start, body_hash FROM nodes"
-            " WHERE rev=? AND kind != ?",
-            (rev, _MODULE_KIND),
+            "SELECT id, path, qualname, kind, line_start, body_hash FROM nodes WHERE rev=?",
+            (rev,),
         )
     }
 

--- a/src/codegraph/query/impact.py
+++ b/src/codegraph/query/impact.py
@@ -1,0 +1,180 @@
+"""The `impact` report: everything downstream of a symbol that a change to
+it could break, ranked by how urgently each dependent deserves review.
+
+A reverse BFS over `edges(rev, dst)`, starting at the queried symbol and
+walking CALLS edges backward to its callers, its callers' callers, and so
+on up to `max_hops`. Each dependent is recorded the first time it is
+reached (fewest hops), and among the edges available at that hop the
+strongest achievable path confidence wins -- the same widest-path bias
+`effects/propagate.py` uses for effect reachability, applied here to
+dependents. Duplicate edge rows for the same `(src, dst)` pair (the same
+call written twice in a body, or the same candidate reached through two
+import aliases) collapse to a single edge of their strongest confidence
+before the walk starts, so they can never count as two distinct hops or
+inflate `rank.salience`'s fan-in term.
+
+Rows whose path starts with `tests/` or whose qualname's last segment
+starts with `test_` are split into their own `tests` group -- a change
+breaking a test is worth knowing, but it should never crowd out production
+callers in the ranked list. `LOW`-confidence dependents are counted in the
+summary but held back from both groups unless `include_low` is set: the
+resolver's least certain guesses are real information, but they should not
+read as confirmed impact by default.
+"""
+
+from __future__ import annotations
+
+from codegraph.query.rank import salience, score
+from codegraph.render import Group, Report, Row, budget
+from codegraph.resolve import HIGH, LOW, MEDIUM
+from codegraph.store import Store
+
+_RANK = {LOW: 0, MEDIUM: 1, HIGH: 2}
+
+
+def _stronger(a: str, b: str) -> str:
+    return a if _RANK[a] >= _RANK[b] else b
+
+
+def _weaker(a: str, b: str) -> str:
+    return a if _RANK[a] <= _RANK[b] else b
+
+
+def _reverse_edges(store: Store, rev: str) -> dict[str, dict[str, str]]:
+    """dst -> {src: confidence}, one entry per (src, dst) pair at its
+    strongest confidence -- duplicate edge rows collapsed before the walk."""
+    edge_confidence: dict[tuple[str, str], str] = {}
+    for row in store.connection.execute(
+        "SELECT src, dst, confidence FROM edges WHERE rev=? AND kind='CALLS'", (rev,)
+    ):
+        key = (row["src"], row["dst"])
+        edge_confidence[key] = _stronger(
+            edge_confidence.get(key, row["confidence"]), row["confidence"]
+        )
+
+    reverse: dict[str, dict[str, str]] = {}
+    for (src, dst), confidence in edge_confidence.items():
+        reverse.setdefault(dst, {})[src] = confidence
+    return reverse
+
+
+def _walk(
+    reverse: dict[str, dict[str, str]], node_id: str, max_hops: int
+) -> dict[str, tuple[int, str]]:
+    """Reverse BFS from `node_id`: node -> (hop, path confidence), each node
+    recorded once at its shortest hop, with the strongest confidence
+    achievable among the edges reaching it at that hop."""
+    found: dict[str, tuple[int, str]] = {}
+    level_confidence: dict[str, str] = {node_id: HIGH}
+    current_level = {node_id}
+    visited = {node_id}
+    hop = 0
+    while current_level and hop < max_hops:
+        next_level: dict[str, str] = {}
+        for current in current_level:
+            path_confidence = level_confidence[current]
+            for src, edge_confidence in reverse.get(current, {}).items():
+                if src in visited:
+                    continue
+                candidate = _weaker(path_confidence, edge_confidence)
+                best = next_level.get(src)
+                if best is None or _RANK[candidate] > _RANK[best]:
+                    next_level[src] = candidate
+        hop += 1
+        for src, confidence in next_level.items():
+            visited.add(src)
+            found[src] = (hop, confidence)
+        level_confidence = next_level
+        current_level = set(next_level)
+    return found
+
+
+def _is_test(path: str, qualname: str) -> bool:
+    return path.startswith("tests/") or qualname.rpartition(".")[2].startswith("test_")
+
+
+def impact_report(
+    store: Store,
+    rev: str,
+    node_id: str,
+    max_hops: int = 3,
+    limit: int = 40,
+    include_low: bool = False,
+) -> Report:
+    """Everything reachable from `node_id` by walking CALLS edges backward,
+    ranked by `rank.score` and split into `dependents` and `tests` groups."""
+    connection = store.connection
+    reverse = _reverse_edges(store, rev)
+    found = _walk(reverse, node_id, max_hops)
+
+    node_info: dict[str, tuple[str, str, int]] = {}
+    if found:
+        placeholders = ",".join("?" * len(found))
+        for row in connection.execute(
+            f"SELECT id, path, qualname, line_start FROM nodes WHERE rev=? AND id IN ({placeholders})",
+            (rev, *found),
+        ):
+            node_info[row["id"]] = (row["path"], row["qualname"], row["line_start"])
+
+    dependent_rows: list[Row] = []
+    test_rows: list[Row] = []
+    low_confidence_hidden = 0
+    entry_points = 0
+    modules: set[str] = set()
+
+    for dependent_id, (hop, confidence) in found.items():
+        info = node_info.get(dependent_id)
+        if info is None:
+            # Should not happen: every edge endpoint owns a node row for a
+            # revision that resolve.py just resolved.
+            continue
+        path, qualname, line_start = info
+
+        if confidence == LOW and not include_low:
+            low_confidence_hidden += 1
+            continue
+
+        salience_value = salience(store, rev, dependent_id)
+        if salience_value >= 0.5:
+            entry_points += 1
+        modules.add(path)
+
+        row = Row(
+            id=dependent_id,
+            location=f"{path}:{line_start}",
+            detail=f"hop {hop}, {confidence} confidence",
+            score=score(hop, confidence, salience_value),
+        )
+        if _is_test(path, qualname):
+            test_rows.append(row)
+        else:
+            dependent_rows.append(row)
+
+    kept, truncated = budget(dependent_rows, limit)
+    groups = [Group("dependents", kept)] if kept else []
+    if test_rows:
+        kept_tests, tests_truncated = budget(test_rows, limit)
+        groups.append(Group("tests", kept_tests))
+        truncated = truncated or tests_truncated
+
+    effects_reachable = sorted(
+        {
+            row["kind"]
+            for row in connection.execute(
+                "SELECT DISTINCT kind FROM effects WHERE rev=? AND node_id=?", (rev, node_id)
+            )
+        }
+    )
+
+    summary = {
+        "symbols": len(dependent_rows) + len(test_rows),
+        "modules": len(modules),
+        "entry_points": entry_points,
+        "low_confidence_hidden": low_confidence_hidden,
+        "effects_reachable": effects_reachable,
+    }
+
+    return Report(summary=summary, groups=groups, truncated=truncated)
+
+
+__all__ = ["impact_report"]

--- a/src/codegraph/query/impact.py
+++ b/src/codegraph/query/impact.py
@@ -24,7 +24,7 @@ read as confirmed impact by default.
 
 from __future__ import annotations
 
-from codegraph.query.rank import salience, score
+from codegraph.query.rank import fan_in, salience, score
 from codegraph.render import Group, Report, Row, budget
 from codegraph.resolve import HIGH, LOW, MEDIUM
 from codegraph.store import Store
@@ -135,7 +135,7 @@ def impact_report(
             continue
 
         salience_value = salience(store, rev, dependent_id)
-        if salience_value >= 0.5:
+        if fan_in(store, rev, dependent_id) == 0:
             entry_points += 1
         modules.add(path)
 

--- a/src/codegraph/query/rank.py
+++ b/src/codegraph/query/rank.py
@@ -28,6 +28,20 @@ def score(hop: int, confidence: str, salience_value: float) -> float:
     return (1.0 / hop) * _CONFIDENCE_WEIGHT[confidence] * (1.0 + salience_value)
 
 
+def fan_in(store: Store, rev: str, node_id: str) -> int:
+    """Count of DISTINCT callers of `node_id` -- never raw edge rows, since
+    the `edges` table can hold more than one row for the same (src, dst)
+    pair. `salience` folds this into its composite score; callers that need
+    the raw fan-in itself (e.g. to test whether a node is a true entry
+    point, `fan_in == 0`) should call this directly rather than
+    reverse-engineering it out of `salience`'s combined value, which a
+    public, well-called node can also cross via its other two terms alone."""
+    row = store.connection.execute(
+        "SELECT COUNT(DISTINCT src) AS n FROM edges WHERE rev=? AND dst=?", (rev, node_id)
+    ).fetchone()
+    return row["n"]
+
+
 def salience(store: Store, rev: str, node_id: str) -> float:
     """How much a node deserves attention on its own merits: 0.5 if it has
     no callers of its own (an entry point), 0.3 if its qualname's last
@@ -35,12 +49,10 @@ def salience(store: Store, rev: str, node_id: str) -> float:
     capped at `_FAN_IN_CAP` distinct callers."""
     connection = store.connection
 
-    fan_in = connection.execute(
-        "SELECT COUNT(DISTINCT src) AS n FROM edges WHERE rev=? AND dst=?", (rev, node_id)
-    ).fetchone()["n"]
+    callers = fan_in(store, rev, node_id)
 
     value = 0.0
-    if fan_in == 0:
+    if callers == 0:
         value += 0.5
 
     row = connection.execute(
@@ -50,9 +62,9 @@ def salience(store: Store, rev: str, node_id: str) -> float:
     if not last_segment.startswith("_"):
         value += 0.3
 
-    value += min(fan_in, _FAN_IN_CAP) / 20
+    value += min(callers, _FAN_IN_CAP) / 20
 
     return value
 
 
-__all__ = ["salience", "score"]
+__all__ = ["fan_in", "salience", "score"]

--- a/src/codegraph/query/rank.py
+++ b/src/codegraph/query/rank.py
@@ -1,0 +1,58 @@
+"""Scoring for the `impact` report: how urgently a dependent deserves a
+human's attention, given how far it sits from the changed symbol, how
+confident the resolver was about the path, and how salient the dependent
+itself is.
+
+`salience` counts fan-in over DISTINCT source nodes, never edge rows: the
+`edges` table can hold more than one row for the same `(src, dst)` pair --
+the same call written twice in a body, or the same candidate reached
+through two import aliases -- and none of that should inflate how many
+distinct callers a node has.
+"""
+
+from __future__ import annotations
+
+from codegraph.resolve import HIGH, LOW, MEDIUM
+from codegraph.store import Store
+
+_CONFIDENCE_WEIGHT = {HIGH: 1.0, MEDIUM: 0.6, LOW: 0.25}
+
+#: Fan-in is capped before it contributes to salience, so one extremely
+#: popular utility cannot dwarf every other salience term.
+_FAN_IN_CAP = 10
+
+
+def score(hop: int, confidence: str, salience_value: float) -> float:
+    """Rank a dependent: closer hops and higher resolver confidence score
+    higher, boosted by how salient the dependent itself is."""
+    return (1.0 / hop) * _CONFIDENCE_WEIGHT[confidence] * (1.0 + salience_value)
+
+
+def salience(store: Store, rev: str, node_id: str) -> float:
+    """How much a node deserves attention on its own merits: 0.5 if it has
+    no callers of its own (an entry point), 0.3 if its qualname's last
+    segment is not private (does not start with `_`), plus a fan-in term
+    capped at `_FAN_IN_CAP` distinct callers."""
+    connection = store.connection
+
+    fan_in = connection.execute(
+        "SELECT COUNT(DISTINCT src) AS n FROM edges WHERE rev=? AND dst=?", (rev, node_id)
+    ).fetchone()["n"]
+
+    value = 0.0
+    if fan_in == 0:
+        value += 0.5
+
+    row = connection.execute(
+        "SELECT qualname FROM nodes WHERE rev=? AND id=?", (rev, node_id)
+    ).fetchone()
+    last_segment = row["qualname"].rpartition(".")[2] if row else node_id.rpartition(".")[2]
+    if not last_segment.startswith("_"):
+        value += 0.3
+
+    value += min(fan_in, _FAN_IN_CAP) / 20
+
+    return value
+
+
+__all__ = ["salience", "score"]

--- a/src/codegraph/store.py
+++ b/src/codegraph/store.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 WORKTREE = "WORKTREE"
 
@@ -25,7 +25,8 @@ CREATE TABLE IF NOT EXISTS blobs (
     blob_sha TEXT PRIMARY KEY,
     status TEXT NOT NULL,
     error TEXT,
-    parser_version TEXT NOT NULL
+    parser_version TEXT NOT NULL,
+    module_body_hash TEXT NOT NULL DEFAULT ''
 );
 CREATE TABLE IF NOT EXISTS blob_nodes (
     blob_sha TEXT NOT NULL,

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,88 @@
+from codegraph.indexer import GitTreeSource, Indexer
+from codegraph.query.diff import diff_report
+from codegraph.store import Store
+from tests.conftest import git
+
+
+def build(repo):
+    store = Store.open(repo)
+    return store, Indexer(repo, store, GitTreeSource(repo))
+
+
+def rows(report, title):
+    return {r.id for g in report.groups if g.title == title for r in g.rows}
+
+
+def test_blank_line_insertion_produces_empty_diff(repo, write):
+    store, indexer = build(repo)
+    base = git(repo, "rev-parse", "HEAD").strip()
+    write("a.py", "\n\n\ndef alpha():\n    return 1\n", commit="shift lines")
+    report = diff_report(store, indexer, base, "HEAD")
+    assert report.groups == []
+    store.close()
+
+
+def test_added_symbol_reported(repo, write):
+    store, indexer = build(repo)
+    base = git(repo, "rev-parse", "HEAD").strip()
+    write("a.py", "def alpha():\n    return 1\n\n\ndef added():\n    pass\n", commit="add")
+    report = diff_report(store, indexer, base, "HEAD")
+    assert "a.py::added" in rows(report, "added")
+    store.close()
+
+
+def test_removed_symbol_reported(repo, write):
+    write("b.py", "def beta():\n    pass\n", commit="b")
+    store, indexer = build(repo)
+    base = git(repo, "rev-parse", "HEAD").strip()
+    (repo / "b.py").unlink()
+    git(repo, "add", "-A"); git(repo, "commit", "-qm", "remove b")
+    report = diff_report(store, indexer, base, "HEAD")
+    assert "b.py::beta" in rows(report, "removed")
+    store.close()
+
+
+def test_changed_body_reported(repo, write):
+    store, indexer = build(repo)
+    base = git(repo, "rev-parse", "HEAD").strip()
+    write("a.py", "def alpha():\n    return 999\n", commit="change body")
+    report = diff_report(store, indexer, base, "HEAD")
+    assert "a.py::alpha" in rows(report, "changed")
+    store.close()
+
+
+def test_newly_reachable_effect_is_headlined(repo, write):
+    write("m.py", "def charge():\n    pass\n\n\ndef checkout():\n    charge()\n", commit="m")
+    store, indexer = build(repo)
+    base = git(repo, "rev-parse", "HEAD").strip()
+    write(
+        "m.py",
+        "import requests\n\n\ndef charge():\n    requests.post('u')\n\n\ndef checkout():\n    charge()\n",
+        commit="add network call",
+    )
+    report = diff_report(store, indexer, base, "HEAD")
+    assert "NETWORK" in str(report.summary)
+    store.close()
+
+
+def test_base_revision_is_not_checked_out(repo, write):
+    store, indexer = build(repo)
+    base = git(repo, "rev-parse", "HEAD").strip()
+    write("a.py", "def alpha():\n    return 2\n", commit="edit")
+    before = (repo / "a.py").read_text()
+    diff_report(store, indexer, base, "HEAD")
+    assert (repo / "a.py").read_text() == before
+    assert git(repo, "rev-parse", "--abbrev-ref", "HEAD").strip() == "main"
+    store.close()
+
+
+def test_missing_base_revision_reports_name_and_raises(repo, write):
+    store, indexer = build(repo)
+    write("a.py", "def alpha():\n    return 2\n", commit="edit")
+    import pytest
+
+    from codegraph.query.diff import MissingRevisionError
+
+    with pytest.raises(MissingRevisionError, match="deadbeef"):
+        diff_report(store, indexer, "deadbeef" * 5, "HEAD")
+    store.close()

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -86,3 +86,38 @@ def test_missing_base_revision_reports_name_and_raises(repo, write):
     with pytest.raises(MissingRevisionError, match="deadbeef"):
         diff_report(store, indexer, "deadbeef" * 5, "HEAD")
     store.close()
+
+
+def test_new_module_only_file_appears_in_added(repo, write):
+    store, indexer = build(repo)
+    base = git(repo, "rev-parse", "HEAD").strip()
+    write("config.py", "TIMEOUT = 30\n", commit="add config")
+    report = diff_report(store, indexer, base, "HEAD")
+    assert "config.py::<module>" in rows(report, "added")
+    store.close()
+
+
+def test_deleted_module_only_file_appears_in_removed(repo, write):
+    write("config.py", "TIMEOUT = 30\n", commit="add config")
+    store, indexer = build(repo)
+    base = git(repo, "rev-parse", "HEAD").strip()
+    (repo / "config.py").unlink()
+    git(repo, "add", "-A"); git(repo, "commit", "-qm", "remove config")
+    report = diff_report(store, indexer, base, "HEAD")
+    assert "config.py::<module>" in rows(report, "removed")
+    store.close()
+
+
+def test_module_level_effect_addition_is_changed_and_new_effect(repo, write):
+    write("m.py", "TIMEOUT = 30\n", commit="m")
+    store, indexer = build(repo)
+    base = git(repo, "rev-parse", "HEAD").strip()
+    write(
+        "m.py",
+        "import requests\n\nTIMEOUT = 30\nrequests.post('u')\n",
+        commit="add module-level network call",
+    )
+    report = diff_report(store, indexer, base, "HEAD")
+    assert "m.py::<module>" in rows(report, "changed")
+    assert "NETWORK" in str(report.summary)
+    store.close()

--- a/tests/test_impact.py
+++ b/tests/test_impact.py
@@ -1,0 +1,134 @@
+import pytest
+
+from codegraph.indexer import GitTreeSource, Indexer
+from codegraph.query.impact import impact_report
+from codegraph.query.rank import salience, score
+from codegraph.store import Store
+
+
+def build(repo):
+    store = Store.open(repo)
+    Indexer(repo, store, GitTreeSource(repo)).reconcile("HEAD")
+    return store
+
+
+def listed(report):
+    return {row.id for group in report.groups for row in group.rows}
+
+
+def test_closer_hops_score_higher():
+    assert score(1, "HIGH", 1.0) > score(3, "HIGH", 1.0)
+
+
+def test_higher_confidence_scores_higher():
+    assert score(1, "HIGH", 1.0) > score(1, "LOW", 1.0)
+
+
+def test_direct_and_transitive_callers_are_found(repo, write):
+    source = (
+        "def target():\n    pass\n\n\n"
+        "def direct():\n    target()\n\n\n"
+        "def indirect():\n    direct()\n"
+    )
+    write("m.py", source, commit="m")
+    store = build(repo)
+    found = listed(impact_report(store, "HEAD", "m.py::target"))
+    assert {"m.py::direct", "m.py::indirect"} <= found
+    store.close()
+
+
+def test_hop_limit_is_respected(repo, write):
+    source = (
+        "def target():\n    pass\n\n\n"
+        "def h1():\n    target()\n\n\n"
+        "def h2():\n    h1()\n\n\n"
+        "def h3():\n    h2()\n\n\n"
+        "def h4():\n    h3()\n"
+    )
+    write("m.py", source, commit="m")
+    store = build(repo)
+    found = listed(impact_report(store, "HEAD", "m.py::target", max_hops=2))
+    assert "m.py::h2" in found
+    assert "m.py::h4" not in found
+    store.close()
+
+
+def test_tests_are_bucketed_separately(repo, write):
+    write("m.py", "def target():\n    pass\n", commit="m")
+    write("tests/__init__.py", "", commit="pkg")
+    write(
+        "tests/test_m.py",
+        "from m import target\n\n\ndef test_target():\n    target()\n",
+        commit="t",
+    )
+    store = build(repo)
+    report = impact_report(store, "HEAD", "m.py::target")
+    test_groups = [g for g in report.groups if g.title == "tests"]
+    assert test_groups and test_groups[0].rows
+    other = {row.id for g in report.groups if g.title != "tests" for row in g.rows}
+    assert "tests/test_m.py::test_target" not in other
+    store.close()
+
+
+def test_low_confidence_counted_but_not_listed(repo, write):
+    write("one.py", "class One:\n    def shared(self):\n        pass\n", commit="1")
+    write("two.py", "class Two:\n    def shared(self):\n        pass\n", commit="2")
+    write("caller.py", "def go(thing):\n    thing.shared()\n", commit="c")
+    store = build(repo)
+    report = impact_report(store, "HEAD", "one.py::One.shared")
+    assert "caller.py::go" not in listed(report)
+    assert report.summary["low_confidence_hidden"] >= 1
+    with_low = impact_report(store, "HEAD", "one.py::One.shared", include_low=True)
+    assert "caller.py::go" in listed(with_low)
+    store.close()
+
+
+def test_summary_reports_reachable_effects(repo, write):
+    source = (
+        "import requests\n\n\n"
+        "def target():\n    requests.get('u')\n\n\n"
+        "def caller():\n    target()\n"
+    )
+    write("m.py", source, commit="m")
+    store = build(repo)
+    report = impact_report(store, "HEAD", "m.py::target")
+    assert "NETWORK" in str(report.summary)
+    store.close()
+
+
+def test_duplicate_edge_rows_do_not_double_count_fan_in(tmp_path):
+    """A caller that calls the target twice (two rows in `edges` for the
+    same (src, dst) pair -- e.g. the same call appearing twice in a body)
+    must contribute fan_in 1, not 2. Schema seeded directly so the edge
+    duplication is exact, mirroring test_effects.py's direct-seed style."""
+    store = Store.open(tmp_path)
+    rev = "HEAD"
+    connection = store.connection
+    connection.execute(
+        "INSERT INTO nodes(rev, id, path, qualname, kind, line_start, line_end, body_hash,"
+        " name_binding) VALUES(?,?,?,?,?,?,?,?,?)",
+        (rev, "m.py::mid", "m.py", "mid", "function", 1, 1, "x", "live"),
+    )
+    connection.executemany(
+        "INSERT INTO edges(rev, src, dst, kind, confidence, provenance, callsite_path,"
+        " callsite_line) VALUES(?,?,?,?,?,?,?,?)",
+        [
+            (rev, "m.py::top", "m.py::mid", "CALLS", "HIGH", "static", "m.py", 1),
+            (rev, "m.py::top", "m.py::mid", "CALLS", "HIGH", "static", "m.py", 2),
+        ],
+    )
+    connection.commit()
+
+    # 0.3 (not private) + min(1, 10) / 20 (one distinct caller, not two rows).
+    assert salience(store, rev, "m.py::mid") == pytest.approx(0.35)
+    store.close()
+
+
+def test_limit_sets_truncated_flag(repo, write):
+    lines = ["def target():\n    pass\n"]
+    lines += [f"def c{i}():\n    target()\n" for i in range(60)]
+    write("m.py", "\n\n".join(lines), commit="m")
+    store = build(repo)
+    report = impact_report(store, "HEAD", "m.py::target", limit=10)
+    assert report.truncated is True
+    store.close()

--- a/tests/test_impact.py
+++ b/tests/test_impact.py
@@ -96,6 +96,25 @@ def test_summary_reports_reachable_effects(repo, write):
     store.close()
 
 
+def test_entry_points_excludes_popular_intermediaries(repo, write):
+    """Regression for the round-2 Major: `entry_points` must count nodes by
+    their OWN fan_in == 0, not by threshold-sniffing `salience`'s combined
+    score. `popular` is public and has 10 distinct callers -- its salience
+    (0 + 0.3 public + 0.5 fan-in-capped = 0.8) crosses 0.5 with no help from
+    the entry-point term at all, so it must NOT be counted. Each `callerN`
+    has no callers of its own and must be."""
+    lines = ["def target():\n    pass\n\n\ndef popular():\n    target()\n"]
+    lines += [f"def caller{i}():\n    popular()\n" for i in range(10)]
+    write("m.py", "\n\n".join(lines), commit="m")
+    store = build(repo)
+    report = impact_report(store, "HEAD", "m.py::target")
+    assert report.summary["entry_points"] == 10
+    found = listed(report)
+    assert "m.py::popular" in found
+    assert all(f"m.py::caller{i}" in found for i in range(10))
+    store.close()
+
+
 def test_duplicate_edge_rows_do_not_double_count_fan_in(tmp_path):
     """A caller that calls the target twice (two rows in `edges` for the
     same (src, dst) pair -- e.g. the same call appearing twice in a body)

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -2,6 +2,7 @@ import os
 import stat
 import time
 
+from codegraph.cli import main
 from codegraph.indexer import GitTreeSource, Indexer
 from codegraph.maintenance import gc, install_hooks
 from codegraph.query.impact import impact_report
@@ -123,6 +124,142 @@ def test_install_hooks_is_idempotent(repo):
     assert first == second
     assert second.count("codegraph index") == 1
     assert {p.name for p in written_again} == {"post-commit", "post-checkout", "post-merge"}
+
+
+# --- Interpreter allowlist and stale-install repair (2nd review round) ---
+
+
+def test_install_hooks_skips_perl_hook_untouched(repo):
+    """Splicing shell syntax into a hook written for a different
+    interpreter corrupts it outright, not just fails to warm it. A Perl
+    hook must be left byte-for-byte alone and absent from the returned
+    (installed) list."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    perl_hook = hooks_dir / "post-commit"
+    original = '#!/usr/bin/perl\nprint "perl-hook-ran\\n";\n'
+    perl_hook.write_text(original)
+    perl_hook.chmod(perl_hook.stat().st_mode | stat.S_IXUSR)
+
+    written = install_hooks(repo)
+
+    assert perl_hook not in written
+    assert perl_hook.read_text() == original
+
+
+def test_install_hooks_skips_env_python_hook_untouched(repo):
+    """`#!/usr/bin/env python3` is exactly as unsafe to splice into as a
+    direct `#!/usr/bin/perl` -- the `env` indirection must still resolve to
+    the real interpreter for the allowlist check."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    python_hook = hooks_dir / "post-checkout"
+    original = "#!/usr/bin/env python3\nprint('python-hook-ran')\n"
+    python_hook.write_text(original)
+    python_hook.chmod(python_hook.stat().st_mode | stat.S_IXUSR)
+
+    written = install_hooks(repo)
+
+    assert python_hook not in written
+    assert python_hook.read_text() == original
+
+
+def test_install_hooks_reports_skip_reason_on_cli(repo, capsys):
+    """A skip must be loud, not silent: the CLI names the skipped hook and
+    says why, on stderr, distinct from the installed paths on stdout."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    perl_hook = hooks_dir / "post-commit"
+    perl_hook.write_text('#!/usr/bin/perl\nprint "hi\\n";\n')
+    perl_hook.chmod(perl_hook.stat().st_mode | stat.S_IXUSR)
+
+    assert main(["install-hooks", "--path", str(repo)]) == 0
+
+    captured = capsys.readouterr()
+    assert "post-commit" not in captured.out
+    assert "post-checkout" in captured.out
+    assert "post-merge" in captured.out
+    assert "skipped post-commit" in captured.err
+    assert "perl" in captured.err.lower()
+
+
+def test_install_hooks_still_installs_allowlisted_shell_shapes(repo):
+    """`#!/bin/bash -e`, `#!/usr/bin/env bash`, and a fully absent shebang
+    all name (or don't contradict) a POSIX-shell-compatible interpreter and
+    must still install normally."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+
+    bash_flag_hook = hooks_dir / "post-commit"
+    bash_flag_hook.write_text("#!/bin/bash -e\necho bash-ran\n")
+    bash_flag_hook.chmod(bash_flag_hook.stat().st_mode | stat.S_IXUSR)
+
+    env_bash_hook = hooks_dir / "post-checkout"
+    env_bash_hook.write_text("#!/usr/bin/env bash\necho env-bash-ran\n")
+    env_bash_hook.chmod(env_bash_hook.stat().st_mode | stat.S_IXUSR)
+
+    # post-merge: no pre-existing file at all.
+
+    written = install_hooks(repo)
+
+    assert {p.name for p in written} == {"post-commit", "post-checkout", "post-merge"}
+    assert "codegraph index" in bash_flag_hook.read_text()
+    assert bash_flag_hook.read_text().startswith("#!/bin/bash -e\n")
+    assert "codegraph index" in env_bash_hook.read_text()
+    assert env_bash_hook.read_text().startswith("#!/usr/bin/env bash\n")
+
+
+def test_install_hooks_repairs_a_stale_pre_fix_install(repo):
+    """A hook carrying the OLD append-at-end block (with `$?` preservation,
+    installed after the pre-existing hook's own `exit 0`) must not be left
+    byte-identical -- it was silently dead. install_hooks repairs it into a
+    live, top-of-file block."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    stale_hook = hooks_dir / "post-commit"
+    stale_hook.write_text(
+        "#!/bin/sh\n"
+        "echo hi >> marker.txt\n"
+        "exit 0\n"
+        "# >>> codegraph (warming only; safe to remove) >>>\n"
+        "_codegraph_status=$?\n"
+        '( cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"'
+        ' && codegraph index --quiet >/dev/null 2>&1 & ) >/dev/null 2>&1 || true\n'
+        "exit $_codegraph_status\n"
+        "# <<< codegraph (warming only; safe to remove) <<<\n"
+    )
+    stale_hook.chmod(stale_hook.stat().st_mode | stat.S_IXUSR)
+
+    written = install_hooks(repo)
+
+    content = stale_hook.read_text()
+    assert stale_hook in written
+    assert "_codegraph_status" not in content  # old dead artifact is gone
+    assert content.count("codegraph index") == 1
+    assert content.index("codegraph index") < content.index("exit 0")
+    assert "echo hi >> marker.txt" in content
+
+
+def test_install_hooks_three_reruns_stay_at_one_invocation(repo):
+    """Repair and idempotency share one mechanism (strip-then-insert), so
+    repeated calls -- even against a hook that keeps ending in its own
+    `exit 0` -- must converge, not accumulate."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    hook = hooks_dir / "post-commit"
+    hook.write_text("#!/bin/sh\necho hi >> marker.txt\nexit 0\n")
+    hook.chmod(hook.stat().st_mode | stat.S_IXUSR)
+
+    install_hooks(repo)
+    first = hook.read_text()
+    install_hooks(repo)
+    second = hook.read_text()
+    install_hooks(repo)
+    third = hook.read_text()
+
+    assert first == second == third
+    assert third.count("codegraph index") == 1
+    assert third.count("# >>> codegraph") == 1
 
 
 def test_gc_does_not_corrupt_a_live_graph(repo, write):

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -1,5 +1,6 @@
 import os
 import stat
+import time
 
 from codegraph.indexer import GitTreeSource, Indexer
 from codegraph.maintenance import gc, install_hooks
@@ -64,13 +65,51 @@ def test_install_hooks_preserves_pre_existing_hook(repo):
     written = install_hooks(repo)
 
     content = existing_hook.read_text()
-    assert original.strip() in content
+    assert "echo ran >> marker.txt" in content
     assert "codegraph index" in content
     assert existing_hook in written
 
     # The pre-existing behavior must still actually fire.
     git(repo, "commit", "--allow-empty", "-qm", "trigger hooks")
     assert (repo / "marker.txt").read_text() == "ran\n"
+
+
+def test_install_hooks_fires_even_after_a_pre_existing_exit(repo, monkeypatch, tmp_path):
+    """A pre-existing hook that ends in `exit 0` -- a very common idiom -- is
+    exactly the case that was silently broken: code appended after that
+    `exit` is unreachable, so the warming block never ran even though
+    install_hooks reported success. It must fire regardless, by running
+    before the pre-existing script's own logic rather than after it."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    existing_hook = hooks_dir / "post-commit"
+    existing_hook.write_text("#!/bin/sh\necho hi >> marker.txt\nexit 0\n")
+    existing_hook.chmod(existing_hook.stat().st_mode | stat.S_IXUSR)
+
+    # A `codegraph` shim on PATH that just logs that it was invoked.
+    shim_dir = tmp_path / "shim"
+    shim_dir.mkdir()
+    log = tmp_path / "invoked.log"
+    shim = shim_dir / "codegraph"
+    shim.write_text(f'#!/bin/sh\necho invoked >> "{log}"\n')
+    shim.chmod(shim.stat().st_mode | stat.S_IXUSR)
+    monkeypatch.setenv("PATH", f"{shim_dir}{os.pathsep}{os.environ['PATH']}")
+
+    install_hooks(repo)
+    content = existing_hook.read_text()
+    # The codegraph block must precede the pre-existing `exit 0`, not follow it.
+    assert content.index("codegraph index") < content.index("exit 0")
+
+    git(repo, "commit", "--allow-empty", "-qm", "trigger hooks despite exit 0")
+
+    # The backgrounded warm-up may still be running when `git commit`
+    # returns; give it a short window to land before asserting it fired.
+    deadline = time.monotonic() + 2.0
+    while not log.exists() and time.monotonic() < deadline:
+        time.sleep(0.02)
+    assert log.exists(), "codegraph shim was never invoked -- warming block was skipped"
+    # The pre-existing hook's own behavior still ran too.
+    assert (repo / "marker.txt").read_text() == "hi\n"
 
 
 def test_install_hooks_is_idempotent(repo):

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -1,0 +1,127 @@
+import os
+import stat
+
+from codegraph.indexer import GitTreeSource, Indexer
+from codegraph.maintenance import gc, install_hooks
+from codegraph.query.impact import impact_report
+from codegraph.resolve import find_symbol
+from codegraph.store import Store
+from tests.conftest import git
+
+
+def test_gc_removes_unreferenced_blobs(repo, write):
+    store = Store.open(repo)
+    indexer = Indexer(repo, store, GitTreeSource(repo))
+    indexer.reconcile("HEAD")
+    write("a.py", "def alpha():\n    return 2\n", commit="edit")
+    indexer.reconcile("HEAD")
+    before = store.connection.execute("SELECT COUNT(*) c FROM blobs").fetchone()["c"]
+    removed = gc(store, {"HEAD"})
+    after = store.connection.execute("SELECT COUNT(*) c FROM blobs").fetchone()["c"]
+    assert removed >= 1
+    assert after < before
+    store.close()
+
+
+def test_gc_keeps_blobs_of_retained_revisions(repo):
+    store = Store.open(repo)
+    Indexer(repo, store, GitTreeSource(repo)).reconcile("HEAD")
+    gc(store, {"HEAD"})
+    rows = store.connection.execute("SELECT COUNT(*) c FROM blobs").fetchone()["c"]
+    assert rows == 1
+    store.close()
+
+
+def test_install_hooks_writes_executable_hooks(repo):
+    written = install_hooks(repo)
+    assert {p.name for p in written} == {"post-commit", "post-checkout", "post-merge"}
+    for path in written:
+        assert os.stat(path).st_mode & stat.S_IXUSR
+        assert "codegraph index" in path.read_text()
+
+
+def test_hooks_do_not_block_the_git_operation(repo, write):
+    install_hooks(repo)
+    write("c.py", "def gamma():\n    pass\n", commit="with hooks installed")
+    assert git(repo, "rev-parse", "--abbrev-ref", "HEAD").strip() == "main"
+
+
+# --- Extra tests per the brief -------------------------------------------
+
+
+def test_install_hooks_preserves_pre_existing_hook(repo):
+    """A repo may already have a post-commit hook (e.g. a linter). Installing
+    codegraph's hooks must not clobber it -- the existing script's own
+    behavior (here, appending to a marker file) must still run, and its
+    original source text must still be present in the file verbatim."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    existing_hook = hooks_dir / "post-commit"
+    original = "#!/bin/sh\necho ran >> marker.txt\n"
+    existing_hook.write_text(original)
+    existing_hook.chmod(existing_hook.stat().st_mode | stat.S_IXUSR)
+
+    written = install_hooks(repo)
+
+    content = existing_hook.read_text()
+    assert original.strip() in content
+    assert "codegraph index" in content
+    assert existing_hook in written
+
+    # The pre-existing behavior must still actually fire.
+    git(repo, "commit", "--allow-empty", "-qm", "trigger hooks")
+    assert (repo / "marker.txt").read_text() == "ran\n"
+
+
+def test_install_hooks_is_idempotent(repo):
+    """Running install_hooks twice must not double-append the codegraph
+    block or produce two invocations of `codegraph index`."""
+    install_hooks(repo)
+    first = (repo / ".git" / "hooks" / "post-commit").read_text()
+    written_again = install_hooks(repo)
+    second = (repo / ".git" / "hooks" / "post-commit").read_text()
+
+    assert first == second
+    assert second.count("codegraph index") == 1
+    assert {p.name for p in written_again} == {"post-commit", "post-checkout", "post-merge"}
+
+
+def test_gc_does_not_corrupt_a_live_graph(repo, write):
+    """After gc(store, {"HEAD"}), a query at HEAD must still return the same
+    answer it did before the gc: Layer 1 rows for retained revisions, and
+    everything Layer 2 needs, must survive."""
+    write(
+        "b.py",
+        "from a import alpha\n\ndef beta():\n    return alpha()\n",
+        commit="add beta",
+    )
+    store = Store.open(repo)
+    indexer = Indexer(repo, store, GitTreeSource(repo))
+    indexer.reconcile("HEAD")
+
+    node_id = find_symbol(store, "HEAD", "alpha")[0]["id"]
+    before = impact_report(store, "HEAD", node_id)
+
+    gc(store, {"HEAD"})
+
+    after = impact_report(store, "HEAD", node_id)
+    assert after == before
+    assert len(before.groups) > 0
+    store.close()
+
+
+def test_gc_with_empty_keep_revs_removes_everything(repo):
+    """An empty keep_revs retains nothing: every Layer 1 row is unreferenced
+    by definition, so gc removes it all. This is the defined behavior for
+    the empty case, not an accident of the query."""
+    store = Store.open(repo)
+    Indexer(repo, store, GitTreeSource(repo)).reconcile("HEAD")
+    before = store.connection.execute("SELECT COUNT(*) c FROM blobs").fetchone()["c"]
+    assert before > 0
+
+    removed = gc(store, set())
+
+    after = store.connection.execute("SELECT COUNT(*) c FROM blobs").fetchone()["c"]
+    assert removed == before
+    assert after == 0
+    store.close()

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -4,7 +4,7 @@ import time
 
 from codegraph.cli import main
 from codegraph.indexer import GitTreeSource, Indexer
-from codegraph.maintenance import gc, install_hooks
+from codegraph.maintenance import gc, install_hooks, plan_hooks
 from codegraph.query.impact import impact_report
 from codegraph.resolve import find_symbol
 from codegraph.store import Store
@@ -260,6 +260,131 @@ def test_install_hooks_three_reruns_stay_at_one_invocation(repo):
     assert first == second == third
     assert third.count("codegraph index") == 1
     assert third.count("# >>> codegraph") == 1
+
+
+# --- Binary hooks, env -S, multi-block convergence, marker anchoring,
+# --- and half-marker refusal (3rd review round) --------------------------
+
+
+def test_install_hooks_skips_binary_hook_but_installs_the_others(repo):
+    """A compiled/binary post-commit (pre-commit frameworks and compiled
+    shims ship these) must not crash the whole command -- it's a non-shell
+    hook, refused the same as Perl, and the other two hooks still install."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    binary_hook = hooks_dir / "post-commit"
+    original = bytes([0x7F, 0x45, 0x4C, 0x46, 0x02, 0x01, 0x01, 0x00, 0xFF, 0xFE, 0x00, 0x01])
+    binary_hook.write_bytes(original)
+    binary_hook.chmod(binary_hook.stat().st_mode | stat.S_IXUSR)
+
+    written = install_hooks(repo)
+
+    assert binary_hook not in written
+    assert {p.name for p in written} == {"post-checkout", "post-merge"}
+    assert binary_hook.read_bytes() == original
+
+
+def test_install_hooks_resolves_env_dash_capital_s_flag(repo):
+    """`#!/usr/bin/env -S bash -e` names bash, not `-S` -- env's own flags
+    must be skipped when hunting for the interpreter token."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    hook = hooks_dir / "post-commit"
+    hook.write_text("#!/usr/bin/env -S bash -e\necho bash-with-env-S-ran\n")
+    hook.chmod(hook.stat().st_mode | stat.S_IXUSR)
+
+    written = install_hooks(repo)
+
+    assert hook in written
+    content = hook.read_text()
+    assert content.startswith("#!/usr/bin/env -S bash -e\n")
+    assert "codegraph index" in content
+    assert "echo bash-with-env-S-ran" in content
+
+
+def test_install_hooks_converges_a_leading_and_trailing_double_block(repo):
+    """A file carrying two codegraph blocks (a current one spliced at the
+    top, plus a stale one still sitting at the end from an even older
+    install) must converge to exactly one block, not one-fewer."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    hook = hooks_dir / "post-commit"
+    hook.write_text(
+        "#!/bin/sh\n"
+        "# >>> codegraph (warming only; safe to remove) >>>\n"
+        '( cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"'
+        " && codegraph index --quiet >/dev/null 2>&1 & ) >/dev/null 2>&1 || true\n"
+        "# <<< codegraph (warming only; safe to remove) <<<\n"
+        "echo real-work\n"
+        "# >>> codegraph (warming only; safe to remove) >>>\n"
+        "_codegraph_status=$?\n"
+        '( cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"'
+        " && codegraph index --quiet >/dev/null 2>&1 & ) >/dev/null 2>&1 || true\n"
+        "exit $_codegraph_status\n"
+        "# <<< codegraph (warming only; safe to remove) <<<\n"
+    )
+    hook.chmod(hook.stat().st_mode | stat.S_IXUSR)
+
+    written = install_hooks(repo)
+
+    content = hook.read_text()
+    assert hook in written
+    assert content.count("# >>> codegraph (warming only; safe to remove) >>>") == 1
+    assert content.count("# <<< codegraph (warming only; safe to remove) <<<") == 1
+    assert content.count("codegraph index") == 1
+    assert "_codegraph_status" not in content
+    assert "echo real-work" in content
+
+
+def test_install_hooks_ignores_marker_text_embedded_in_other_lines(repo):
+    """Marker matching must be anchored to a whole line, not a substring
+    search -- a hook whose own comment or echoed string happens to contain
+    the marker text must keep every real statement around it."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    hook = hooks_dir / "post-commit"
+    hook.write_text(
+        "#!/bin/sh\n"
+        "do_important_setup_step\n"
+        'echo "reminder: # >>> codegraph (warming only; safe to remove) >>> not a real marker"\n'
+        "do_important_setup_step\n"
+    )
+    hook.chmod(hook.stat().st_mode | stat.S_IXUSR)
+
+    written = install_hooks(repo)
+
+    content = hook.read_text()
+    assert hook in written
+    assert content.count("do_important_setup_step") == 2
+    assert "not a real marker" in content
+    assert "codegraph index" in content
+
+
+def test_install_hooks_skips_half_marker_left_byte_identical(repo):
+    """A begin marker with no matching end is damage from some previous
+    mishap, not a shape to guess a repair for -- it must be skipped
+    loudly and left completely untouched, not silently grown a second
+    (also broken) block on the next run."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    hook = hooks_dir / "post-commit"
+    original = (
+        "#!/bin/sh\n"
+        "# >>> codegraph (warming only; safe to remove) >>>\n"
+        "echo oops-truncated-mid-block\n"
+    )
+    hook.write_text(original)
+    hook.chmod(hook.stat().st_mode | stat.S_IXUSR)
+
+    written = install_hooks(repo)
+
+    assert hook not in written
+    assert hook.read_text() == original
+
+    results = plan_hooks(repo)
+    result = next(r for r in results if r.name == "post-commit")
+    assert not result.installed
+    assert "malformed" in result.reason.lower()
 
 
 def test_gc_does_not_corrupt_a_live_graph(repo, write):

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -146,3 +146,27 @@ def test_global_statement_with_multiple_names_recorded_separately():
     result = parse_blob(source)
     names = {r.raw_name for r in result.refs if r.ref_kind == "global"}
     assert names == {"A", "B"}
+
+
+def test_module_body_hash_ignores_line_shift():
+    top = parse_blob(b"def alpha():\n    return 1\n")
+    shifted = parse_blob(b"\n\n\ndef alpha():\n    return 1\n")
+    assert top.module_body_hash == shifted.module_body_hash
+
+
+def test_module_body_hash_ignores_nested_body_changes():
+    one = parse_blob(b"def alpha():\n    return 1\n")
+    two = parse_blob(b"def alpha():\n    return 2\n")
+    assert one.module_body_hash == two.module_body_hash
+
+
+def test_module_body_hash_changes_with_top_level_statement():
+    one = parse_blob(b"def alpha():\n    return 1\n")
+    two = parse_blob(b"import requests\n\n\ndef alpha():\n    return 1\n")
+    assert one.module_body_hash != two.module_body_hash
+
+
+def test_module_body_hash_changes_when_def_is_added():
+    one = parse_blob(b"def alpha():\n    return 1\n")
+    two = parse_blob(b"def alpha():\n    return 1\n\n\ndef beta():\n    return 2\n")
+    assert one.module_body_hash != two.module_body_hash


### PR DESCRIPTION
Third of four stacked PRs. Base: `feat/effects` (#8).

The commands a person actually runs.

- **`impact`** — reverse BFS from a node, ranked by hop × confidence × salience,
  with entry points called out. Duplicate `(src, dst)` rows collapse to their
  strongest confidence before the walk, and a path carries its *weakest* link.
- **`diff`** — what changed between two revisions, grouped `added` / `removed` /
  `changed`, compared on body hashes rather than line numbers.
- **`gc`** — evict Layer 2 for revisions you no longer keep. Layer 1 survives.
- **`install-hooks`** — warming only, and never required for correctness (D5),
  which is what licenses it to *refuse* rather than risk damage.

Two fixes here are worth reading on their own:

**`entry_points` gated on `salience >= 0.5`** — a composite score whose own
inputs could cross the threshold without the node being an entry point at all.
Sniffing a composite to recover one of its inputs *is* the defect, so `fan_in()`
is now exposed and the gate is `== 0`.

**Module nodes were excluded from `diff`** to suppress a false positive, which
also suppressed every true positive: new module-only files, deleted ones, and
module-scope `requests.post(...)` all reported nothing. The real bug was that a
module node's `body_hash` was the file's blob SHA — the file's *identity*, not
the module's *body*. Fixed the hash, deleted the filter.

**`install-hooks` will not touch a hook it does not understand.** It writes into
`.git/hooks/` and nowhere else, inserts after the shebang, and skips loudly on
anything not in a shell-interpreter allowlist — an earlier version spliced `sh`
into a `#!/usr/bin/perl` hook and destroyed it. Binary and undecodable hooks are
caught per-hook so one bad file cannot block the whole command.
