### PR TITLE
Cap the bare-name fan-out instead of enumerating it

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "codegraph",
+  "owner": {
+    "name": "swalla02"
+  },
+  "plugins": [
+    {
+      "name": "codegraph",
+      "source": "./",
+      "description": "A sidecar code graph for Python: impact and side-effect analysis via a CLI (resolve, impact, effects, diff).",
+      "version": "0.1.0"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "codegraph",
+  "version": "0.1.0",
+  "description": "A sidecar code graph for Python: impact and side-effect analysis via a CLI (resolve, impact, effects, diff).",
+  "author": {
+    "name": "swalla02"
+  },
+  "homepage": "https://github.com/swalla02/codegraph",
+  "repository": "https://github.com/swalla02/codegraph",
+  "license": "MIT"
+}

--- a/.superpowers/sdd/2026-08-29-codegraph-v1/final-batch-c-report.md
+++ b/.superpowers/sdd/2026-08-29-codegraph-v1/final-batch-c-report.md
@@ -1,0 +1,231 @@
+# Final verification — Batch C report
+
+Single commit on `feat/packaging`, on top of `c8a2976` ("fix: CLI coherence, rendering, and docs
+from whole-branch review"): `fix: evidence must justify reported confidence` (`8861357`).
+
+Files touched: `src/codegraph/query/effects.py`, `src/codegraph/effects/propagate.py`,
+`src/codegraph/effects/builtin.toml`, `tests/test_effects.py`, `tests/test_effect_catalog.py`.
+
+All three findings stem from the one root cause the ledger names: a node can carry multiple
+`direct=1` rows for the same `(node_id, kind)` at different confidences and different lines — no
+`UNIQUE` constraint on `effects` (`store.py:98-105`), and `detect_direct` writes one row per call
+site, so two `open()` calls in one function (one literal-mode, one variable-mode) is ordinary, not
+contrived.
+
+## C1 (HIGH) — `_evidence_location` could print evidence that contradicts the reported confidence
+
+`query/effects.py:71-78` selected the printed location with `ORDER BY evidence_line LIMIT 1` and
+no confidence filter, so the earliest call site printed regardless of whether *its own* confidence
+supported the tier being reported next to it.
+
+Fixed: `_evidence_location` now takes the reported `confidence` as a fourth argument, fetches all
+`direct=1` rows for `(rev, direct_node_id, kind)`, discards any whose own `CONFIDENCE_RANK` is
+below the target, and picks the earliest line among the survivors. Applied uniformly to both call
+shapes — a direct effect on the queried node itself (`cause == node_id`, chain length 1) and the
+terminal node of a propagated witness chain (`cause == chain[-1]`) — since the call site in
+`effects_report` is a single line (`query/effects.py:58`) feeding both.
+
+**Why `>=` and not exact equality**, verified against the existing suite before settling on it: the
+task description says "rows at the reported tier," which reads as exact-match at first glance, but
+that breaks two pre-existing tests that must stay green —
+`test_cycle_confidence_is_the_bottleneck_out_of_the_asking_node` and
+`test_direct_effect_confidence_bounds_the_propagated_confidence` — both of which report a LOW/MEDIUM
+confidence for a node whose direct effect's *own* row is strictly HIGH-er (the propagation
+bottleneck is the `CALLS` edge, not the direct detection). An exact-match filter would find no row
+at all there and print an empty location, regressing the exact "empty location" Critical this
+project already shipped once. `>=` is the correct reading: a row whose own confidence is *at least*
+the reported tier never contradicts it, which is exactly the "supports" language in the finding.
+Ran all four `test_no_effect_row_has_an_empty_witness_or_location` fixtures plus both bottleneck
+tests after the change — all green.
+
+**Verified live** with the exact repro from the finding (`/tmp/c1repro`, indexed and queried
+through the real CLI, not just the unit test):
+
+```
+def load(path, mode, path2):
+    open(path, mode)      # line 2: MEDIUM (open!ambiguous)
+    return open(path2)    # line 3: HIGH (open)
+```
+
+`codegraph effects m.py::load` now prints `FS_READ HIGH via m.py::load` at **`m.py:3`** — the HIGH
+call — instead of the previous `m.py:2` (the MEDIUM, ambiguous call).
+
+**New tests**, both seeding different lines at different confidences (the exact gap B0's
+`test_effects_report_picks_the_strongest_confidence_for_a_repeated_kind` missed, since it seeds
+both duplicate rows at the *same* `evidence_line`):
+
+- `test_evidence_location_picks_a_row_that_supports_the_reported_confidence` — the direct case,
+  hand-seeded schema mirroring the live repro above; asserts `location == "m.py:3"`.
+- `test_evidence_at_the_end_of_a_propagated_witness_chain_justifies_its_tier` — the propagated
+  case the finding explicitly calls out ("make sure this holds for propagated effects too"): `a ->
+  b -> c` over two HIGH edges, `c` carries a MEDIUM row at line 5 and a HIGH row at line 9; asserts
+  the printed location is `m.py:9`, not the earlier MEDIUM line.
+
+## C2 (MED) — `propagate.py:102` overwrote instead of reducing with `stronger()`
+
+`direct_by_node.setdefault(row["node_id"], {})[row["kind"]] = row["confidence"]` kept whichever
+row SQL scan order returned last for a given `(node_id, kind)`, rather than reducing with
+`stronger()` the way `witness_path`'s own `direct_confidence` (propagate.py:180-182) already does.
+
+Fixed to reduce with `stronger()`:
+
+```python
+bucket = direct_by_node.setdefault(row["node_id"], {})
+bucket[row["kind"]] = stronger(bucket.get(row["kind"], row["confidence"]), row["confidence"])
+```
+
+This makes `propagate`'s `direct_by_node` reduction byte-identical in form to `witness_path`'s
+`direct_confidence` reduction — before the fix the two were divergent (last-write-wins vs.
+`stronger()`-max), which is exactly the kind of drift the critical constraint warns about: *the
+graph a confidence is derived from must remain identical to the graph the witness BFS traverses.*
+After the fix both use the same reduction, so they can't drift apart again.
+
+**New test**, proving order-dependence the way the finding asks (`HIGH`-then-`LOW` vs.
+`LOW`-then-`HIGH` on an identical graph):
+`test_propagate_reduces_duplicate_direct_rows_with_stronger_not_scan_order` seeds `callee`'s HIGH
+NETWORK row *before* its LOW row (last-write-wins would have kept LOW, making `callee` ineligible
+at the HIGH tier and silently downgrading `caller`, reached over a HIGH `CALLS` edge, to LOW).
+Asserts `caller`'s report is `NETWORK HIGH via ...`.
+
+**Totality re-verified**: `test_no_effect_row_has_an_empty_witness_or_location` (all four fixture
+shapes) and both C1 regression tests above (which call `propagate()` and then walk the witness
+chain end to end) all pass — the BFS never comes back empty for a triple this fix produces.
+
+## C3 (follow-up) — restore HIGH for the literal `requests` HTTP verbs
+
+Added eight literal builtin rules to `builtin.toml` — `requests.get`, `.post`, `.put`, `.patch`,
+`.delete`, `.head`, `.options`, `.request` — each `kind = "NETWORK"` with no `confidence` override,
+since a pattern with no wildcard already derives HIGH from `Catalog.match_with_confidence`'s own
+specificity rule (`best.prefix_len == pattern_len`). `requests.*` is untouched and stays the MEDIUM
+catch-all for the rest of the namespace (`requests.codes`, `requests.utils.*`, `Session()`).
+
+**Verified longest-literal-prefix-wins actually favors the literal rules, not just assumed it**:
+read `Catalog._best_match` (`catalog.py:126-137`) — it ranks by `(prefix_len, is_override,
+rule.match)` and picks the max, so a literal `requests.get` (`prefix_len = 13`, no wildcard) beats
+`requests.*` (`prefix_len = 9`, up to the `*`) on `prefix_len` alone, `is_override` never entering
+it. Confirmed live via `Catalog.load(Config()).match_with_confidence(...)`:
+
+```
+requests.get      -> ('NETWORK', 'HIGH')
+requests.post      -> ('NETWORK', 'HIGH')
+requests.put/.patch/.delete/.head/.options/.request -> all ('NETWORK', 'HIGH')
+requests.codes      -> ('NETWORK', 'MEDIUM')   # catch-all still applies
+requests.utils.quote -> ('NETWORK', 'MEDIUM')  # catch-all still applies
+httpx.get           -> ('NETWORK', 'MEDIUM')   # left alone, see below
+```
+
+Also re-ran `test_override_beats_builtin_on_longer_prefix` (an override `requests.get -> DB_READ`
+must still beat the new builtin `requests.get -> NETWORK` rule, since both have the same
+`prefix_len` and the tie breaks on `is_override`): passes unchanged, `catalog.match("requests.get")
+== "DB_READ"`.
+
+**One pre-existing test needed a genuine update, not just re-passing**:
+`test_partial_prefix_match_is_medium_confidence` asserted `requests.get` was MEDIUM — now false by
+design, since C3 is exactly "make `requests.get` HIGH again." Changed its `requests` half to
+`requests.codes`, which still exercises the bare-catch-all MEDIUM path (no verb-specific rule
+matches it) without contradicting the fix. `boto3.client` (the other half of that test) is
+untouched.
+
+**New tests** in `test_effect_catalog.py`: a parametrized test asserting all eight verbs are
+`('NETWORK', 'HIGH')`, and `test_requests_verb_literal_beats_requests_namespace_catchall` asserting
+both the verb-wins-over-catch-all precedence and that the catch-all still serves
+`requests.codes`.
+
+**Left alone, with justification** (per the explicit instruction not to go on a catalog-rewriting
+spree): `httpx.*` was not given the same literal-verb treatment. `requests` was singled out by the
+finding as "the most common and least ambiguous network call in Python" and specifically
+worse-labeled *by this branch's own F3 fix* — a regression this batch is undoing, not a new
+improvement. `httpx.*` was never HIGH before F3 (it's always been under the same MEDIUM
+namespace-wildcard rule), so leaving it alone doesn't reintroduce any regression, and extending the
+same treatment to it, `socket.*`, `subprocess.*`, etc. would be a broader precision/recall change
+outside what was asked. `boto3.*` is explicitly still open as deferred finding #1 (S3 reads
+mislabeled as writes) — a different, unrelated problem with that catalog entry — and not
+something this batch's scope covers.
+
+## Gates (run for real)
+
+- `uv run pytest -q` → **212 passed, 3 deselected** (200 baseline + 12 new: 3 in
+  `tests/test_effects.py` — C1 x2, C2 x1 — plus 9 in `tests/test_effect_catalog.py` — the 8
+  parametrized HTTP-verb tests plus the precedence test; the 9th file change,
+  `test_partial_prefix_match_is_medium_confidence`, is a correction to an existing test, not a
+  new one).
+- `uv run pytest -m slow -s` → **3 passed**. Precision/recall observed: **precision=1.00,
+  recall=0.90** — unchanged from the pre-C3 baseline recorded in the ledger. This makes sense:
+  the accuracy fixture (`tests/fixtures/labelled_calls.json`) grades `CALLS`-edge resolution, and
+  C3 only changes effect-*confidence* tiering for a catalog pattern, never which calls resolve to
+  which node. Did not touch the fixture or the floors; reporting the real number as instructed.
+- `uv run ruff check .` → **All checks passed!** (repo-wide, no new suppressions needed).
+- `skills/codegraph/SKILL.md` re-checked line by line against the "Reading the output" section:
+  its existing claim ("`location` is that call site's `file:line`, clickable evidence rather than
+  a claim you have to trust") was already accurate prose — C1's fix makes that claim *true* in the
+  duplicate-row case it previously wasn't; no wording changed since nothing false is now being
+  asserted. No mention of `requests` or HTTP verbs anywhere in the file, so C3 needed no doc
+  update either. Confirmed via `grep`, not by assumption.
+
+## Found but left alone (in scope for triage, not for this batch)
+
+- `httpx.*`, `socket.*`, `boto3.*`, and every other namespace-wildcard catalog entry — see C3's
+  "left alone" note above; extending literal-verb treatment to them would be new scope, not part
+  of restoring `requests`'s pre-F3 detection.
+- `catalog.py`'s module docstring (lines 9-13) illustrates precedence with an example that reads
+  "`requests.get` (override, fully literal) beats `requests.*` (built-in...)" — still a correct,
+  general illustration of the precedence mechanism, just no longer the only way `requests.get`
+  could exist as a literal rule now that it's also a builtin. Left as-is: it's not inaccurate, and
+  rewording it is cosmetic, outside this batch's three findings.
+- Everything already filed for post-merge in the ledger (deferred findings, F8, F13, F16) is
+  untouched — none of it intersects the `effects`/`propagate`/catalog code this batch touched.
+
+---
+
+## Follow-up — flaky perf smoke test in `tests/test_perf.py`
+
+`test_branch_switch_is_under_a_second` was reported flaky: 1 failure in 3 isolated local runs, and
+a verification agent hit it failing twice at 1.20s and 1.28s against its `elapsed < 1.0` threshold.
+No recent commit touches the indexer path this test exercises, so this reads as scheduler/IO noise
+on a shared sandbox, not a regression — the same branch-switch code path is exercised deterministically
+by `stats.blobs_parsed == 0`, which never failed.
+
+**What the test protects, and what I changed.** The test carries two assertions with very
+different jobs:
+
+- `assert stats.blobs_parsed == 0` — the project's load-bearing cost guarantee: creating a branch
+  must re-parse nothing. Deterministic, the real content of the test. **Left untouched.**
+- `assert elapsed < 1.0` — a wall-clock smoke check meant to catch an order-of-magnitude
+  regression (e.g. branch switch accidentally becoming O(repo size) again), not to referee a
+  ~280ms scheduling hiccup on a shared box.
+
+I raised the wall-clock bound from `1.0` to `3.0` seconds and added a comment stating explicitly
+that it is an order-of-magnitude guard, not a performance target, so it doesn't get tightened back
+down by someone chasing a benchmark number later. `blobs_parsed == 0` is exactly as strict as
+before — I am not loosening the guarantee, I am stopping wall-clock noise from being mistaken for
+it.
+
+**Rename.** `test_branch_switch_is_under_a_second` no longer described the bound after raising it
+to 3.0s, so I renamed it to `test_branch_switch_reparses_nothing` — which also better names what
+the test actually verifies (the `blobs_parsed == 0` guarantee is the point; the timing is a
+backstop). Checked for other references to the old name: only the test file itself and
+`docs/superpowers/plans/2026-08-29-codegraph-v1.md` (a historical planning doc recording the
+original plan snippet, not code) mention it. Left the plan doc alone — it's a record of what was
+planned, not a live reference, and out of scope for this fix.
+
+**`test_cold_index_and_warm_query_are_fast`** — checked for the same fragility
+(`cold < 60.0`, `warm < 0.3`) per instructions, but only to act if there was real evidence. Ran it
+7 times in isolation: **7/7 passed** (9.68s-12.62s cold time, well under 60s each run; no warm-query
+failures at any run). No evidence of flakiness, so per the "only if you find real evidence"
+instruction, I left both bounds in that test unchanged.
+
+### Gates
+
+- `uv run pytest -q` → **212 passed, 3 deselected** (matches expected).
+- `uv run pytest -m slow -q`, run **five times**, full results:
+  1. `3 passed, 212 deselected in 28.42s`
+  2. `3 passed, 212 deselected in 23.01s`
+  3. `3 passed, 212 deselected in 26.58s`
+  4. `3 passed, 212 deselected in 26.23s`
+  5. `3 passed, 212 deselected in 21.58s`
+
+  All five green, no flakiness observed after the fix.
+- `uv run ruff check .` → **All checks passed!**
+
+Single commit: `test: stop wall-clock noise from failing the cost-guarantee test`. Not pushed, no
+PR opened, per instructions.

--- a/README.md
+++ b/README.md
@@ -16,18 +16,154 @@ Composed, they give the answer you actually want before a change: not "47 things
 call this," which is anxiety rather than information, but *"47 things call this,
 and 3 of the paths end in a database write."*
 
-It follows git. The parse cache is content-addressed by blob SHA, so a file's
-content is analysed once for the life of the repository and shared across every
-branch. Creating a branch costs nothing; switching to one you've seen re-parses
-nothing. After the first index, work is proportional to the diff, never to
-repository size.
+It follows git. The parse cache is content-addressed by git blob SHA, so a
+file's content is analysed once for the life of the repository and shared
+across every branch: creating a branch changes no blobs, so it costs zero
+parsing, and switching to a branch whose blobs have already been seen also
+costs zero parsing — this half of the cost guarantee is measured, not just
+claimed (see "The cost guarantee, honestly" below).
 
 That also makes `codegraph diff` possible — the semantic delta of a branch:
-which symbols and edges changed, and which side effects newly became reachable.
+which symbols and edges changed, and which side effects newly became
+reachable.
 
-Built agent-first: a CLI and an MCP server, installable as a Claude Code plugin
-(`/plugin marketplace add swalla02/codegraph`), with a schema a visual
-navigator can project from later.
+Built agent-first: a CLI, installable as a Claude Code plugin
+(`/plugin marketplace add swalla02/codegraph`), driven through `SKILL.md`
+rather than an MCP server (see "Why no MCP server" below), with a schema a
+visual navigator can project from later.
 
-**Status:** pre-implementation. See
-[the design spec](docs/superpowers/specs/2026-08-29-codegraph-design.md).
+**Status:** implemented and in use. See
+[the design spec](docs/superpowers/specs/2026-08-29-codegraph-design.md) for
+the full rationale behind every decision below.
+
+## Install
+
+Requires Python 3.12+.
+
+```sh
+pip install /path/to/codegraph   # or: uv pip install /path/to/codegraph
+```
+
+This installs the `codegraph` console script (`pyproject.toml`'s
+`[project.scripts]` entry point). Not yet published to PyPI — install from a
+checkout or a git URL until it is.
+
+### As a Claude Code plugin
+
+```
+/plugin marketplace add swalla02/codegraph
+```
+
+The repository doubles as its own marketplace (`.claude-plugin/
+marketplace.json` and `plugin.json`), so this one command both registers and
+installs it. It adds `skills/codegraph/SKILL.md`, which teaches an agent when
+and how to invoke the CLI — no server process, no MCP tool definitions
+occupying context on every turn. You still need the `codegraph` console
+script on `PATH` (install it as above); the plugin does not bundle a Python
+runtime.
+
+## Commands
+
+Every command reconciles the requested revision before answering (see "Lazy
+refresh on query" below), so results are never stale, only occasionally
+slower on a cold cache.
+
+| Command | What it does |
+|---|---|
+| `codegraph status [--rev REV]` | Reconcile a revision and print summary counts: paths, blobs parsed/cached, edges, unresolved refs, parse errors. |
+| `codegraph index [--rev REV] [--rebuild] [--quiet]` | Reconcile a revision into the graph explicitly, paying the cold-build cost up front. `--rebuild` discards the Layer 1 parse cache first; `--quiet` is what the warming hooks invoke in the background. |
+| `codegraph resolve <name>` | Fuzzy-match a name (trailing name, qualname, or full node id) to node ids. |
+| `codegraph effects <symbol> [--json]` | Report every side-effect kind reachable from a symbol, each with a witness chain down to the causing `file:line`. |
+| `codegraph impact <symbol> [--hops N] [--limit N] [--all] [--json]` | Report the ranked dependents of a symbol — everything a change to it could break. |
+| `codegraph diff [<base>..<head>] [--json]` | Report what changed between two revisions by content hash, never by line number: symbols added/removed/changed, plus any side effect newly reachable. Defaults to `merge-base(default branch, HEAD)..WORKTREE` — "what has this branch changed so far." |
+| `codegraph gc [--keep REV]` | Prune the Layer 1 parse cache down to what `HEAD`, the worktree, and any `--keep`-named revisions still reference. Never touches the graph itself, so it can only make a future answer slower to rebuild, never wrong. |
+| `codegraph install-hooks` | Install `post-commit`/`post-checkout`/`post-merge` git hooks that warm the cache in the background. Purely an optimization — every query reconciles the working tree itself regardless (see below), so results are identical whether or not a hook ever fires. |
+
+`resolve`, `impact`, and `effects` share one exit-code convention for
+resolving `<symbol>` to a node id: `0` = a single unambiguous match, `1` =
+nothing matched, `2` = more than one match (every candidate is printed; pick
+the right one and re-run with the full node id).
+
+All commands accept `--path <dir>` to run against a different repository
+root (default: the current directory).
+
+## `codegraph.toml`
+
+The built-in effect catalog (stdlib, `requests`/`httpx`, SQLAlchemy, psycopg,
+boto3, ...) only knows public library calls. Most side effects in a real
+codebase sit behind house abstractions instead — a `Repo.save()`, an internal
+`db` module — so a project-level `codegraph.toml` at the repository root lets
+you extend the catalog to reach them:
+
+```toml
+source_roots = ["", "src"]
+
+[[effect]]
+match = "app.db.*"
+kind = "DB_WRITE"
+```
+
+`source_roots` controls how a file path is turned into a Python module name
+for import resolution (`src/pay/service.py` -> `pay.service` when `"src"` is
+a root). `[[effect]]` entries merge over the built-in catalog by pattern;
+`match` is a dotted-name glob (`*` wildcards allowed) and `kind` is one of
+the nine effect kinds (`DB_WRITE`, `DB_READ`, `NETWORK`, `PROCESS`,
+`FS_WRITE`, `FS_READ`, `ENV_READ`, `GLOBAL_MUTATE`, `NONDETERMINISM`).
+
+It lives at the repository root, not inside `.codegraph/`, because it is
+hand-written configuration meant to be committed and shared, whereas
+`.codegraph/` self-ignores and holds only derived cache: config is tracked,
+everything derived is disposable.
+
+## Lazy refresh on query
+
+Every query reconciles the working tree first, then answers — the `git
+status` model, not an explicit-index-only model where a stale index silently
+lies. No daemon, no required hooks; `codegraph index` exists only to pay the
+cold-build cost up front rather than on the first real query, and
+`install-hooks` exists only to move that cost into the background after a
+commit/checkout/merge. If a hook never fires and `index` is never run by
+hand, every answer is still correct — merely slower on that one query.
+
+## The cost guarantee, honestly
+
+The design's core promise is "after the first index, work is proportional to
+the diff, never to repository size." That promise has two halves, and they
+are not in the same place:
+
+- **Parse (Layer 1) — real, and measured.** The parse cache is keyed on git
+  blob SHA, not `(path, mtime)`, so identical content is parsed once for the
+  life of the repository regardless of how many branches or paths reference
+  it. Verified directly against a scratch repo: creating a branch parses 0
+  blobs, switching `A -> B -> A` re-parses 0 blobs on the return trip, and
+  results do not depend on file mtimes across checkouts (which `git
+  checkout` rewrites indiscriminately and an mtime-keyed cache would have
+  re-parsed on every switch).
+- **Resolve (Layer 2) — not yet proportional.** `resolve_revision` currently
+  re-resolves the *entire* symbol table for a revision on every reconcile,
+  rather than the design's intended `D ∪ dependents(D)` incremental
+  invalidation (`resolve.dependents` exists and is tested, but has no
+  production caller yet). For a small-to-medium repository this is fast
+  enough not to notice; for a large one, the resolve step — not the parse
+  step — is where reconcile time will scale with repository size today, not
+  with the size of your diff. Tracked as follow-up work; this README will
+  stop calling this out honestly the day it's fixed, not before.
+
+## Why no MCP server
+
+MCP's main advantage is discoverability — the agent sees the tool without
+being told. `SKILL.md` already provides that, and it only loads into context
+when relevant, whereas MCP tool definitions occupy context on every request
+whether used or not. A CLI also works in any harness, composes with `jq` and
+shell pipelines, and needs no server process. MCP is an explicit non-goal for
+this version; it could become an additive wrapper later for harnesses without
+shell access, but nothing here requires it.
+
+## The anti-pattern this displaces
+
+Do not grep for callers. Grep misses dynamically dispatched calls (anything
+reached through a method resolution order, an attribute, or an alias) and
+gives you no way to know when you are done — there is no signal that you have
+found the last caller versus just the last one grep's pattern happened to
+match. `codegraph impact` walks the actual call graph and reports both the
+full set and how confident it is in each edge.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,24 @@ a root). `[[effect]]` entries merge over the built-in catalog by pattern;
 the nine effect kinds (`DB_WRITE`, `DB_READ`, `NETWORK`, `PROCESS`,
 `FS_WRITE`, `FS_READ`, `ENV_READ`, `GLOBAL_MUTATE`, `NONDETERMINISM`).
 
+`ambiguity_limit` (default `25`, `0` to disable) bounds the last-resort
+resolution step. When a call like `item.save()` names nothing importable,
+nothing module-local, and nothing reachable through `self`, the resolver
+falls back to matching `save` against every definition in the repository.
+On a small codebase that is a handful of candidates and a useful
+over-approximation. On django it was 971 for a single call site, and 96.6%
+of the whole graph was that kind of guess — the edge table grew with the
+*square* of the repository. Past this many equally-weak candidates the call
+is recorded once as ambiguous, with the name and the count, instead of as N
+edges. Nothing is discarded to improve precision: the N edges and the one
+record make the same claim, and a `HIGH` or `MEDIUM` hit — one the resolver
+actually distinguished — is never collapsed. Raise it if you want the full
+cross product back.
+
+```toml
+ambiguity_limit = 25
+```
+
 It lives at the repository root, not inside `.codegraph/`, because it is
 hand-written configuration meant to be committed and shared, whereas
 `.codegraph/` self-ignores and holds only derived cache: config is tracked,
@@ -143,11 +161,14 @@ are not in the same place:
   re-resolves the *entire* symbol table for a revision on every reconcile,
   rather than the design's intended `D ∪ dependents(D)` incremental
   invalidation (`resolve.dependents` exists and is tested, but has no
-  production caller yet). For a small-to-medium repository this is fast
-  enough not to notice; for a large one, the resolve step — not the parse
-  step — is where reconcile time will scale with repository size today, not
-  with the size of your diff. Tracked as follow-up work; this README will
-  stop calling this out honestly the day it's fixed, not before.
+  production caller yet). Measured, one-file edit, steady state: flask (83
+  files) reconciles in 0.36s, django (2,930 files) in **22s** — of which one
+  blob is parsed and everything else is the whole revision being rebuilt.
+  django's *cold* index is 65s, so at that size an incremental edit costs a
+  third of a full re-index rather than nothing. The resolve step, not the
+  parse step, is where reconcile time scales with repository size today.
+  Tracked as follow-up work; this README will stop calling this out honestly
+  the day it's fixed, not before.
 
 ## Why no MCP server
 

--- a/skills/codegraph/SKILL.md
+++ b/skills/codegraph/SKILL.md
@@ -28,11 +28,16 @@ Reach for this skill:
    ```
 
    `<name>` can be a trailing name (`open_workspace`), a qualname
-   (`cli.py::open_workspace`), or a full node id. Exit code tells you what
-   happened: `0` and one line of output means a single unambiguous match
-   (the node id, e.g. `src/codegraph/cli.py::open_workspace`); `2` means
-   more than one symbol matched and every match is printed — pick the right
-   one and re-run with the full id; `1` means nothing matched.
+   (`cli.py::open_workspace`), or a full node id.
+
+   All three symbol-taking commands — `resolve`, `impact`, and `effects` —
+   share the same exit-code convention for resolving that name/id to a
+   symbol: `0` means a single unambiguous match (the node id is printed,
+   e.g. `src/codegraph/cli.py::open_workspace`, and for `impact`/`effects`
+   the report follows); `1` means nothing matched (a message on stderr);
+   `2` means more than one symbol matched, and every match is printed
+   (`resolve` to stdout, `impact`/`effects` to stderr) — pick the right one
+   and re-run with the full id.
 
 2. Ask what depends on it and what it can reach:
 
@@ -72,10 +77,16 @@ the full set and how confident it is in each edge.
 
 ## Reading the output
 
-- `impact`'s summary line (`symbols · modules · entry_points ·
-  low_confidence_hidden · effects_reachable`) counts `LOW`-confidence
-  dependents in `low_confidence_hidden` but hides them from the `dependents`
-  and `tests` groups by default — the resolver's least certain guesses are
+- `impact`'s summary has five fields, in order: `symbols`, `modules`,
+  `entry_points`, and `low_confidence_hidden` are all integer counts;
+  `effects_reachable` is a **list of effect-kind strings**, not a count —
+  e.g. `["DB_WRITE", "PROCESS"]`, or `[]` when the symbol reaches nothing.
+  In `--json` output it is a real JSON array; in the default text output
+  the summary line joins all five fields with ` · `, so
+  `effects_reachable` shows up as Python's list repr, e.g.
+  `6 · 1 · 6 · 0 · ['DB_WRITE', 'PROCESS']`. `low_confidence_hidden` counts
+  `LOW`-confidence dependents that are held back from the `dependents` and
+  `tests` groups by default — the resolver's least certain guesses are
   real information, but they should not read as confirmed impact. Pass
   `--all` to include them in the listed rows.
 - Rows under a `tests` group are dependents whose path is under `tests/` or

--- a/skills/codegraph/SKILL.md
+++ b/skills/codegraph/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: codegraph
+description: Use when about to modify a Python function or class, or when asked "what breaks if I change this", "what does this affect", "is this safe to change", or "what did this branch change" — answers with a ranked, git-native call graph instead of a grep.
+---
+
+# codegraph
+
+`codegraph` is a sidecar index over a Python codebase (content-addressed by
+git blob SHA, so it never touches how the code is written). It answers two
+questions grep structurally cannot: who transitively depends on a symbol,
+ranked, and which of those paths reach a side effect (database write,
+network call, filesystem write, global mutation, ...).
+
+## Trigger
+
+Reach for this skill:
+
+- Before modifying any function or class.
+- When asked "what breaks if I change this", "what does this affect", "is
+  this safe to change", or "what did this branch change".
+
+## Workflow
+
+1. Resolve the symbol to a node id:
+
+   ```
+   codegraph resolve <name>
+   ```
+
+   `<name>` can be a trailing name (`open_workspace`), a qualname
+   (`cli.py::open_workspace`), or a full node id. Exit code tells you what
+   happened: `0` and one line of output means a single unambiguous match
+   (the node id, e.g. `src/codegraph/cli.py::open_workspace`); `2` means
+   more than one symbol matched and every match is printed — pick the right
+   one and re-run with the full id; `1` means nothing matched.
+
+2. Ask what depends on it and what it can reach:
+
+   ```
+   codegraph impact <id>
+   codegraph effects <id>
+   ```
+
+   `impact` walks callers (and callers of callers, up to `--hops`, default
+   3) and ranks them. `effects` reports every side-effect kind reachable
+   downstream of the symbol, each with a witness chain down to the exact
+   `file:line` that causes it.
+
+3. Read only the top-ranked hits, not the whole list — rows are sorted by
+   score (`impact`) or severity (`effects`), most important first, and long
+   result sets are truncated with a `truncated` flag rather than dumped in
+   full.
+
+`codegraph diff [<base>..<head>]` reports what a branch actually changed —
+symbols added/removed/changed by content hash (never by line number) plus
+any side effect that newly became reachable. With no argument it diffs
+`merge-base(default branch, HEAD)` against the worktree, which is what you
+want when asked "what did this branch change".
+
+All of `resolve`, `impact`, `effects`, and `diff` accept `--path <dir>` to
+run against a different repository root, and `impact`/`effects`/`diff` accept
+`--json` for machine-readable output instead of the default text.
+
+## The anti-pattern this displaces
+
+Do not grep for callers. Grep misses dynamically dispatched calls (anything
+reached through a method resolution order, an attribute, or an alias) and
+gives you no way to know when you are done — there is no signal that you
+have found the last caller versus just the last one grep's pattern happened
+to match. `codegraph impact` walks the actual call graph and tells you both
+the full set and how confident it is in each edge.
+
+## Reading the output
+
+- `impact`'s summary line (`symbols · modules · entry_points ·
+  low_confidence_hidden · effects_reachable`) counts `LOW`-confidence
+  dependents in `low_confidence_hidden` but hides them from the `dependents`
+  and `tests` groups by default — the resolver's least certain guesses are
+  real information, but they should not read as confirmed impact. Pass
+  `--all` to include them in the listed rows.
+- Rows under a `tests` group are dependents whose path is under `tests/` or
+  whose name starts with `test_`. They are bucketed separately from
+  `dependents` on purpose: a change breaking a test is worth knowing, but
+  tests should never crowd production callers out of the ranked list.
+- Each `impact` row's `detail` column reads `hop N, <CONFIDENCE> confidence`
+  — `HIGH`/`MEDIUM`/`LOW` reflects how certain the resolver is that the call
+  really targets this symbol (e.g. a dynamic dispatch site is weaker
+  evidence than a direct, unambiguous call).
+- Each `effects` row's `detail` reads `<KIND> <CONFIDENCE> via <chain>` —
+  the chain is the call path from the queried symbol down to the concrete
+  call site; `location` is that call site's `file:line`, clickable evidence
+  rather than a claim you have to trust.

--- a/skills/codegraph/SKILL.md
+++ b/skills/codegraph/SKILL.md
@@ -77,18 +77,29 @@ the full set and how confident it is in each edge.
 
 ## Reading the output
 
-- `impact`'s summary has five fields, in order: `symbols`, `modules`,
-  `entry_points`, and `low_confidence_hidden` are all integer counts;
+- Every report's default text output leads with a summary line of
+  `key: value` pairs joined by ` · `, one per summary field, in the order
+  the producer defines them — e.g. `impact`'s reads `symbols: 6 ·
+  modules: 1 · entry_points: 6 · low_confidence_hidden: 0 ·
+  effects_reachable: DB_WRITE, PROCESS`. `symbols`, `modules`,
+  `entry_points`, and `low_confidence_hidden` are integer counts;
   `effects_reachable` is a **list of effect-kind strings**, not a count —
-  e.g. `["DB_WRITE", "PROCESS"]`, or `[]` when the symbol reaches nothing.
-  In `--json` output it is a real JSON array; in the default text output
-  the summary line joins all five fields with ` · `, so
-  `effects_reachable` shows up as Python's list repr, e.g.
-  `6 · 1 · 6 · 0 · ['DB_WRITE', 'PROCESS']`. `low_confidence_hidden` counts
-  `LOW`-confidence dependents that are held back from the `dependents` and
-  `tests` groups by default — the resolver's least certain guesses are
-  real information, but they should not read as confirmed impact. Pass
-  `--all` to include them in the listed rows.
+  in `--json` output it is a real JSON array; in text it is rendered as a
+  comma-separated list (`DB_WRITE, PROCESS`), or `none` when the symbol
+  reaches nothing, never Python's list repr. `low_confidence_hidden`
+  counts `LOW`-confidence dependents that are held back from the
+  `dependents` and `tests` groups by default — the resolver's least
+  certain guesses are real information, but they should not read as
+  confirmed impact. Pass `--all` to include them in the listed rows.
+- `impact --limit N` caps the *total* rows kept across `dependents` and
+  `tests` combined at `N` (default 40) — not `N` each — so the printed
+  report never exceeds its documented budget.
+- `diff`'s summary reads `new_effects: <kind list or none> ·
+  added: N · removed: N · changed: N · base: <sha> · head: <rev>`.
+  `new_effects` covers every symbol newly reachable at `head`, whether it
+  is itself new (`added`) or pre-existing and edited (`changed`) — an
+  effect reachable only through a brand-new function is not invisible
+  just because the function has no `base` counterpart to diff against.
 - Rows under a `tests` group are dependents whose path is under `tests/` or
   whose name starts with `test_`. They are bucketed separately from
   `dependents` on purpose: a change breaking a test is worth knowing, but

--- a/src/codegraph/cli.py
+++ b/src/codegraph/cli.py
@@ -30,6 +30,8 @@ def _print_stats(stats) -> None:
     print(f"paths: {stats.paths_total} ({stats.paths_dirty} dirty)")
     print(f"blobs: {stats.blobs_parsed} parsed, {stats.blobs_cached} cached")
     print(f"edges: {stats.edges}, unresolved: {stats.unresolved}")
+    if stats.ambiguous:
+        print(f"ambiguous: {stats.ambiguous} reference(s) matched too many names to enumerate")
     if stats.parse_errors:
         print(f"parse errors: {stats.parse_errors}")
     if stats.shadowed:

--- a/src/codegraph/cli.py
+++ b/src/codegraph/cli.py
@@ -40,7 +40,12 @@ def _cmd_status(args: argparse.Namespace) -> int:
     root = Path(args.path).resolve()
     store, indexer = open_workspace(root)
     try:
-        _print_stats(indexer.reconcile(args.rev))
+        try:
+            stats = indexer.reconcile(args.rev)
+        except gitio.GitError:
+            print(f"revision not found: {args.rev}", file=sys.stderr)
+            return 1
+        _print_stats(stats)
     finally:
         store.close()
     return 0
@@ -53,7 +58,11 @@ def _cmd_index(args: argparse.Namespace) -> int:
         if args.rebuild:
             store.connection.execute("DELETE FROM blobs")
             store.connection.commit()
-        stats = indexer.reconcile(args.rev)
+        try:
+            stats = indexer.reconcile(args.rev)
+        except gitio.GitError:
+            print(f"revision not found: {args.rev}", file=sys.stderr)
+            return 1
         if args.quiet:
             # --quiet suppresses the stats chatter (this is what the
             # warming hooks invoke in the background), but a parse failure
@@ -72,7 +81,11 @@ def _cmd_resolve(args: argparse.Namespace) -> int:
     root = Path(args.path).resolve()
     store, indexer = open_workspace(root)
     try:
-        indexer.reconcile(args.rev)
+        try:
+            indexer.reconcile(args.rev)
+        except gitio.GitError:
+            print(f"revision not found: {args.rev}", file=sys.stderr)
+            return 1
         matches = find_symbol(store, args.rev, args.query)
         for row in matches:
             print(row["id"])
@@ -89,7 +102,11 @@ def _cmd_effects(args: argparse.Namespace) -> int:
     root = Path(args.path).resolve()
     store, indexer = open_workspace(root)
     try:
-        indexer.reconcile(args.rev)
+        try:
+            indexer.reconcile(args.rev)
+        except gitio.GitError:
+            print(f"revision not found: {args.rev}", file=sys.stderr)
+            return 1
         matches = find_symbol(store, args.rev, args.symbol)
         if not matches:
             print(f"no symbol matching {args.symbol!r}", file=sys.stderr)
@@ -112,7 +129,20 @@ def _cmd_impact(args: argparse.Namespace) -> int:
     root = Path(args.path).resolve()
     store, indexer = open_workspace(root)
     try:
-        indexer.reconcile(args.rev)
+        if args.hops < 1:
+            # `--hops 0` (or negative) is not "walk zero hops"; the reverse
+            # BFS never runs and the report comes back with an empty
+            # `dependents` group at exit 0 -- reading exactly as "nothing
+            # depends on this," the confidently-wrong answer the design doc
+            # says is worse than no tool at all. Reject it loudly instead
+            # of returning a report that looks like a real, checked answer.
+            print(f"--hops must be >= 1 (got {args.hops})", file=sys.stderr)
+            return 1
+        try:
+            indexer.reconcile(args.rev)
+        except gitio.GitError:
+            print(f"revision not found: {args.rev}", file=sys.stderr)
+            return 1
         matches = find_symbol(store, args.rev, args.symbol)
         if not matches:
             print(f"no symbol matching {args.symbol!r}", file=sys.stderr)
@@ -127,6 +157,7 @@ def _cmd_impact(args: argparse.Namespace) -> int:
             args.rev,
             matches[0]["id"],
             max_hops=args.hops,
+            limit=args.limit,
             include_low=args.all,
         )
         print(render_json(report) if args.json else render_text(report))
@@ -205,7 +236,12 @@ def _cmd_install_hooks(args: argparse.Namespace) -> int:
     same trust failure as the corruption it avoids.
     """
     root = Path(args.path).resolve()
-    for result in plan_hooks(root):
+    try:
+        results = plan_hooks(root)
+    except FileNotFoundError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    for result in results:
         if result.installed:
             print(result.path)
         else:
@@ -262,6 +298,12 @@ def build_parser() -> argparse.ArgumentParser:
     impact_parser.add_argument(
         "--all", action="store_true", help="Include LOW-confidence dependents"
     )
+    impact_parser.add_argument(
+        "--limit",
+        type=int,
+        default=40,
+        help="Maximum rows to keep, total across dependents and tests (default: 40)",
+    )
     impact_parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
     impact_parser.set_defaults(handler=_cmd_impact)
 
@@ -309,7 +351,17 @@ def main(argv: list[str] | None = None) -> int:
     if args.handler is None:
         parser.print_help()
         return 0
-    return args.handler(args)
+    try:
+        return args.handler(args)
+    except Exception as exc:  # noqa: BLE001 -- last-resort net, see comment below
+        # Every command that can fail on user input (a bad --rev, a
+        # non-git --path for install-hooks, ...) already has its own
+        # targeted handler above, printing a clear one-line message. This
+        # is the net underneath those: any exception a handler did not
+        # anticipate still gets a one-line stderr message and a nonzero
+        # exit here, never a raw traceback dumped at the user.
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
 
 
 def run() -> None:

--- a/src/codegraph/cli.py
+++ b/src/codegraph/cli.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from codegraph import __version__, gitio
 from codegraph.indexer import FsTreeSource, GitTreeSource, Indexer
-from codegraph.maintenance import gc, install_hooks
+from codegraph.maintenance import gc, plan_hooks
 from codegraph.query.diff import MissingRevisionError, diff_report
 from codegraph.query.effects import effects_report
 from codegraph.query.impact import impact_report
@@ -199,10 +199,17 @@ def _cmd_install_hooks(args: argparse.Namespace) -> int:
     """Install post-commit/post-checkout/post-merge hooks that warm the
     cache in the background. Purely an optimization -- see D5: every query
     reconciles the working tree itself, so results are identical whether or
-    not these ever fire."""
+    not these ever fire. A hook whose pre-existing script isn't
+    shell-compatible is skipped rather than corrupted -- reported by name
+    and reason on stderr, never silently, since a silent skip would be the
+    same trust failure as the corruption it avoids.
+    """
     root = Path(args.path).resolve()
-    for path in install_hooks(root):
-        print(path)
+    for result in plan_hooks(root):
+        if result.installed:
+            print(result.path)
+        else:
+            print(f"skipped {result.name}: {result.reason}", file=sys.stderr)
     return 0
 
 

--- a/src/codegraph/cli.py
+++ b/src/codegraph/cli.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 from codegraph import __version__, gitio
 from codegraph.indexer import FsTreeSource, GitTreeSource, Indexer
+from codegraph.query.effects import effects_report
+from codegraph.render import render_json, render_text
 from codegraph.resolve import find_symbol
 from codegraph.store import WORKTREE, Store
 
@@ -71,6 +73,28 @@ def _cmd_resolve(args: argparse.Namespace) -> int:
         store.close()
 
 
+def _cmd_effects(args: argparse.Namespace) -> int:
+    """Report the side effects transitively reachable from a symbol."""
+    root = Path(args.path).resolve()
+    store, indexer = open_workspace(root)
+    try:
+        indexer.reconcile(args.rev)
+        matches = find_symbol(store, args.rev, args.symbol)
+        if not matches:
+            print(f"no symbol matching {args.symbol!r}", file=sys.stderr)
+            return 1
+        if len(matches) > 1:
+            print(f"ambiguous symbol {args.symbol!r}:", file=sys.stderr)
+            for row in matches:
+                print(f"  {row['id']}", file=sys.stderr)
+            return 2
+        report = effects_report(store, args.rev, matches[0]["id"])
+        print(render_json(report) if args.json else render_text(report))
+        return 0
+    finally:
+        store.close()
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="codegraph")
     parser.add_argument("--version", action="version", version=__version__)
@@ -97,6 +121,15 @@ def build_parser() -> argparse.ArgumentParser:
     resolve_parser.add_argument("--path", default=".", help="Repository root (default: cwd)")
     resolve_parser.add_argument("--rev", default=WORKTREE, help="Revision to resolve against")
     resolve_parser.set_defaults(handler=_cmd_resolve)
+
+    effects_parser = subparsers.add_parser(
+        "effects", help="Report side effects reachable from a symbol"
+    )
+    effects_parser.add_argument("symbol", help="Node id, qualname, or trailing name")
+    effects_parser.add_argument("--path", default=".", help="Repository root (default: cwd)")
+    effects_parser.add_argument("--rev", default=WORKTREE, help="Revision to query")
+    effects_parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    effects_parser.set_defaults(handler=_cmd_effects)
 
     return parser
 

--- a/src/codegraph/cli.py
+++ b/src/codegraph/cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from codegraph import __version__, gitio
 from codegraph.indexer import FsTreeSource, GitTreeSource, Indexer
+from codegraph.maintenance import gc, install_hooks
 from codegraph.query.diff import MissingRevisionError, diff_report
 from codegraph.query.effects import effects_report
 from codegraph.query.impact import impact_report
@@ -52,7 +53,9 @@ def _cmd_index(args: argparse.Namespace) -> int:
         if args.rebuild:
             store.connection.execute("DELETE FROM blobs")
             store.connection.commit()
-        _print_stats(indexer.reconcile(args.rev))
+        stats = indexer.reconcile(args.rev)
+        if not args.quiet:
+            _print_stats(stats)
     finally:
         store.close()
     return 0
@@ -170,6 +173,33 @@ def _cmd_diff(args: argparse.Namespace) -> int:
         store.close()
 
 
+def _cmd_gc(args: argparse.Namespace) -> int:
+    """Prune Layer 1 (the blob parse cache) down to what HEAD, the worktree,
+    and any `--keep`-named revisions still reference. Never touches Layer 2,
+    so this can never make an existing answer stale -- only slower to
+    rebuild for an evicted revision."""
+    root = Path(args.path).resolve()
+    store = Store.open(root)
+    try:
+        keep_revs = {"HEAD", WORKTREE, *args.keep}
+        removed = gc(store, keep_revs)
+        print(f"gc: removed {removed} blob(s) unreferenced by {', '.join(sorted(keep_revs))}")
+    finally:
+        store.close()
+    return 0
+
+
+def _cmd_install_hooks(args: argparse.Namespace) -> int:
+    """Install post-commit/post-checkout/post-merge hooks that warm the
+    cache in the background. Purely an optimization -- see D5: every query
+    reconciles the working tree itself, so results are identical whether or
+    not these ever fire."""
+    root = Path(args.path).resolve()
+    for path in install_hooks(root):
+        print(path)
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="codegraph")
     parser.add_argument("--version", action="version", version=__version__)
@@ -188,6 +218,9 @@ def build_parser() -> argparse.ArgumentParser:
         "--rebuild",
         action="store_true",
         help="Discard the Layer 1 parse cache before reconciling",
+    )
+    index_parser.add_argument(
+        "--quiet", action="store_true", help="Suppress stats output (used by warming hooks)"
     )
     index_parser.set_defaults(handler=_cmd_index)
 
@@ -231,6 +264,25 @@ def build_parser() -> argparse.ArgumentParser:
     diff_parser.add_argument("--path", default=".", help="Repository root (default: cwd)")
     diff_parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
     diff_parser.set_defaults(handler=_cmd_diff)
+
+    gc_parser = subparsers.add_parser(
+        "gc", help="Prune Layer 1 cache entries unreachable from retained revisions"
+    )
+    gc_parser.add_argument("--path", default=".", help="Repository root (default: cwd)")
+    gc_parser.add_argument(
+        "--keep",
+        action="append",
+        default=[],
+        metavar="REV",
+        help="Additional revision to retain besides HEAD and the worktree (repeatable)",
+    )
+    gc_parser.set_defaults(handler=_cmd_gc)
+
+    hooks_parser = subparsers.add_parser(
+        "install-hooks", help="Install git hooks that warm the cache in the background"
+    )
+    hooks_parser.add_argument("--path", default=".", help="Repository root (default: cwd)")
+    hooks_parser.set_defaults(handler=_cmd_install_hooks)
 
     return parser
 

--- a/src/codegraph/cli.py
+++ b/src/codegraph/cli.py
@@ -54,7 +54,13 @@ def _cmd_index(args: argparse.Namespace) -> int:
             store.connection.execute("DELETE FROM blobs")
             store.connection.commit()
         stats = indexer.reconcile(args.rev)
-        if not args.quiet:
+        if args.quiet:
+            # --quiet suppresses the stats chatter (this is what the
+            # warming hooks invoke in the background), but a parse failure
+            # is a real signal, not chatter -- let it through on stderr.
+            if stats.parse_errors:
+                print(f"parse errors: {stats.parse_errors}", file=sys.stderr)
+        else:
             _print_stats(stats)
     finally:
         store.close()

--- a/src/codegraph/cli.py
+++ b/src/codegraph/cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from codegraph import __version__, gitio
 from codegraph.indexer import FsTreeSource, GitTreeSource, Indexer
+from codegraph.query.diff import MissingRevisionError, diff_report
 from codegraph.query.effects import effects_report
 from codegraph.query.impact import impact_report
 from codegraph.render import render_json, render_text
@@ -125,6 +126,44 @@ def _cmd_impact(args: argparse.Namespace) -> int:
         store.close()
 
 
+def _diff_revspec(root: Path, revspec: str | None) -> tuple[str, str]:
+    """Split `<base>..<head>` into its two sides. A bare `<base>` (no `..`)
+    diffs it against the worktree. With no argument at all, base defaults
+    to `merge_base(default_branch, HEAD)` and head to the worktree --
+    "what has this branch changed so far."
+    """
+    if revspec:
+        if ".." in revspec:
+            base, _, head = revspec.partition("..")
+            return base, head or WORKTREE
+        return revspec, WORKTREE
+    if not gitio.is_repo(root):
+        raise MissingRevisionError("HEAD")
+    try:
+        branch = gitio.default_branch(root)
+        base = gitio.merge_base(root, branch, "HEAD")
+    except gitio.GitError as exc:
+        raise MissingRevisionError(str(exc)) from exc
+    return base, WORKTREE
+
+
+def _cmd_diff(args: argparse.Namespace) -> int:
+    """Report what changed between two revisions, compared on body_hash."""
+    root = Path(args.path).resolve()
+    store, indexer = open_workspace(root)
+    try:
+        try:
+            base, head = _diff_revspec(root, args.revspec)
+            report = diff_report(store, indexer, base, head)
+        except MissingRevisionError as exc:
+            print(f"revision not found: {exc.rev}", file=sys.stderr)
+            return 1
+        print(render_json(report) if args.json else render_text(report))
+        return 0
+    finally:
+        store.close()
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="codegraph")
     parser.add_argument("--version", action="version", version=__version__)
@@ -173,6 +212,19 @@ def build_parser() -> argparse.ArgumentParser:
     )
     impact_parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
     impact_parser.set_defaults(handler=_cmd_impact)
+
+    diff_parser = subparsers.add_parser(
+        "diff", help="Report what changed between two revisions"
+    )
+    diff_parser.add_argument(
+        "revspec",
+        nargs="?",
+        default=None,
+        help="<base>..<head> (default: merge-base(default branch, HEAD)..WORKTREE)",
+    )
+    diff_parser.add_argument("--path", default=".", help="Repository root (default: cwd)")
+    diff_parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    diff_parser.set_defaults(handler=_cmd_diff)
 
     return parser
 

--- a/src/codegraph/cli.py
+++ b/src/codegraph/cli.py
@@ -135,6 +135,12 @@ def _diff_revspec(root: Path, revspec: str | None) -> tuple[str, str]:
     if revspec:
         if ".." in revspec:
             base, _, head = revspec.partition("..")
+            if not base:
+                # "..HEAD" -- an empty base has no sensible default (unlike
+                # an empty head, which reasonably falls back to WORKTREE),
+                # so name the missing side rather than passing "" through
+                # to raise a blank, nameless error later.
+                raise MissingRevisionError("<base>")
             return base, head or WORKTREE
         return revspec, WORKTREE
     if not gitio.is_repo(root):

--- a/src/codegraph/cli.py
+++ b/src/codegraph/cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from codegraph import __version__, gitio
 from codegraph.indexer import FsTreeSource, GitTreeSource, Indexer
 from codegraph.query.effects import effects_report
+from codegraph.query.impact import impact_report
 from codegraph.render import render_json, render_text
 from codegraph.resolve import find_symbol
 from codegraph.store import WORKTREE, Store
@@ -95,6 +96,35 @@ def _cmd_effects(args: argparse.Namespace) -> int:
         store.close()
 
 
+def _cmd_impact(args: argparse.Namespace) -> int:
+    """Report the ranked dependents of a symbol -- everything a change to
+    it could break."""
+    root = Path(args.path).resolve()
+    store, indexer = open_workspace(root)
+    try:
+        indexer.reconcile(args.rev)
+        matches = find_symbol(store, args.rev, args.symbol)
+        if not matches:
+            print(f"no symbol matching {args.symbol!r}", file=sys.stderr)
+            return 1
+        if len(matches) > 1:
+            print(f"ambiguous symbol {args.symbol!r}:", file=sys.stderr)
+            for row in matches:
+                print(f"  {row['id']}", file=sys.stderr)
+            return 2
+        report = impact_report(
+            store,
+            args.rev,
+            matches[0]["id"],
+            max_hops=args.hops,
+            include_low=args.all,
+        )
+        print(render_json(report) if args.json else render_text(report))
+        return 0
+    finally:
+        store.close()
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="codegraph")
     parser.add_argument("--version", action="version", version=__version__)
@@ -130,6 +160,19 @@ def build_parser() -> argparse.ArgumentParser:
     effects_parser.add_argument("--rev", default=WORKTREE, help="Revision to query")
     effects_parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
     effects_parser.set_defaults(handler=_cmd_effects)
+
+    impact_parser = subparsers.add_parser("impact", help="Report the ranked dependents of a symbol")
+    impact_parser.add_argument("symbol", help="Node id, qualname, or trailing name")
+    impact_parser.add_argument("--path", default=".", help="Repository root (default: cwd)")
+    impact_parser.add_argument("--rev", default=WORKTREE, help="Revision to query")
+    impact_parser.add_argument(
+        "--hops", type=int, default=3, help="Maximum hops to walk (default: 3)"
+    )
+    impact_parser.add_argument(
+        "--all", action="store_true", help="Include LOW-confidence dependents"
+    )
+    impact_parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    impact_parser.set_defaults(handler=_cmd_impact)
 
     return parser
 

--- a/src/codegraph/config.py
+++ b/src/codegraph/config.py
@@ -8,11 +8,29 @@ from pathlib import Path
 
 CONFIG_NAME = "codegraph.toml"
 
+#: How many equally-plausible low-confidence candidates a single call site may
+#: name before the graph stops enumerating them.
+#:
+#: The last-resort resolution step matches a call's final dotted segment against
+#: every live definition in the revision. On a small codebase that yields a
+#: handful of candidates and the over-approximation is useful. On a large one it
+#: yields hundreds -- 971 for a single call site in django -- and the resulting
+#: edge set says only "this could be anything named `save`", which is the
+#: question restated, not an answer to it. Enumerating it is also quadratic in
+#: repo size.
+#:
+#: Above this many LOW candidates the call site is recorded once as ambiguous
+#: (with the name and the count) instead of as N edges. Nothing is discarded to
+#: improve precision -- the claim is identical, stored in O(1) rather than O(n).
+#: Raise it (or set it to 0 for no limit) if you want the full cross product.
+DEFAULT_AMBIGUITY_LIMIT = 25
+
 
 @dataclass(frozen=True)
 class Config:
     source_roots: tuple[str, ...] = ("", "src")
     effect_overrides: tuple[dict, ...] = ()
+    ambiguity_limit: int = DEFAULT_AMBIGUITY_LIMIT
 
     @classmethod
     def load(cls, root: Path) -> Config:
@@ -20,7 +38,13 @@ class Config:
         if not path.exists():
             return cls()
         data = tomllib.loads(path.read_text())
+        limit = data.get("ambiguity_limit", DEFAULT_AMBIGUITY_LIMIT)
+        if not isinstance(limit, int) or isinstance(limit, bool) or limit < 0:
+            raise ValueError(
+                f"{CONFIG_NAME}: ambiguity_limit must be a non-negative integer, got {limit!r}"
+            )
         return cls(
             source_roots=tuple(data.get("source_roots", ["", "src"])),
             effect_overrides=tuple(data.get("effect", [])),
+            ambiguity_limit=limit,
         )

--- a/src/codegraph/effects/__init__.py
+++ b/src/codegraph/effects/__init__.py
@@ -1,0 +1,11 @@
+"""Effect catalog: rules and matching for side-effect kinds.
+
+Detecting effects at call sites and propagating them through the call
+graph lives elsewhere (Task 10); this package only owns the rule set.
+"""
+
+from __future__ import annotations
+
+from codegraph.effects.catalog import EFFECT_KINDS, Catalog, Rule
+
+__all__ = ["EFFECT_KINDS", "Catalog", "Rule"]

--- a/src/codegraph/effects/builtin.toml
+++ b/src/codegraph/effects/builtin.toml
@@ -17,6 +17,47 @@
 match = "requests.*"
 kind = "NETWORK"
 
+# `requests.*` above has to stay MEDIUM: it matches the whole namespace,
+# including non-network members (`requests.codes`, `requests.utils.*`,
+# `Session()`), not just the HTTP verbs. But that leaves `requests.get` /
+# `.post` -- the single most common and least ambiguous network call in
+# Python -- worse labeled than before that fix, purely for uniformity. Each
+# of these is a fully literal pattern (no wildcard), so it derives HIGH
+# from its own specificity and, having a longer literal prefix than
+# `requests.*`, wins the match over it (see catalog.py's precedence rule)
+# without needing a `confidence` override.
+[[effect]]
+match = "requests.get"
+kind = "NETWORK"
+
+[[effect]]
+match = "requests.post"
+kind = "NETWORK"
+
+[[effect]]
+match = "requests.put"
+kind = "NETWORK"
+
+[[effect]]
+match = "requests.patch"
+kind = "NETWORK"
+
+[[effect]]
+match = "requests.delete"
+kind = "NETWORK"
+
+[[effect]]
+match = "requests.head"
+kind = "NETWORK"
+
+[[effect]]
+match = "requests.options"
+kind = "NETWORK"
+
+[[effect]]
+match = "requests.request"
+kind = "NETWORK"
+
 [[effect]]
 match = "httpx.*"
 kind = "NETWORK"

--- a/src/codegraph/effects/builtin.toml
+++ b/src/codegraph/effects/builtin.toml
@@ -72,7 +72,15 @@ match = "*.execute"
 kind = "DB_WRITE"
 
 [[effect]]
-match = "psycopg*"
+match = "*.fetchone"
+kind = "DB_READ"
+
+[[effect]]
+match = "*.fetchall"
+kind = "DB_READ"
+
+[[effect]]
+match = "*.fetchmany"
 kind = "DB_READ"
 
 [[effect]]

--- a/src/codegraph/effects/builtin.toml
+++ b/src/codegraph/effects/builtin.toml
@@ -1,0 +1,96 @@
+# Built-in effect catalog: dotted-name glob patterns to side-effect kinds.
+#
+# Loaded by `codegraph.effects.catalog.Catalog.load` and merged with a
+# project's `codegraph.toml` [[effect]] overrides. See catalog.py for the
+# matching rule (longest literal prefix wins, overrides break ties).
+#
+# GLOBAL_MUTATE has no entries here by design: it is detected syntactically
+# (assignment to a module/class-level name), not by a call-site catalog.
+
+[[effect]]
+match = "requests.*"
+kind = "NETWORK"
+
+[[effect]]
+match = "httpx.*"
+kind = "NETWORK"
+
+[[effect]]
+match = "urllib.request.*"
+kind = "NETWORK"
+
+[[effect]]
+match = "socket.*"
+kind = "NETWORK"
+
+[[effect]]
+match = "subprocess.*"
+kind = "PROCESS"
+
+[[effect]]
+match = "os.system"
+kind = "PROCESS"
+
+[[effect]]
+match = "os.exec*"
+kind = "PROCESS"
+
+[[effect]]
+match = "os.environ*"
+kind = "ENV_READ"
+
+[[effect]]
+match = "os.getenv"
+kind = "ENV_READ"
+
+[[effect]]
+match = "open"
+kind = "FS_READ"
+
+[[effect]]
+match = "pathlib.Path.read*"
+kind = "FS_READ"
+
+[[effect]]
+match = "pathlib.Path.write*"
+kind = "FS_WRITE"
+
+[[effect]]
+match = "shutil.*"
+kind = "FS_WRITE"
+
+[[effect]]
+match = "*.session.commit"
+kind = "DB_WRITE"
+
+[[effect]]
+match = "*.session.add"
+kind = "DB_WRITE"
+
+[[effect]]
+match = "*.execute"
+kind = "DB_WRITE"
+
+[[effect]]
+match = "psycopg*"
+kind = "DB_READ"
+
+[[effect]]
+match = "boto3.*"
+kind = "DB_WRITE"
+
+[[effect]]
+match = "random.*"
+kind = "NONDETERMINISM"
+
+[[effect]]
+match = "time.time"
+kind = "NONDETERMINISM"
+
+[[effect]]
+match = "uuid.uuid4"
+kind = "NONDETERMINISM"
+
+[[effect]]
+match = "datetime.datetime.now"
+kind = "NONDETERMINISM"

--- a/src/codegraph/effects/builtin.toml
+++ b/src/codegraph/effects/builtin.toml
@@ -2,7 +2,13 @@
 #
 # Loaded by `codegraph.effects.catalog.Catalog.load` and merged with a
 # project's `codegraph.toml` [[effect]] overrides. See catalog.py for the
-# matching rule (longest literal prefix wins, overrides break ties).
+# matching rule (longest literal prefix wins, overrides break ties) and for
+# how confidence is derived from a rule's own match specificity unless it
+# sets an explicit `confidence` override (HIGH/MEDIUM/LOW) -- a fully
+# literal pattern (no wildcard at all) is HIGH, a bare wildcard-head
+# pattern like `*.execute` (matching any receiver whatsoever) is LOW, and
+# anything with a real but partial literal prefix (`requests.*`,
+# `boto3.*`) is MEDIUM.
 #
 # GLOBAL_MUTATE has no entries here by design: it is detected syntactically
 # (assignment to a module/class-level name), not by a call-site catalog.
@@ -44,8 +50,29 @@ match = "os.getenv"
 kind = "ENV_READ"
 
 [[effect]]
+# `parse.py`'s `_open_call_marker` only produces this name for a bare
+# `open(...)` call whose mode is absent or a literal read-only string
+# (e.g. no second arg, or `"r"`/`"rb"`) -- a genuine read, so the derived
+# HIGH confidence (this pattern has no wildcard at all) is warranted.
 match = "open"
 kind = "FS_READ"
+
+[[effect]]
+# A literal mode string containing w/a/x/+ -- also a genuine, not merely
+# inferred, write; HIGH is warranted for the same reason as `open` above.
+match = "open!write"
+kind = "FS_WRITE"
+
+[[effect]]
+# The mode argument was present but not a string literal (a variable, an
+# expression) -- kept at the conservative FS_READ default, since dropping
+# it would violate the over-approximation bias, but *not* at HIGH: unlike
+# the two rules above, the evidence here does not actually establish the
+# kind, so an explicit override caps it below what this pattern's literal
+# spelling would otherwise derive.
+match = "open!ambiguous"
+kind = "FS_READ"
+confidence = "MEDIUM"
 
 [[effect]]
 match = "pathlib.Path.read*"

--- a/src/codegraph/effects/catalog.py
+++ b/src/codegraph/effects/catalog.py
@@ -1,0 +1,120 @@
+"""Effect catalog: dotted-name glob patterns mapped to side-effect kinds.
+
+Rules come from two sources merged at load time: the built-in patterns
+shipped in `builtin.toml`, and a project's `codegraph.toml` overrides
+(`Config.effect_overrides`). Most real side effects sit behind house
+abstractions (`app.db.save`), not `requests.get` directly, which is why the
+override channel exists at all rather than the built-in list being enough.
+
+Precedence: on a name that matches more than one rule, the rule with the
+longest leading literal segment (the run of characters before the first
+glob wildcard) wins. `requests.get` (override, fully literal) beats
+`requests.*` (built-in, literal prefix `requests.`), so an override always
+beats a built-in it is more specific than, regardless of load order.
+
+This module owns rules and matching only. Detecting which call sites are
+effects, and propagating that through the call graph, is Task 10.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import re
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NamedTuple
+
+from codegraph.config import Config
+
+EFFECT_KINDS: tuple[str, ...] = (
+    "DB_READ",
+    "DB_WRITE",
+    "NETWORK",
+    "FS_READ",
+    "FS_WRITE",
+    "PROCESS",
+    "ENV_READ",
+    "GLOBAL_MUTATE",
+    "NONDETERMINISM",
+)
+
+_BUILTIN_TOML = Path(__file__).with_name("builtin.toml")
+
+_WILDCARD = re.compile(r"[*?\[]")
+
+
+def _literal_prefix_len(pattern: str) -> int:
+    """Length of the leading run of literal characters before a glob wildcard."""
+    found = _WILDCARD.search(pattern)
+    return found.start() if found else len(pattern)
+
+
+@dataclass(frozen=True)
+class Rule:
+    match: str
+    kind: str
+
+
+class _Compiled(NamedTuple):
+    rule: Rule
+    regex: re.Pattern[str]
+    prefix_len: int
+    is_override: bool
+
+
+def _parse_rules(text: str) -> tuple[Rule, ...]:
+    data = tomllib.loads(text)
+    return tuple(Rule(match=entry["match"], kind=entry["kind"]) for entry in data.get("effect", []))
+
+
+class Catalog:
+    """A merged, ready-to-query set of effect rules."""
+
+    def __init__(self, rules: tuple[Rule, ...], override_count: int) -> None:
+        self._rules = rules
+        first_override = len(rules) - override_count
+        self._compiled = tuple(
+            _Compiled(
+                rule=rule,
+                regex=re.compile(fnmatch.translate(rule.match)),
+                prefix_len=_literal_prefix_len(rule.match),
+                is_override=i >= first_override,
+            )
+            for i, rule in enumerate(rules)
+        )
+
+    @classmethod
+    def load(cls, config: Config) -> Catalog:
+        builtin_rules = _parse_rules(_BUILTIN_TOML.read_text())
+        override_rules = tuple(
+            Rule(match=entry["match"], kind=entry["kind"]) for entry in config.effect_overrides
+        )
+        return cls(builtin_rules + override_rules, len(override_rules))
+
+    def match(self, dotted: str) -> str | None:
+        """The kind of the best-matching rule for `dotted`, or None."""
+        best: _Compiled | None = None
+        for compiled in self._compiled:
+            if not compiled.regex.match(dotted):
+                continue
+            key = (compiled.prefix_len, compiled.is_override, compiled.rule.match)
+            best_key = (
+                (best.prefix_len, best.is_override, best.rule.match) if best is not None else None
+            )
+            if best is None or key > best_key:
+                best = compiled
+        return best.rule.kind if best else None
+
+    def fingerprint(self) -> str:
+        """Stable hash over all rules: same rules -> same digest, any run.
+
+        Unlike `hash()`, which is salted per process, this is a plain
+        SHA-256 over a sorted, delimited encoding of every rule, so it is
+        safe to bake into an on-disk cache key.
+        """
+        digest = hashlib.sha256()
+        for rule in sorted(self._rules, key=lambda r: (r.match, r.kind)):
+            digest.update(f"{rule.match}\x00{rule.kind}\n".encode())
+        return digest.hexdigest()

--- a/src/codegraph/effects/catalog.py
+++ b/src/codegraph/effects/catalog.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import NamedTuple
 
 from codegraph.config import Config
+from codegraph.resolve import HIGH, LOW, MEDIUM
 
 EFFECT_KINDS: tuple[str, ...] = (
     "DB_READ",
@@ -51,16 +52,34 @@ def _literal_prefix_len(pattern: str) -> int:
     return found.start() if found else len(pattern)
 
 
+_CONFIDENCES: tuple[str, ...] = (HIGH, MEDIUM, LOW)
+
+
 @dataclass(frozen=True)
 class Rule:
     match: str
     kind: str
+    #: Explicit override; `None` (the default, and every built-in pattern
+    #: but one) means "derive from match specificity" -- see
+    #: `Catalog._confidence_for`. The one built-in exception is `open`'s
+    #: non-literal-mode fallback (`open!ambiguous` in builtin.toml): a
+    #: fully literal pattern name would otherwise derive HIGH, but the
+    #: *kind* assigned to it (FS_READ, the conservative default) is not
+    #: actually known -- the call's mode argument wasn't a literal, so
+    #: this is the one case where the pattern's specificity doesn't speak
+    #: to how much the evidence actually supports the kind it names.
+    confidence: str | None = None
 
     def __post_init__(self) -> None:
         if self.kind not in EFFECT_KINDS:
             raise ValueError(
                 f"unknown effect kind {self.kind!r} for pattern {self.match!r}; "
                 f"must be one of {EFFECT_KINDS}"
+            )
+        if self.confidence is not None and self.confidence not in _CONFIDENCES:
+            raise ValueError(
+                f"unknown confidence {self.confidence!r} for pattern {self.match!r}; "
+                f"must be one of {_CONFIDENCES}"
             )
 
 
@@ -73,7 +92,10 @@ class _Compiled(NamedTuple):
 
 def _parse_rules(text: str) -> tuple[Rule, ...]:
     data = tomllib.loads(text)
-    return tuple(Rule(match=entry["match"], kind=entry["kind"]) for entry in data.get("effect", []))
+    return tuple(
+        Rule(match=entry["match"], kind=entry["kind"], confidence=entry.get("confidence"))
+        for entry in data.get("effect", [])
+    )
 
 
 class Catalog:
@@ -96,12 +118,12 @@ class Catalog:
     def load(cls, config: Config) -> Catalog:
         builtin_rules = _parse_rules(_BUILTIN_TOML.read_text())
         override_rules = tuple(
-            Rule(match=entry["match"], kind=entry["kind"]) for entry in config.effect_overrides
+            Rule(match=entry["match"], kind=entry["kind"], confidence=entry.get("confidence"))
+            for entry in config.effect_overrides
         )
         return cls(builtin_rules + override_rules, len(override_rules))
 
-    def match(self, dotted: str) -> str | None:
-        """The kind of the best-matching rule for `dotted`, or None."""
+    def _best_match(self, dotted: str) -> _Compiled | None:
         best: _Compiled | None = None
         for compiled in self._compiled:
             if not compiled.regex.match(dotted):
@@ -112,7 +134,42 @@ class Catalog:
             )
             if best is None or key > best_key:
                 best = compiled
+        return best
+
+    def match(self, dotted: str) -> str | None:
+        """The kind of the best-matching rule for `dotted`, or None."""
+        best = self._best_match(dotted)
         return best.rule.kind if best else None
+
+    def match_with_confidence(self, dotted: str) -> tuple[str, str] | None:
+        """(kind, confidence) for the best-matching rule, or `None`.
+
+        Confidence falls out of the winning rule's match specificity -- the
+        same longest-literal-prefix signal `match` already uses to rank
+        overlapping rules against each other (see the module docstring):
+        a fully literal pattern with no wildcard at all (`requests.get`,
+        `os.getenv`) is HIGH; a bare wildcard-head pattern (`*.execute`,
+        matching a completely uninferable receiver) can be no more than
+        LOW; anything in between -- a real but partial literal prefix, like
+        `requests.*` or `boto3.*` -- sits at MEDIUM: the namespace is known,
+        the specific member is not. A rule may override this via its own
+        `confidence` field for the rare case where specificity of the NAME
+        match doesn't track certainty of the KIND assigned to it (see
+        `Rule.confidence`).
+        """
+        best = self._best_match(dotted)
+        if best is None:
+            return None
+        if best.rule.confidence is not None:
+            return best.rule.kind, best.rule.confidence
+        pattern_len = len(best.rule.match)
+        if best.prefix_len == pattern_len:
+            confidence = HIGH
+        elif best.prefix_len == 0:
+            confidence = LOW
+        else:
+            confidence = MEDIUM
+        return best.rule.kind, confidence
 
     def fingerprint(self) -> str:
         """Stable hash over all rules: same rules -> same digest, any run.
@@ -123,5 +180,5 @@ class Catalog:
         """
         digest = hashlib.sha256()
         for rule in sorted(self._rules, key=lambda r: (r.match, r.kind)):
-            digest.update(f"{rule.match}\x00{rule.kind}\n".encode())
+            digest.update(f"{rule.match}\x00{rule.kind}\x00{rule.confidence or ''}\n".encode())
         return digest.hexdigest()

--- a/src/codegraph/effects/catalog.py
+++ b/src/codegraph/effects/catalog.py
@@ -56,6 +56,13 @@ class Rule:
     match: str
     kind: str
 
+    def __post_init__(self) -> None:
+        if self.kind not in EFFECT_KINDS:
+            raise ValueError(
+                f"unknown effect kind {self.kind!r} for pattern {self.match!r}; "
+                f"must be one of {EFFECT_KINDS}"
+            )
+
 
 class _Compiled(NamedTuple):
     rule: Rule

--- a/src/codegraph/effects/detect.py
+++ b/src/codegraph/effects/detect.py
@@ -32,16 +32,21 @@ def detect_direct(store: Store, rev: str, catalog: Catalog, config: Config) -> i
         (rev,),
     ):
         if row["ref_kind"] == "global":
-            kind = "GLOBAL_MUTATE"
+            # Syntactic detection (assignment to a name declared `global`/
+            # `nonlocal`), not a catalog match -- there is no pattern
+            # specificity to derive uncertainty from, and none is
+            # warranted: this is exact by construction.
+            kind, confidence = "GLOBAL_MUTATE", HIGH
         else:
             dotted = _expand(row["raw_name"], import_maps.get(row["path"], {}))
-            kind = catalog.match(dotted)
-        if kind is None:
-            continue
+            matched = catalog.match_with_confidence(dotted)
+            if matched is None:
+                continue
+            kind, confidence = matched
         node_id = _owning_node(
             row["path"], row["from_qualname"], row["line"], owner_index, live_index
         )
-        rows.append((rev, node_id, kind, 1, row["path"], row["line"], HIGH))
+        rows.append((rev, node_id, kind, 1, row["path"], row["line"], confidence))
 
     connection.execute("DELETE FROM effects WHERE rev=? AND direct=1", (rev,))
     connection.executemany(

--- a/src/codegraph/effects/detect.py
+++ b/src/codegraph/effects/detect.py
@@ -1,0 +1,139 @@
+"""Direct effect detection: catalog matches against refs, not edges.
+
+`requests.get` never resolves to a node in this repo -- resolution only
+links to symbols the repo itself defines -- so an edge-only pass would miss
+every external call, which is most real side effects. This module reads
+`blob_refs` (joined through `tree` for the revision) instead: every `call`
+ref is expanded through its file's import map to a canonical dotted name
+and matched against the effect `Catalog`; every `global`/`nonlocal` ref
+(`ref_kind="global"`, from `parse.py`) is a `GLOBAL_MUTATE` by construction,
+since that kind is syntactic and has no catalog pattern.
+"""
+
+from __future__ import annotations
+
+from codegraph.config import Config
+from codegraph.effects.catalog import Catalog
+from codegraph.resolve import (
+    HIGH,
+    MODULE_SCOPE,
+    absolute_module,
+    module_for_path,
+    package_for_module,
+)
+from codegraph.store import Store
+
+
+def detect_direct(store: Store, rev: str, catalog: Catalog) -> int:
+    """Tag every ref in `rev` that is a direct effect. Returns rows written."""
+    connection = store.connection
+    config = Config.load(store.directory.parent)
+    import_maps = _import_maps(store, rev, config)
+    owner_index = _owner_index(store, rev)
+
+    rows: list[tuple] = []
+    for row in connection.execute(
+        "SELECT t.path AS path, r.from_qualname, r.ref_kind, r.raw_name, r.line"
+        " FROM blob_refs r JOIN tree t ON t.blob_sha = r.blob_sha"
+        " WHERE t.rev=? AND r.ref_kind IN ('call', 'global')",
+        (rev,),
+    ):
+        if row["ref_kind"] == "global":
+            kind = "GLOBAL_MUTATE"
+        else:
+            dotted = _expand(row["raw_name"], import_maps.get(row["path"], {}))
+            kind = catalog.match(dotted)
+        if kind is None:
+            continue
+        node_id = _owning_node(row["path"], row["from_qualname"], row["line"], owner_index)
+        rows.append((rev, node_id, kind, 1, row["path"], row["line"], HIGH))
+
+    connection.execute("DELETE FROM effects WHERE rev=? AND direct=1", (rev,))
+    connection.executemany(
+        "INSERT INTO effects(rev, node_id, kind, direct, evidence_path, evidence_line,"
+        " confidence) VALUES(?,?,?,?,?,?,?)",
+        rows,
+    )
+    return len(rows)
+
+
+def _expand(raw_name: str, import_map: dict[str, str]) -> str:
+    """Expand a local alias through the file's import map, e.g. `db.save`
+    (with `from app import db`) -> `app.db.save`, so a project override like
+    `app.db.*` matches the house abstraction rather than the call's literal
+    spelling. A name whose head isn't imported (a builtin, a local, `self`)
+    passes through unchanged, which is what the built-in catalog expects."""
+    head, _, rest = raw_name.partition(".")
+    target = import_map.get(head)
+    if target is None:
+        return raw_name
+    return f"{target}.{rest}" if rest else target
+
+
+def _import_maps(store: Store, rev: str, config: Config) -> dict[str, dict[str, str]]:
+    """Per-path local-alias -> absolute-dotted-module map.
+
+    Mirrors the alias expansion `resolve.py`'s symbol table builds for call
+    resolution, but detection only needs the alias map, not a full resolver.
+    """
+    connection = store.connection
+    paths = [
+        row["path"]
+        for row in connection.execute("SELECT DISTINCT path FROM tree WHERE rev=?", (rev,))
+    ]
+    module_for = {path: module_for_path(path, config.source_roots) for path in paths}
+    maps: dict[str, dict[str, str]] = {path: {} for path in paths}
+
+    rows = connection.execute(
+        "SELECT t.path, i.module, i.level, i.name, i.alias FROM blob_imports i"
+        " JOIN tree t ON t.blob_sha = i.blob_sha WHERE t.rev=? ORDER BY t.path, i.ordinal",
+        (rev,),
+    )
+    for row in rows:
+        path = row["path"]
+        alias_map = maps[path]
+        package = package_for_module(module_for[path], path)
+        module = absolute_module(row["module"], row["level"], package)
+        if row["name"] is None:
+            alias_map[row["alias"] or module] = module
+            if row["alias"] is None:
+                alias_map.setdefault(module.partition(".")[0], module.partition(".")[0])
+        else:
+            target = f"{module}.{row['name']}" if module else row["name"]
+            alias_map[row["alias"] or row["name"]] = target
+    return maps
+
+
+def _owner_index(store: Store, rev: str) -> dict[tuple[str, str], list[tuple[str, int, int]]]:
+    """(path, qualname) -> [(node id, line_start, line_end), ...], including
+    shadowed definitions, so a ref inside a shadowed body still attributes
+    to it rather than to the live definition sharing its name."""
+    index: dict[tuple[str, str], list[tuple[str, int, int]]] = {}
+    for row in store.connection.execute(
+        "SELECT id, path, qualname, line_start, line_end FROM nodes WHERE rev=? ORDER BY id",
+        (rev,),
+    ):
+        index.setdefault((row["path"], row["qualname"]), []).append(
+            (row["id"], row["line_start"], row["line_end"])
+        )
+    return index
+
+
+def _owning_node(
+    path: str,
+    from_qualname: str,
+    line: int,
+    index: dict[tuple[str, str], list[tuple[str, int, int]]],
+) -> str:
+    """The node that owns a ref; mirrors `resolve.py`'s `_source_id`."""
+    if from_qualname == MODULE_SCOPE:
+        return f"{path}::{MODULE_SCOPE}"
+    candidates = index.get((path, from_qualname))
+    if not candidates:
+        return f"{path}::{from_qualname}"
+    if len(candidates) == 1:
+        return candidates[0][0]
+    for node_id, line_start, line_end in candidates:
+        if line_start <= line <= line_end:
+            return node_id
+    return candidates[-1][0]

--- a/src/codegraph/effects/detect.py
+++ b/src/codegraph/effects/detect.py
@@ -14,22 +14,15 @@ from __future__ import annotations
 
 from codegraph.config import Config
 from codegraph.effects.catalog import Catalog
-from codegraph.resolve import (
-    HIGH,
-    MODULE_SCOPE,
-    absolute_module,
-    module_for_path,
-    package_for_module,
-)
+from codegraph.resolve import HIGH, MODULE_SCOPE, build_import_maps
 from codegraph.store import Store
 
 
-def detect_direct(store: Store, rev: str, catalog: Catalog) -> int:
+def detect_direct(store: Store, rev: str, catalog: Catalog, config: Config) -> int:
     """Tag every ref in `rev` that is a direct effect. Returns rows written."""
     connection = store.connection
-    config = Config.load(store.directory.parent)
-    import_maps = _import_maps(store, rev, config)
-    owner_index = _owner_index(store, rev)
+    import_maps, _imported_modules = build_import_maps(connection, rev, config)
+    owner_index, live_index = _owner_index(store, rev)
 
     rows: list[tuple] = []
     for row in connection.execute(
@@ -45,7 +38,9 @@ def detect_direct(store: Store, rev: str, catalog: Catalog) -> int:
             kind = catalog.match(dotted)
         if kind is None:
             continue
-        node_id = _owning_node(row["path"], row["from_qualname"], row["line"], owner_index)
+        node_id = _owning_node(
+            row["path"], row["from_qualname"], row["line"], owner_index, live_index
+        )
         rows.append((rev, node_id, kind, 1, row["path"], row["line"], HIGH))
 
     connection.execute("DELETE FROM effects WHERE rev=? AND direct=1", (rev,))
@@ -70,53 +65,26 @@ def _expand(raw_name: str, import_map: dict[str, str]) -> str:
     return f"{target}.{rest}" if rest else target
 
 
-def _import_maps(store: Store, rev: str, config: Config) -> dict[str, dict[str, str]]:
-    """Per-path local-alias -> absolute-dotted-module map.
-
-    Mirrors the alias expansion `resolve.py`'s symbol table builds for call
-    resolution, but detection only needs the alias map, not a full resolver.
-    """
-    connection = store.connection
-    paths = [
-        row["path"]
-        for row in connection.execute("SELECT DISTINCT path FROM tree WHERE rev=?", (rev,))
-    ]
-    module_for = {path: module_for_path(path, config.source_roots) for path in paths}
-    maps: dict[str, dict[str, str]] = {path: {} for path in paths}
-
-    rows = connection.execute(
-        "SELECT t.path, i.module, i.level, i.name, i.alias FROM blob_imports i"
-        " JOIN tree t ON t.blob_sha = i.blob_sha WHERE t.rev=? ORDER BY t.path, i.ordinal",
-        (rev,),
-    )
-    for row in rows:
-        path = row["path"]
-        alias_map = maps[path]
-        package = package_for_module(module_for[path], path)
-        module = absolute_module(row["module"], row["level"], package)
-        if row["name"] is None:
-            alias_map[row["alias"] or module] = module
-            if row["alias"] is None:
-                alias_map.setdefault(module.partition(".")[0], module.partition(".")[0])
-        else:
-            target = f"{module}.{row['name']}" if module else row["name"]
-            alias_map[row["alias"] or row["name"]] = target
-    return maps
-
-
-def _owner_index(store: Store, rev: str) -> dict[tuple[str, str], list[tuple[str, int, int]]]:
+def _owner_index(
+    store: Store, rev: str
+) -> tuple[dict[tuple[str, str], list[tuple[str, int, int]]], dict[tuple[str, str], str]]:
     """(path, qualname) -> [(node id, line_start, line_end), ...], including
     shadowed definitions, so a ref inside a shadowed body still attributes
-    to it rather than to the live definition sharing its name."""
+    to it rather than to the live definition sharing its name; and
+    (path, qualname) -> live node id, mirroring `resolve.py`'s
+    `qualname_index` for the same-fallback reason `_owning_node` uses it."""
     index: dict[tuple[str, str], list[tuple[str, int, int]]] = {}
+    live: dict[tuple[str, str], str] = {}
     for row in store.connection.execute(
-        "SELECT id, path, qualname, line_start, line_end FROM nodes WHERE rev=? ORDER BY id",
+        "SELECT id, path, qualname, line_start, line_end, name_binding FROM nodes"
+        " WHERE rev=? ORDER BY id",
         (rev,),
     ):
-        index.setdefault((row["path"], row["qualname"]), []).append(
-            (row["id"], row["line_start"], row["line_end"])
-        )
-    return index
+        key = (row["path"], row["qualname"])
+        index.setdefault(key, []).append((row["id"], row["line_start"], row["line_end"]))
+        if row["name_binding"] == "live":
+            live[key] = row["id"]
+    return index, live
 
 
 def _owning_node(
@@ -124,11 +92,16 @@ def _owning_node(
     from_qualname: str,
     line: int,
     index: dict[tuple[str, str], list[tuple[str, int, int]]],
+    live: dict[tuple[str, str], str],
 ) -> str:
-    """The node that owns a ref; mirrors `resolve.py`'s `_source_id`."""
+    """The node that owns a ref; mirrors `resolve.py`'s `_source_id`,
+    including its fallback to the live binding (not just "the last
+    candidate") when a ref's line falls inside no recorded span -- so
+    detection and resolution attribute the same ref to the same node."""
     if from_qualname == MODULE_SCOPE:
         return f"{path}::{MODULE_SCOPE}"
-    candidates = index.get((path, from_qualname))
+    key = (path, from_qualname)
+    candidates = index.get(key)
     if not candidates:
         return f"{path}::{from_qualname}"
     if len(candidates) == 1:
@@ -136,4 +109,4 @@ def _owning_node(
     for node_id, line_start, line_end in candidates:
         if line_start <= line <= line_end:
             return node_id
-    return candidates[-1][0]
+    return live.get(key, candidates[-1][0])

--- a/src/codegraph/effects/propagate.py
+++ b/src/codegraph/effects/propagate.py
@@ -1,0 +1,221 @@
+"""Effect propagation: `effects(n) = direct(n) UNION union(effects(callees))`
+over the `CALLS` edge closure for one revision.
+
+Strongly connected components of the call graph are condensed with Tarjan's
+algorithm first, so every member of a recursion cycle shares one effect
+union computed once. A naive recursive walk without this recurses forever
+on mutual recursion (`ping` calls `pong` calls `ping` ...) -- that's what
+`test_recursion_cycle_does_not_hang` guards against. Once condensed, the
+component graph is a DAG, so a single memoized post-order walk computes
+every component's effect set in one pass, carrying confidence as the
+minimum along whichever concrete edge/path produced the strongest claim.
+
+`witness_path` is a separate, on-demand BFS over the (uncondensed) `CALLS`
+graph, used at query time. BFS never revisits a node, so cycles are handled
+for free there and it needs no SCC step of its own.
+
+This module never queries the effect `Catalog`: it only reads `effects`
+rows Task 10's `detect_direct` already wrote, and `edges`.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Iterator
+
+from codegraph.resolve import HIGH, LOW, MEDIUM
+from codegraph.store import Store
+
+_RANK = {LOW: 0, MEDIUM: 1, HIGH: 2}
+
+
+def _weaker(a: str, b: str) -> str:
+    return a if _RANK[a] <= _RANK[b] else b
+
+
+def _stronger(a: str, b: str) -> str:
+    return a if _RANK[a] >= _RANK[b] else b
+
+
+def propagate(store: Store, rev: str) -> int:
+    """Write transitive (`direct=0`) effect rows for `rev`. Returns the
+    count of rows written."""
+    connection = store.connection
+    connection.execute("DELETE FROM effects WHERE rev=? AND direct=0", (rev,))
+
+    node_ids = {row["id"] for row in connection.execute("SELECT id FROM nodes WHERE rev=?", (rev,))}
+    calls: dict[str, set[str]] = {node_id: set() for node_id in node_ids}
+    edge_confidence: dict[tuple[str, str], str] = {}
+    for row in connection.execute(
+        "SELECT src, dst, confidence FROM edges WHERE rev=? AND kind='CALLS'", (rev,)
+    ):
+        src, dst, confidence = row["src"], row["dst"], row["confidence"]
+        if src not in node_ids or dst not in node_ids:
+            continue
+        calls[src].add(dst)
+        key = (src, dst)
+        edge_confidence[key] = _stronger(edge_confidence.get(key, confidence), confidence)
+
+    direct_by_node: dict[str, dict[str, str]] = {}
+    for row in connection.execute(
+        "SELECT node_id, kind, confidence FROM effects WHERE rev=? AND direct=1", (rev,)
+    ):
+        bucket = direct_by_node.setdefault(row["node_id"], {})
+        bucket[row["kind"]] = _stronger(
+            bucket.get(row["kind"], row["confidence"]), row["confidence"]
+        )
+
+    components, comp_of = _tarjan_scc(node_ids, calls)
+
+    comp_direct: dict[int, dict[str, str]] = {}
+    for node_id, node_kinds in direct_by_node.items():
+        comp = comp_of.get(node_id)
+        if comp is None:
+            continue
+        bucket = comp_direct.setdefault(comp, {})
+        for kind, confidence in node_kinds.items():
+            bucket[kind] = _stronger(bucket.get(kind, confidence), confidence)
+
+    comp_edges: dict[int, dict[int, str]] = {}
+    for (src, dst), confidence in edge_confidence.items():
+        c_src, c_dst = comp_of[src], comp_of[dst]
+        if c_src == c_dst:
+            continue
+        bucket = comp_edges.setdefault(c_src, {})
+        bucket[c_dst] = _stronger(bucket.get(c_dst, confidence), confidence)
+
+    # The condensation is a DAG (Tarjan guarantees no cycles between
+    # distinct components), so a plain memoized recursion terminates.
+    cache: dict[int, dict[str, str]] = {}
+
+    def comp_effects(comp: int) -> dict[str, str]:
+        if comp in cache:
+            return cache[comp]
+        result = dict(comp_direct.get(comp, {}))
+        for succ, edge_conf in comp_edges.get(comp, {}).items():
+            for kind, confidence in comp_effects(succ).items():
+                propagated = _weaker(edge_conf, confidence)
+                if kind not in result or _RANK[propagated] > _RANK[result[kind]]:
+                    result[kind] = propagated
+        cache[comp] = result
+        return result
+
+    rows: list[tuple] = []
+    for comp_index in range(len(components)):
+        effects_here = comp_effects(comp_index)
+        if not effects_here:
+            continue
+        for node_id in components[comp_index]:
+            own_direct = direct_by_node.get(node_id, {})
+            for kind, confidence in effects_here.items():
+                if kind in own_direct:
+                    continue
+                rows.append((rev, node_id, kind, 0, None, None, confidence))
+
+    connection.executemany(
+        "INSERT INTO effects(rev, node_id, kind, direct, evidence_path, evidence_line,"
+        " confidence) VALUES(?,?,?,?,?,?,?)",
+        rows,
+    )
+    return len(rows)
+
+
+def _tarjan_scc(
+    nodes: set[str], adjacency: dict[str, set[str]]
+) -> tuple[list[list[str]], dict[str, int]]:
+    """Tarjan's strongly-connected-components algorithm, iterative so a deep
+    call graph can't blow the interpreter's recursion limit."""
+    index_of: dict[str, int] = {}
+    lowlink: dict[str, int] = {}
+    on_stack: set[str] = set()
+    stack: list[str] = []
+    components: list[list[str]] = []
+    counter = 0
+
+    def strongconnect(root: str) -> None:
+        nonlocal counter
+        work: list[tuple[str, Iterator[str]]] = [(root, iter(adjacency.get(root, ())))]
+        index_of[root] = counter
+        lowlink[root] = counter
+        counter += 1
+        stack.append(root)
+        on_stack.add(root)
+
+        while work:
+            v, neighbors = work[-1]
+            advanced = False
+            for w in neighbors:
+                if w not in index_of:
+                    index_of[w] = counter
+                    lowlink[w] = counter
+                    counter += 1
+                    stack.append(w)
+                    on_stack.add(w)
+                    work.append((w, iter(adjacency.get(w, ()))))
+                    advanced = True
+                    break
+                if w in on_stack:
+                    lowlink[v] = min(lowlink[v], index_of[w])
+            if advanced:
+                continue
+
+            work.pop()
+            if work:
+                parent = work[-1][0]
+                lowlink[parent] = min(lowlink[parent], lowlink[v])
+            if lowlink[v] == index_of[v]:
+                component = []
+                while True:
+                    w = stack.pop()
+                    on_stack.discard(w)
+                    component.append(w)
+                    if w == v:
+                        break
+                components.append(component)
+
+    for node in nodes:
+        if node not in index_of:
+            strongconnect(node)
+
+    comp_of = {node_id: i for i, component in enumerate(components) for node_id in component}
+    return components, comp_of
+
+
+def witness_path(store: Store, rev: str, node_id: str, kind: str) -> list[str]:
+    """Shortest chain of node ids from `node_id` to a node whose direct
+    effect of `kind` causes it, via `CALLS` edges. `[]` if none exists."""
+    connection = store.connection
+    direct_nodes = {
+        row["node_id"]
+        for row in connection.execute(
+            "SELECT DISTINCT node_id FROM effects WHERE rev=? AND kind=? AND direct=1",
+            (rev, kind),
+        )
+    }
+    if node_id in direct_nodes:
+        return [node_id]
+
+    calls: dict[str, list[str]] = {}
+    for row in connection.execute(
+        "SELECT DISTINCT src, dst FROM edges WHERE rev=? AND kind='CALLS'", (rev,)
+    ):
+        calls.setdefault(row["src"], []).append(row["dst"])
+
+    visited = {node_id}
+    parent: dict[str, str] = {}
+    queue: deque[str] = deque([node_id])
+    while queue:
+        current = queue.popleft()
+        for nxt in calls.get(current, ()):
+            if nxt in visited:
+                continue
+            visited.add(nxt)
+            parent[nxt] = current
+            if nxt in direct_nodes:
+                chain = [nxt]
+                while chain[-1] != node_id:
+                    chain.append(parent[chain[-1]])
+                chain.reverse()
+                return chain
+            queue.append(nxt)
+    return []

--- a/src/codegraph/effects/propagate.py
+++ b/src/codegraph/effects/propagate.py
@@ -1,41 +1,57 @@
-"""Effect propagation: `effects(n) = direct(n) UNION union(effects(callees))`
-over the `CALLS` edge closure for one revision.
+"""Effect propagation: for each node, the strongest confidence tier at
+which it can reach an effect-bearing node, over the `CALLS` edge closure
+for one revision.
 
-Strongly connected components of the call graph are condensed with Tarjan's
-algorithm first, so every member of a recursion cycle shares one effect
-union computed once. A naive recursive walk without this recurses forever
-on mutual recursion (`ping` calls `pong` calls `ping` ...) -- that's what
-`test_recursion_cycle_does_not_hang` guards against. Once condensed, the
-component graph is a DAG, so a single memoized post-order walk computes
-every component's effect set in one pass, carrying confidence as the
-minimum along whichever concrete edge/path produced the strongest claim.
+This is the classic widest-path (bottleneck shortest-path) problem: a
+node's confidence for an effect is `max` over every path to a node that has
+that effect directly, of the `min` edge confidence along that path. Rather
+than search per-path, it is solved level-wise: for each confidence tier,
+strongest first (`HIGH`, then `MEDIUM`, then `LOW`), build the subgraph of
+`CALLS` edges at that tier or better, and find every node that can reach an
+effect-bearing node within it via plain reachability -- multi-source BFS on
+the reversed graph, starting from the effect-bearing nodes. The first
+(strongest) tier at which a node reaches an effect wins; a weaker tier
+never overwrites it.
 
-`witness_path` is a separate, on-demand BFS over the (uncondensed) `CALLS`
-graph, used at query time. BFS never revisits a node, so cycles are handled
-for free there and it needs no SCC step of its own. It is confidence-aware:
-`propagate` reports the *best* confidence over every path (the aggregate
-claim "this effect is reachable, at the strongest confidence any path
-supports"), so the witness search is restricted to edges strong enough to
-support that same confidence -- otherwise the printed chain could be a
-weak, unrelated path to a claim it does not actually justify.
+Plain reachability handles cycles for free -- a visited set is all it
+takes -- so mutual recursion (`ping` calls `pong` calls `ping` ...) needs
+no special handling; `test_recursion_cycle_does_not_hang` passes without
+any SCC step. An earlier version of this module condensed strongly
+connected components with Tarjan and unioned effects across each
+component, but that scheme could hand out a confidence no real path
+supported: it merged a component member's direct effect into the whole
+component's set without accounting for the edge confidence needed to
+*reach* that member from elsewhere in the cycle. Concretely: `A --LOW-->
+B`, `B --HIGH--> A`, `B` has a direct HIGH effect -- the old code merged
+B's HIGH straight into the shared `{A, B}` union, reporting HIGH for A even
+though the only way out of A is the LOW edge. Level-wise reachability does
+not have that failure mode, because the tier a node's confidence is
+assigned at is exactly the subgraph a path was found to exist in -- there
+is no condensation step to smuggle a stronger neighbor's confidence past
+the weak edge needed to reach it.
+
+`witness_path` reconstructs that path on demand at query time: a forward
+BFS from the queried node, restricted to `CALLS` edges at the reported
+confidence or better. Because `propagate` only ever assigns a confidence
+for which such a path exists, this BFS is total -- it cannot come back
+empty for a `(node_id, kind, confidence)` triple `propagate` actually
+produced.
 
 This module never queries the effect `Catalog`: it only reads `effects`
-rows Task 10's `detect_direct` already wrote, and `edges`.
+rows `detect_direct` already wrote, and `edges`.
 """
 
 from __future__ import annotations
 
 from collections import deque
-from collections.abc import Iterator
 
 from codegraph.resolve import HIGH, LOW, MEDIUM
 from codegraph.store import Store
 
+#: Strongest first: the order `propagate` walks tiers in, since the first
+#: (strongest) tier at which a node reaches an effect is the one that wins.
+_TIERS = (HIGH, MEDIUM, LOW)
 _RANK = {LOW: 0, MEDIUM: 1, HIGH: 2}
-
-
-def _weaker(a: str, b: str) -> str:
-    return a if _RANK[a] <= _RANK[b] else b
 
 
 def _stronger(a: str, b: str) -> str:
@@ -49,7 +65,7 @@ def propagate(store: Store, rev: str) -> int:
     connection.execute("DELETE FROM effects WHERE rev=? AND direct=0", (rev,))
 
     node_ids = {row["id"] for row in connection.execute("SELECT id FROM nodes WHERE rev=?", (rev,))}
-    calls: dict[str, set[str]] = {node_id: set() for node_id in node_ids}
+
     edge_confidence: dict[tuple[str, str], str] = {}
     for row in connection.execute(
         "SELECT src, dst, confidence FROM edges WHERE rev=? AND kind='CALLS'", (rev,)
@@ -57,65 +73,45 @@ def propagate(store: Store, rev: str) -> int:
         src, dst, confidence = row["src"], row["dst"], row["confidence"]
         if src not in node_ids or dst not in node_ids:
             continue
-        calls[src].add(dst)
         key = (src, dst)
         edge_confidence[key] = _stronger(edge_confidence.get(key, confidence), confidence)
 
+    # reverse_by_tier[tier][dst] = every src with an edge src->dst whose
+    # confidence is at least `tier`. These are nested supersets as the tier
+    # weakens: the HIGH subgraph is a subset of MEDIUM-or-better, which is a
+    # subset of LOW-or-better (everything).
+    reverse_by_tier: dict[str, dict[str, set[str]]] = {tier: {} for tier in _TIERS}
+    for (src, dst), confidence in edge_confidence.items():
+        rank = _RANK[confidence]
+        for tier in _TIERS:
+            if _RANK[tier] <= rank:
+                reverse_by_tier[tier].setdefault(dst, set()).add(src)
+
     direct_by_node: dict[str, dict[str, str]] = {}
+    direct_nodes_by_kind: dict[str, set[str]] = {}
     for row in connection.execute(
         "SELECT node_id, kind, confidence FROM effects WHERE rev=? AND direct=1", (rev,)
     ):
-        bucket = direct_by_node.setdefault(row["node_id"], {})
-        bucket[row["kind"]] = _stronger(
-            bucket.get(row["kind"], row["confidence"]), row["confidence"]
-        )
+        direct_by_node.setdefault(row["node_id"], {})[row["kind"]] = row["confidence"]
+        direct_nodes_by_kind.setdefault(row["kind"], set()).add(row["node_id"])
 
-    components, comp_of = _tarjan_scc(node_ids, calls)
-
-    comp_direct: dict[int, dict[str, str]] = {}
-    for node_id, node_kinds in direct_by_node.items():
-        comp = comp_of.get(node_id)
-        if comp is None:
-            continue
-        bucket = comp_direct.setdefault(comp, {})
-        for kind, confidence in node_kinds.items():
-            bucket[kind] = _stronger(bucket.get(kind, confidence), confidence)
-
-    comp_edges: dict[int, dict[int, str]] = {}
-    for (src, dst), confidence in edge_confidence.items():
-        c_src, c_dst = comp_of[src], comp_of[dst]
-        if c_src == c_dst:
-            continue
-        bucket = comp_edges.setdefault(c_src, {})
-        bucket[c_dst] = _stronger(bucket.get(c_dst, confidence), confidence)
-
-    # The condensation is a DAG (Tarjan guarantees no cycles between
-    # distinct components), so a plain memoized recursion terminates.
-    cache: dict[int, dict[str, str]] = {}
-
-    def comp_effects(comp: int) -> dict[str, str]:
-        if comp in cache:
-            return cache[comp]
-        result = dict(comp_direct.get(comp, {}))
-        for succ, edge_conf in comp_edges.get(comp, {}).items():
-            for kind, confidence in comp_effects(succ).items():
-                propagated = _weaker(edge_conf, confidence)
-                if kind not in result or _RANK[propagated] > _RANK[result[kind]]:
-                    result[kind] = propagated
-        cache[comp] = result
-        return result
+    # node_confidence[node][kind] = the strongest tier at which `node` can
+    # reach some node that carries `kind` directly.
+    node_confidence: dict[str, dict[str, str]] = {}
+    for tier in _TIERS:
+        adjacency = reverse_by_tier[tier]
+        for kind, sources in direct_nodes_by_kind.items():
+            for node_id in _reverse_reachable(sources, adjacency):
+                bucket = node_confidence.setdefault(node_id, {})
+                bucket.setdefault(kind, tier)
 
     rows: list[tuple] = []
-    for comp_index in range(len(components)):
-        effects_here = comp_effects(comp_index)
-        if not effects_here:
-            continue
-        for node_id in components[comp_index]:
-            own_direct = direct_by_node.get(node_id, {})
-            for kind, confidence in effects_here.items():
-                if kind in own_direct:
-                    continue
-                rows.append((rev, node_id, kind, 0, None, None, confidence))
+    for node_id, kinds in node_confidence.items():
+        own_direct = direct_by_node.get(node_id, {})
+        for kind, confidence in kinds.items():
+            if kind in own_direct:
+                continue
+            rows.append((rev, node_id, kind, 0, None, None, confidence))
 
     connection.executemany(
         "INSERT INTO effects(rev, node_id, kind, direct, evidence_path, evidence_line,"
@@ -125,76 +121,32 @@ def propagate(store: Store, rev: str) -> int:
     return len(rows)
 
 
-def _tarjan_scc(
-    nodes: set[str], adjacency: dict[str, set[str]]
-) -> tuple[list[list[str]], dict[str, int]]:
-    """Tarjan's strongly-connected-components algorithm, iterative so a deep
-    call graph can't blow the interpreter's recursion limit."""
-    index_of: dict[str, int] = {}
-    lowlink: dict[str, int] = {}
-    on_stack: set[str] = set()
-    stack: list[str] = []
-    components: list[list[str]] = []
-    counter = 0
-
-    def strongconnect(root: str) -> None:
-        nonlocal counter
-        work: list[tuple[str, Iterator[str]]] = [(root, iter(adjacency.get(root, ())))]
-        index_of[root] = counter
-        lowlink[root] = counter
-        counter += 1
-        stack.append(root)
-        on_stack.add(root)
-
-        while work:
-            v, neighbors = work[-1]
-            advanced = False
-            for w in neighbors:
-                if w not in index_of:
-                    index_of[w] = counter
-                    lowlink[w] = counter
-                    counter += 1
-                    stack.append(w)
-                    on_stack.add(w)
-                    work.append((w, iter(adjacency.get(w, ()))))
-                    advanced = True
-                    break
-                if w in on_stack:
-                    lowlink[v] = min(lowlink[v], index_of[w])
-            if advanced:
-                continue
-
-            work.pop()
-            if work:
-                parent = work[-1][0]
-                lowlink[parent] = min(lowlink[parent], lowlink[v])
-            if lowlink[v] == index_of[v]:
-                component = []
-                while True:
-                    w = stack.pop()
-                    on_stack.discard(w)
-                    component.append(w)
-                    if w == v:
-                        break
-                components.append(component)
-
-    for node in nodes:
-        if node not in index_of:
-            strongconnect(node)
-
-    comp_of = {node_id: i for i, component in enumerate(components) for node_id in component}
-    return components, comp_of
+def _reverse_reachable(sources: set[str], adjacency: dict[str, set[str]]) -> set[str]:
+    """Every node that can reach some node in `sources` via the forward
+    edges `adjacency` encodes in reverse (`adjacency[dst]` is every direct
+    predecessor of `dst`). Multi-source BFS on the reverse graph; a plain
+    visited set makes this correct in the presence of cycles without any
+    extra bookkeeping."""
+    visited = set(sources)
+    queue: deque[str] = deque(sources)
+    while queue:
+        current = queue.popleft()
+        for predecessor in adjacency.get(current, ()):
+            if predecessor not in visited:
+                visited.add(predecessor)
+                queue.append(predecessor)
+    return visited
 
 
 def witness_path(store: Store, rev: str, node_id: str, kind: str, confidence: str) -> list[str]:
     """Fewest-hop chain of node ids from `node_id` to a node whose direct
     effect of `kind` causes it, restricted to `CALLS` edges strong enough
-    to support `confidence` -- the aggregate value `propagate` already
-    computed as the best achievable across every path. Every edge on the
-    chain has confidence >= `confidence`, so the chain's own bottleneck
-    confidence is never weaker than the number printed next to it. `[]` if
-    no such chain exists (should not happen for a `(node_id, kind)` pair
-    `propagate` actually produced this confidence for)."""
+    to support `confidence` -- the value `propagate` already computed as
+    the strongest tier at which `node_id` can reach an effect of this
+    kind. Every edge on the chain has confidence >= `confidence`, so the
+    chain's own bottleneck confidence is never weaker than the number
+    printed next to it. `[]` if no such chain exists (should not happen
+    for a `(node_id, kind, confidence)` triple `propagate` produced)."""
     connection = store.connection
     direct_nodes = {
         row["node_id"]

--- a/src/codegraph/effects/propagate.py
+++ b/src/codegraph/effects/propagate.py
@@ -12,7 +12,12 @@ minimum along whichever concrete edge/path produced the strongest claim.
 
 `witness_path` is a separate, on-demand BFS over the (uncondensed) `CALLS`
 graph, used at query time. BFS never revisits a node, so cycles are handled
-for free there and it needs no SCC step of its own.
+for free there and it needs no SCC step of its own. It is confidence-aware:
+`propagate` reports the *best* confidence over every path (the aggregate
+claim "this effect is reachable, at the strongest confidence any path
+supports"), so the witness search is restricted to edges strong enough to
+support that same confidence -- otherwise the printed chain could be a
+weak, unrelated path to a claim it does not actually justify.
 
 This module never queries the effect `Catalog`: it only reads `effects`
 rows Task 10's `detect_direct` already wrote, and `edges`.
@@ -181,9 +186,15 @@ def _tarjan_scc(
     return components, comp_of
 
 
-def witness_path(store: Store, rev: str, node_id: str, kind: str) -> list[str]:
-    """Shortest chain of node ids from `node_id` to a node whose direct
-    effect of `kind` causes it, via `CALLS` edges. `[]` if none exists."""
+def witness_path(store: Store, rev: str, node_id: str, kind: str, confidence: str) -> list[str]:
+    """Fewest-hop chain of node ids from `node_id` to a node whose direct
+    effect of `kind` causes it, restricted to `CALLS` edges strong enough
+    to support `confidence` -- the aggregate value `propagate` already
+    computed as the best achievable across every path. Every edge on the
+    chain has confidence >= `confidence`, so the chain's own bottleneck
+    confidence is never weaker than the number printed next to it. `[]` if
+    no such chain exists (should not happen for a `(node_id, kind)` pair
+    `propagate` actually produced this confidence for)."""
     connection = store.connection
     direct_nodes = {
         row["node_id"]
@@ -195,11 +206,21 @@ def witness_path(store: Store, rev: str, node_id: str, kind: str) -> list[str]:
     if node_id in direct_nodes:
         return [node_id]
 
-    calls: dict[str, list[str]] = {}
+    target_rank = _RANK[confidence]
+    edge_confidence: dict[tuple[str, str], str] = {}
     for row in connection.execute(
-        "SELECT DISTINCT src, dst FROM edges WHERE rev=? AND kind='CALLS'", (rev,)
+        "SELECT src, dst, confidence FROM edges WHERE rev=? AND kind='CALLS'", (rev,)
     ):
-        calls.setdefault(row["src"], []).append(row["dst"])
+        key = (row["src"], row["dst"])
+        edge_confidence[key] = _stronger(
+            edge_confidence.get(key, row["confidence"]), row["confidence"]
+        )
+
+    calls: dict[str, list[str]] = {}
+    for (src, dst), conf in edge_confidence.items():
+        if _RANK[conf] < target_rank:
+            continue
+        calls.setdefault(src, []).append(dst)
 
     visited = {node_id}
     parent: dict[str, str] = {}

--- a/src/codegraph/effects/propagate.py
+++ b/src/codegraph/effects/propagate.py
@@ -4,14 +4,20 @@ for one revision.
 
 This is the classic widest-path (bottleneck shortest-path) problem: a
 node's confidence for an effect is `max` over every path to a node that has
-that effect directly, of the `min` edge confidence along that path. Rather
-than search per-path, it is solved level-wise: for each confidence tier,
-strongest first (`HIGH`, then `MEDIUM`, then `LOW`), build the subgraph of
-`CALLS` edges at that tier or better, and find every node that can reach an
-effect-bearing node within it via plain reachability -- multi-source BFS on
-the reversed graph, starting from the effect-bearing nodes. The first
-(strongest) tier at which a node reaches an effect wins; a weaker tier
-never overwrites it.
+that effect directly, of the `min` confidence along that path -- and the
+direct effect's OWN recorded confidence is itself one link in that chain,
+not just the CALLS edges leading to it. A bare-wildcard-head catalog match
+(`*.execute`) is LOW at the node that directly makes it; a caller reaching
+that node only over HIGH edges still only earns LOW, because the weakest
+link in its path is the direct detection itself. Rather than search
+per-path, it is solved level-wise: for each confidence tier, strongest
+first (`HIGH`, then `MEDIUM`, then `LOW`), build the subgraph of `CALLS`
+edges at that tier or better, and find every node that can reach a node
+that carries the effect directly **at that tier or better** within it via
+plain reachability -- multi-source BFS on the reversed graph, starting
+from only the effect-bearing nodes whose own direct confidence clears the
+tier being tried. The first (strongest) tier at which a node reaches an
+eligible effect wins; a weaker tier never overwrites it.
 
 Plain reachability handles cycles for free -- a visited set is all it
 takes -- so mutual recursion (`ping` calls `pong` calls `ping` ...) needs
@@ -32,10 +38,15 @@ the weak edge needed to reach it.
 
 `witness_path` reconstructs that path on demand at query time: a forward
 BFS from the queried node, restricted to `CALLS` edges at the reported
-confidence or better. Because `propagate` only ever assigns a confidence
-for which such a path exists, this BFS is total -- it cannot come back
-empty for a `(node_id, kind, confidence)` triple `propagate` actually
-produced.
+confidence or better, that only accepts a direct-effect node as the chain's
+end if ITS OWN confidence also clears that same tier -- the identical
+eligibility test `propagate` used to assign the confidence in the first
+place. Because `propagate` only ever assigns a confidence for which such a
+path exists (edges AND direct effect both at or above that tier), this BFS
+stays total -- it cannot come back empty for a `(node_id, kind,
+confidence)` triple `propagate` actually produced. Total-by-construction
+depends on this: the graph a confidence was derived from and the graph the
+witness BFS traverses must stay identical, tier-eligibility rule included.
 
 This module never queries the effect `Catalog`: it only reads `effects`
 rows `detect_direct` already wrote, and `edges`.
@@ -45,17 +56,13 @@ from __future__ import annotations
 
 from collections import deque
 
-from codegraph.resolve import HIGH, LOW, MEDIUM
+from codegraph.resolve import CONFIDENCE_RANK, HIGH, LOW, MEDIUM, stronger
 from codegraph.store import Store
 
 #: Strongest first: the order `propagate` walks tiers in, since the first
 #: (strongest) tier at which a node reaches an effect is the one that wins.
 _TIERS = (HIGH, MEDIUM, LOW)
-_RANK = {LOW: 0, MEDIUM: 1, HIGH: 2}
-
-
-def _stronger(a: str, b: str) -> str:
-    return a if _RANK[a] >= _RANK[b] else b
+_RANK = CONFIDENCE_RANK
 
 
 def propagate(store: Store, rev: str) -> int:
@@ -74,7 +81,7 @@ def propagate(store: Store, rev: str) -> int:
         if src not in node_ids or dst not in node_ids:
             continue
         key = (src, dst)
-        edge_confidence[key] = _stronger(edge_confidence.get(key, confidence), confidence)
+        edge_confidence[key] = stronger(edge_confidence.get(key, confidence), confidence)
 
     # reverse_by_tier[tier][dst] = every src with an edge src->dst whose
     # confidence is at least `tier`. These are nested supersets as the tier
@@ -96,12 +103,26 @@ def propagate(store: Store, rev: str) -> int:
         direct_nodes_by_kind.setdefault(row["kind"], set()).add(row["node_id"])
 
     # node_confidence[node][kind] = the strongest tier at which `node` can
-    # reach some node that carries `kind` directly.
+    # reach some node that carries `kind` directly, bounded by BOTH the
+    # edges on the path AND that direct effect's own recorded confidence --
+    # the weakest link in the whole chain, not just the CALLS-edge portion
+    # of it. At tier T, a direct-effect node only counts as a valid
+    # endpoint if its own confidence for `kind` is >= T: a HIGH chain of
+    # edges into a LOW-confidence direct effect (e.g. a bare-wildcard-head
+    # catalog match) must not report HIGH just because the edges were
+    # strong -- the direct detection itself is the weak link there. At the
+    # weakest tier (LOW), every direct node is eligible regardless of its
+    # own confidence, so this is a strict narrowing of the old
+    # edge-only behavior, never a loss of reachability.
     node_confidence: dict[str, dict[str, str]] = {}
     for tier in _TIERS:
         adjacency = reverse_by_tier[tier]
+        tier_rank = _RANK[tier]
         for kind, sources in direct_nodes_by_kind.items():
-            for node_id in _reverse_reachable(sources, adjacency):
+            eligible = {s for s in sources if _RANK[direct_by_node[s][kind]] >= tier_rank}
+            if not eligible:
+                continue
+            for node_id in _reverse_reachable(eligible, adjacency):
                 bucket = node_confidence.setdefault(node_id, {})
                 bucket.setdefault(kind, tier)
 
@@ -143,28 +164,37 @@ def witness_path(store: Store, rev: str, node_id: str, kind: str, confidence: st
     effect of `kind` causes it, restricted to `CALLS` edges strong enough
     to support `confidence` -- the value `propagate` already computed as
     the strongest tier at which `node_id` can reach an effect of this
-    kind. Every edge on the chain has confidence >= `confidence`, so the
-    chain's own bottleneck confidence is never weaker than the number
-    printed next to it. `[]` if no such chain exists (should not happen
-    for a `(node_id, kind, confidence)` triple `propagate` produced)."""
+    kind. Every edge on the chain has confidence >= `confidence`, AND the
+    direct effect at the chain's end has its own confidence >= `confidence`
+    too, so the chain's own bottleneck -- including the direct detection at
+    the end of it, not just the edges leading there -- is never weaker than
+    the number printed next to it. `[]` if no such chain exists (should not
+    happen for a `(node_id, kind, confidence)` triple `propagate`
+    produced)."""
     connection = store.connection
-    direct_nodes = {
-        row["node_id"]
-        for row in connection.execute(
-            "SELECT DISTINCT node_id FROM effects WHERE rev=? AND kind=? AND direct=1",
-            (rev, kind),
+    direct_confidence: dict[str, str] = {}
+    for row in connection.execute(
+        "SELECT node_id, confidence FROM effects WHERE rev=? AND kind=? AND direct=1",
+        (rev, kind),
+    ):
+        direct_confidence[row["node_id"]] = stronger(
+            direct_confidence.get(row["node_id"], row["confidence"]), row["confidence"]
         )
-    }
-    if node_id in direct_nodes:
+    if node_id in direct_confidence:
         return [node_id]
 
     target_rank = _RANK[confidence]
+    # A direct-effect node only counts as a valid witness endpoint if its
+    # OWN confidence for `kind` is >= `confidence` -- the same eligibility
+    # test `propagate` applied when it assigned this confidence, so this
+    # BFS stays total for every triple `propagate` can actually produce.
+    direct_nodes = {n for n, c in direct_confidence.items() if _RANK[c] >= target_rank}
     edge_confidence: dict[tuple[str, str], str] = {}
     for row in connection.execute(
         "SELECT src, dst, confidence FROM edges WHERE rev=? AND kind='CALLS'", (rev,)
     ):
         key = (row["src"], row["dst"])
-        edge_confidence[key] = _stronger(
+        edge_confidence[key] = stronger(
             edge_confidence.get(key, row["confidence"]), row["confidence"]
         )
 

--- a/src/codegraph/effects/propagate.py
+++ b/src/codegraph/effects/propagate.py
@@ -99,7 +99,18 @@ def propagate(store: Store, rev: str) -> int:
     for row in connection.execute(
         "SELECT node_id, kind, confidence FROM effects WHERE rev=? AND direct=1", (rev,)
     ):
-        direct_by_node.setdefault(row["node_id"], {})[row["kind"]] = row["confidence"]
+        # A node can carry more than one direct=1 row for the same
+        # (node_id, kind) -- `effects` has no UNIQUE constraint and
+        # `detect_direct` writes one row per call site, so two calls in
+        # one function (e.g. one `open()` with a literal mode, one with a
+        # variable mode) are enough to produce it. Reduce with `stronger()`
+        # rather than letting SQL scan order pick whichever row happens to
+        # come back last -- this must match `witness_path`'s own
+        # `direct_confidence` reduction (below) exactly, since the graph a
+        # confidence is derived from and the graph the witness BFS
+        # traverses have to stay identical for the BFS to stay total.
+        bucket = direct_by_node.setdefault(row["node_id"], {})
+        bucket[row["kind"]] = stronger(bucket.get(row["kind"], row["confidence"]), row["confidence"])
         direct_nodes_by_kind.setdefault(row["kind"], set()).add(row["node_id"])
 
     # node_confidence[node][kind] = the strongest tier at which `node` can

--- a/src/codegraph/gitio.py
+++ b/src/codegraph/gitio.py
@@ -40,7 +40,14 @@ def ls_tree(root: Path, rev: str) -> dict[str, str]:
     parsing its `<mode> SP <type> SP <sha> TAB <path>` shape is a small
     price for that guarantee.
     """
-    out = _run(root, "ls-tree", "-r", "-z", rev)
+    # `--end-of-options` (verified against a scratch repo, git 2.43): a
+    # `rev` that happens to start with `-` (a maliciously or accidentally
+    # named branch/tag, or a bad `--rev` value threaded through from the
+    # CLI) would otherwise be parsed as an `ls-tree` OPTION rather than the
+    # tree-ish it is. Inert today -- callers only ever pass `HEAD`,
+    # `WORKTREE`, or a value already validated by `_resolve`/`rev_parse` --
+    # but live the moment that stops being true.
+    out = _run(root, "ls-tree", "-r", "-z", "--end-of-options", rev)
     tree: dict[str, str] = {}
     for entry in out.split(b"\0"):
         if not entry:
@@ -167,11 +174,22 @@ def hash_object(root: Path, data: bytes) -> str:
 
 
 def rev_parse(root: Path, rev: str) -> str:
-    return _run(root, "rev-parse", rev).decode().strip()
+    # `--end-of-options` guards `rev` the same way `ls_tree` guards its
+    # `rev` (see there for why); `--verify` is paired with it on git's own
+    # recommendation (`git rev-parse --help`, "SPECIFYING REVISIONS": `git
+    # rev-parse --verify --end-of-options $REV`) -- `rev-parse` alone
+    # doesn't just resolve-or-error for a single revision, it "massages"
+    # each argument (which can echo one back verbatim rather than
+    # resolving it), so `--end-of-options` alone changes what this
+    # function returns; `--verify` restores the original single-sha-or-
+    # error shape every caller here relies on.
+    return _run(root, "rev-parse", "--verify", "--end-of-options", rev).decode().strip()
 
 
 def merge_base(root: Path, a: str, b: str) -> str:
-    return _run(root, "merge-base", a, b).decode().strip()
+    # Same `--end-of-options` guard as `ls_tree`/`rev_parse`, for the same
+    # reason: `a`/`b` can be user-controlled revs.
+    return _run(root, "merge-base", "--end-of-options", a, b).decode().strip()
 
 
 def default_branch(root: Path) -> str:

--- a/src/codegraph/gitio.py
+++ b/src/codegraph/gitio.py
@@ -29,14 +29,28 @@ def is_repo(root: Path) -> bool:
 
 
 def ls_tree(root: Path, rev: str) -> dict[str, str]:
-    out = _run(root, "ls-tree", "-r", "-z", "--format=%(objectname) %(path)", rev)
+    """`-r -z` with NO `--format`: the `%(path)` atom quotes a path (any
+    non-ASCII byte, or a literal `"`/`\\`) even under `-z`, honoring
+    `core.quotePath` for the non-ASCII case and quoting unconditionally for
+    the disambiguation-needed characters regardless of that setting -- so a
+    file like `ünïcode.py` comes back C-quoted (`"...\\303\\274n..."`), fails
+    `.endswith(".py")`, and silently drops out of the tree. Plain `ls-tree`
+    output (no `--format`) genuinely never quotes under `-z`, verified
+    against non-ASCII, space, embedded-quote and embedded-backslash paths;
+    parsing its `<mode> SP <type> SP <sha> TAB <path>` shape is a small
+    price for that guarantee.
+    """
+    out = _run(root, "ls-tree", "-r", "-z", rev)
     tree: dict[str, str] = {}
     for entry in out.split(b"\0"):
         if not entry:
             continue
-        sha, _, path = entry.decode().partition(" ")
-        if path.endswith(".py"):
-            tree[path] = sha
+        meta, _, path_bytes = entry.partition(b"\t")
+        path = path_bytes.decode()
+        if not path.endswith(".py"):
+            continue
+        sha = meta.split(b" ")[2].decode()
+        tree[path] = sha
     return tree
 
 

--- a/src/codegraph/indexer.py
+++ b/src/codegraph/indexer.py
@@ -143,7 +143,9 @@ class Indexer:
         # One transaction for the whole reconcile: Layer 1 fill-in and the
         # Layer 2 rewrite either both land or neither does.
         with connection:
-            parsed, cached, errors = self._ensure_parsed(set(tree.values()))
+            blob_shas = set(tree.values())
+            parsed, cached = self._ensure_parsed(blob_shas)
+            errors = self._error_count(blob_shas)
 
             connection.execute("DELETE FROM tree WHERE rev=?", (rev,))
             connection.executemany(
@@ -181,9 +183,9 @@ class Indexer:
             unresolved=resolved.unresolved,
         )
 
-    def _ensure_parsed(self, shas: set[str]) -> tuple[int, int, int]:
+    def _ensure_parsed(self, shas: set[str]) -> tuple[int, int]:
         """Fill Layer 1 for any sha not already parsed at the current parser
-        version. Returns (blobs_parsed, blobs_cached, parse_errors)."""
+        version. Returns (blobs_parsed, blobs_cached)."""
         connection = self.store.connection
         known = {
             row["blob_sha"]
@@ -192,11 +194,9 @@ class Indexer:
             )
         }
         missing = sorted(shas - known)
-        errors = 0
 
         for sha, data in self.source.read(missing):
             result = parse_blob(data)
-            errors += int(result.error is not None)
             connection.execute(
                 "INSERT OR REPLACE INTO blobs(blob_sha, status, error, parser_version,"
                 " module_body_hash) VALUES(?, ?, ?, ?, ?)",
@@ -243,7 +243,33 @@ class Indexer:
                 [(sha, i.ordinal, i.module, i.level, i.name, i.alias) for i in result.imports],
             )
 
-        return len(missing), len(shas) - len(missing), errors
+        return len(missing), len(shas) - len(missing)
+
+    def _error_count(self, shas: set[str]) -> int:
+        """Count of `shas` (the current revision's own blobs) whose Layer 1
+        parse is recorded as an error, regardless of whether that parse ran
+        this pass or an earlier one.
+
+        `_ensure_parsed` only fills in blobs Layer 1 hasn't seen yet, so
+        counting errors only over blobs parsed THIS pass (the old approach)
+        made `parse_errors` report correctly on the first run and then
+        silently vanish on every later run, since a broken file's blob is
+        cached (status='error') after run 1 and never re-parsed -- while the
+        file stays exactly as broken and excluded from the graph. Re-reading
+        the `blobs` table for the revision's current tree, instead of
+        trusting this pass's own counter, makes the number reflect reality
+        regardless of cache state.
+        """
+        if not shas:
+            return 0
+        connection = self.store.connection
+        placeholders = ",".join("?" * len(shas))
+        row = connection.execute(
+            f"SELECT COUNT(*) AS n FROM blobs WHERE status='error' AND blob_sha IN"
+            f" ({placeholders})",
+            tuple(shas),
+        ).fetchone()
+        return row["n"]
 
     def _materialize_nodes(self, rev: str, tree: dict[str, str]) -> int:
         """Rebuild Layer 2's `nodes` rows for `rev` from Layer 1, and return

--- a/src/codegraph/indexer.py
+++ b/src/codegraph/indexer.py
@@ -167,7 +167,7 @@ class Indexer:
             # transaction: a revision is never visible with edges but
             # stale (or missing) effects.
             catalog = Catalog.load(self.config)
-            detect_direct(self.store, rev, catalog)
+            detect_direct(self.store, rev, catalog, self.config)
             propagate(self.store, rev)
 
         return IndexStats(

--- a/src/codegraph/indexer.py
+++ b/src/codegraph/indexer.py
@@ -18,6 +18,9 @@ from typing import Protocol
 
 from codegraph import gitio
 from codegraph.config import Config
+from codegraph.effects.catalog import Catalog
+from codegraph.effects.detect import detect_direct
+from codegraph.effects.propagate import propagate
 from codegraph.parse import PARSER_VERSION, parse_blob
 from codegraph.resolve import MODULE_SCOPE, resolve_revision
 from codegraph.store import WORKTREE, Store
@@ -159,6 +162,13 @@ class Indexer:
             # Phase 2 runs inside the same transaction: a revision is never
             # visible with materialized nodes but stale edges.
             resolved = resolve_revision(self.store, rev, self.config)
+
+            # Effect detection and propagation close out the same
+            # transaction: a revision is never visible with edges but
+            # stale (or missing) effects.
+            catalog = Catalog.load(self.config)
+            detect_direct(self.store, rev, catalog)
+            propagate(self.store, rev)
 
         return IndexStats(
             paths_total=len(tree),

--- a/src/codegraph/indexer.py
+++ b/src/codegraph/indexer.py
@@ -198,9 +198,15 @@ class Indexer:
             result = parse_blob(data)
             errors += int(result.error is not None)
             connection.execute(
-                "INSERT OR REPLACE INTO blobs(blob_sha, status, error, parser_version) "
-                "VALUES(?, ?, ?, ?)",
-                (sha, "error" if result.error else "ok", result.error, PARSER_VERSION),
+                "INSERT OR REPLACE INTO blobs(blob_sha, status, error, parser_version,"
+                " module_body_hash) VALUES(?, ?, ?, ?, ?)",
+                (
+                    sha,
+                    "error" if result.error else "ok",
+                    result.error,
+                    PARSER_VERSION,
+                    result.module_body_hash,
+                ),
             )
             connection.executemany(
                 "INSERT OR REPLACE INTO blob_nodes(blob_sha, ordinal, qualname, kind,"
@@ -246,13 +252,30 @@ class Indexer:
         Every path also gets a synthetic module node (`path::<module>`), so
         that a module-scope call's edge `src` — an import-time side effect
         like `app = create_app()` — has a real row in `nodes` rather than a
-        dangling id. Its `body_hash` is the path's blob sha: a file-changed
-        signal, not a symbol-changed one, since no per-symbol hash exists at
-        module scope. Its span is a placeholder (`1..1`): the file's true
-        last line isn't available from Layer 1's parsed tables without
-        re-reading blob content, and nothing downstream depends on it yet.
+        dangling id. Its `body_hash` is `parse.py`'s `module_body_hash`: a
+        structural hash of the module's top-level statements with nested
+        def/class bodies elided, computed once per blob and cached on the
+        `blobs` row alongside it -- whitespace-insensitive like every other
+        `body_hash`, but still sensitive to a module-scope statement (an
+        import, a top-level call) changing. Falls back to the blob sha
+        itself when a blob has no cached hash (a parse error leaves it
+        empty), so a broken file's module node still changes identity
+        when its content does. Its span is a placeholder (`1..1`): the
+        file's true last line isn't available from Layer 1's parsed
+        tables without re-reading blob content, and nothing downstream
+        depends on it yet.
         """
         connection = self.store.connection
+        module_hashes: dict[str, str] = {}
+        shas = set(tree.values())
+        if shas:
+            placeholders = ",".join("?" * len(shas))
+            for row in connection.execute(
+                f"SELECT blob_sha, module_body_hash FROM blobs WHERE blob_sha IN ({placeholders})",
+                tuple(shas),
+            ):
+                module_hashes[row["blob_sha"]] = row["module_body_hash"]
+
         shadowed = 0
         rows: list[tuple] = []
         for path, sha in tree.items():
@@ -284,7 +307,7 @@ class Indexer:
                     "module",
                     1,
                     1,
-                    sha,
+                    module_hashes.get(sha) or sha,
                     "live",
                 )
             )

--- a/src/codegraph/indexer.py
+++ b/src/codegraph/indexer.py
@@ -36,6 +36,7 @@ class IndexStats:
     shadowed: int = 0
     edges: int = 0
     unresolved: int = 0
+    ambiguous: int = 0
 
 
 class TreeSource(Protocol):
@@ -181,6 +182,7 @@ class Indexer:
             shadowed=shadowed,
             edges=resolved.edges,
             unresolved=resolved.unresolved,
+            ambiguous=resolved.ambiguous,
         )
 
     def _ensure_parsed(self, shas: set[str]) -> tuple[int, int]:

--- a/src/codegraph/maintenance.py
+++ b/src/codegraph/maintenance.py
@@ -11,6 +11,7 @@ hook never fires, or `gc` is never run, results are byte-identical.
 from __future__ import annotations
 
 import stat
+from dataclasses import dataclass
 from pathlib import Path
 
 from codegraph.store import Store
@@ -34,6 +35,12 @@ _HOOK_BLOCK = f"""{_BEGIN_MARKER}
 ( cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" && codegraph index --quiet >/dev/null 2>&1 & ) >/dev/null 2>&1 || true
 {_END_MARKER}
 """
+
+# Splicing shell syntax into a script written for a different interpreter
+# corrupts it outright (a Perl or Python hook fails to even parse). This is
+# the allowlist of interpreters `_HOOK_BLOCK`'s POSIX-shell syntax is safe
+# to land inside; anything else is left completely untouched.
+_SHELL_INTERPRETERS = {"sh", "bash", "dash", "ash", "ksh", "zsh"}
 
 
 def _chunks(items: list[str], size: int) -> list[list[str]]:
@@ -105,6 +112,43 @@ def _hooks_dir(root: Path) -> Path:
     raise FileNotFoundError(f"not a git repository: {root}")
 
 
+def _shebang_interpreter(shebang_line: str) -> str:
+    """The interpreter name a `#!...` line claims, resolving
+    `#!/usr/bin/env <interp> [flags]` to `<interp>` the same as
+    `#!/path/to/<interp> [flags]`. Empty string if the line names nothing
+    (a bare `#!`)."""
+    tokens = shebang_line[2:].split()
+    if not tokens:
+        return ""
+    name = Path(tokens[0]).name
+    if name == "env" and len(tokens) > 1:
+        name = Path(tokens[1]).name
+    return name
+
+
+def _is_shell_shebang(shebang_line: str) -> bool:
+    return _shebang_interpreter(shebang_line) in _SHELL_INTERPRETERS
+
+
+def _strip_existing_block(text: str) -> str:
+    """Remove a previously-installed codegraph block, wherever it sits and
+    whatever its interior looks like (this repairs a stale block from an
+    older version of `install_hooks` -- e.g. one still doing `$?`
+    preservation, or one appended at the end after a pre-existing `exit` --
+    just as readily as a current one). A malformed/truncated marker pair
+    (no matching end) is left alone rather than guessed at."""
+    start = text.find(_BEGIN_MARKER)
+    if start == -1:
+        return text
+    end = text.find(_END_MARKER, start)
+    if end == -1:
+        return text
+    end += len(_END_MARKER)
+    tail = text[end:]
+    tail = tail.removeprefix("\n")
+    return text[:start] + tail
+
+
 def _insert_after_shebang(existing: str) -> str:
     """Splice `_HOOK_BLOCK` in as the first statement of the script, right
     after its shebang line so it always runs -- before any pre-existing
@@ -120,30 +164,76 @@ def _insert_after_shebang(existing: str) -> str:
     return "#!/bin/sh\n" + _HOOK_BLOCK + existing
 
 
-def install_hooks(root: Path) -> list[Path]:
-    """Write (or extend) `post-commit`, `post-checkout`, and `post-merge`
-    hooks that warm the codegraph cache in the background.
+@dataclass(frozen=True)
+class HookResult:
+    """One hook's outcome: installed (written or repaired), or skipped with
+    a human-readable reason."""
 
-    Idempotent: re-running never double-appends the codegraph block. A
-    pre-existing hook is never overwritten -- the codegraph block is spliced
-    in right after the shebang, so whatever the rest of the script does
-    (including its own `exit`) runs exactly as before, just after ours.
+    name: str
+    path: Path
+    installed: bool
+    reason: str | None = None
 
-    Returns the paths of all three hooks (written or already present).
+
+def plan_hooks(root: Path) -> list[HookResult]:
+    """Install (or repair) `post-commit`, `post-checkout`, and
+    `post-merge`, one `HookResult` per hook.
+
+    A pre-existing hook whose shebang names an interpreter outside
+    `_SHELL_INTERPRETERS` (Perl, Python, Ruby, Node, ...) is **left
+    completely untouched** and reported as skipped -- splicing POSIX-shell
+    syntax into it would corrupt the script outright, not just fail to warm
+    it. A file with no shebang at all makes no interpreter claim to
+    contradict, so it's treated the same as a shell script (a `#!/bin/sh`
+    is added). This refusal is safe precisely because of D5: warming is
+    optional, so a skipped hook only ever costs speed, never correctness.
+
+    A hook already carrying a codegraph block -- from this run or an older
+    version of `install_hooks` -- has that block stripped and a fresh one
+    spliced in fresh each time. This is what makes repeated calls
+    idempotent (always converges to exactly one block) *and*
+    self-repairing (a block left dead by a since-fixed bug, e.g. one
+    appended after the pre-existing hook's own `exit 0`, is replaced with a
+    live one instead of staying broken forever).
     """
     hooks_dir = _hooks_dir(root)
     hooks_dir.mkdir(parents=True, exist_ok=True)
 
-    written: list[Path] = []
+    results: list[HookResult] = []
     for name in _HOOK_NAMES:
         path = hooks_dir / name
         existing = path.read_text() if path.exists() else ""
+        lines = existing.splitlines()
 
-        if _BEGIN_MARKER not in existing:
-            path.write_text(_insert_after_shebang(existing))
+        if lines and lines[0].startswith("#!") and not _is_shell_shebang(lines[0]):
+            results.append(
+                HookResult(
+                    name=name,
+                    path=path,
+                    installed=False,
+                    reason=(
+                        f"existing hook uses a non-shell interpreter ({lines[0].strip()}); "
+                        "warming not installed"
+                    ),
+                )
+            )
+            continue
 
+        content = _insert_after_shebang(_strip_existing_block(existing))
+        path.write_text(content)
         mode = path.stat().st_mode
         path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-        written.append(path)
+        results.append(HookResult(name=name, path=path, installed=True))
 
-    return written
+    return results
+
+
+def install_hooks(root: Path) -> list[Path]:
+    """Paths of the hooks actually installed or repaired.
+
+    Omits any hook skipped for using a non-shell interpreter -- see
+    `plan_hooks` for the reason behind each skip, which is what the CLI
+    surfaces to the user (a skip must be loud, never silent: D5 licenses
+    skipping a hook, not hiding that it happened).
+    """
+    return [result.path for result in plan_hooks(root) if result.installed]

--- a/src/codegraph/maintenance.py
+++ b/src/codegraph/maintenance.py
@@ -22,14 +22,16 @@ _HOOK_NAMES = ("post-commit", "post-checkout", "post-merge")
 _BEGIN_MARKER = "# >>> codegraph (warming only; safe to remove) >>>"
 _END_MARKER = "# <<< codegraph (warming only; safe to remove) <<<"
 
-# Preserves `$?` from whatever ran before this block (0 at a fresh script's
-# start) so appending to a pre-existing hook can never flip its exit status:
-# our warming command is backgrounded and its own status discarded, then the
-# script exits with the status it already had.
+# Fires a backgrounded job and falls straight through -- no `exit`, no
+# capturing `$?`. It has to sit as the *first* statement after the shebang
+# (see `_insert_after_shebang`) rather than at the end: a pre-existing hook
+# commonly ends in its own `exit 0` (or `exit 1`, or hits one inside an
+# `if`), and code appended after that is simply never reached. A block that
+# runs first can't be skipped that way, and since all it does is background
+# a job, it can't change -- or need to preserve -- whatever exit status the
+# rest of the script goes on to produce.
 _HOOK_BLOCK = f"""{_BEGIN_MARKER}
-_codegraph_status=$?
 ( cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" && codegraph index --quiet >/dev/null 2>&1 & ) >/dev/null 2>&1 || true
-exit $_codegraph_status
 {_END_MARKER}
 """
 
@@ -103,14 +105,29 @@ def _hooks_dir(root: Path) -> Path:
     raise FileNotFoundError(f"not a git repository: {root}")
 
 
+def _insert_after_shebang(existing: str) -> str:
+    """Splice `_HOOK_BLOCK` in as the first statement of the script, right
+    after its shebang line so it always runs -- before any pre-existing
+    `exit`, `exec`, or `if`-guarded early return could skip it.
+
+    A file with no shebang gets one (`#!/bin/sh`) prepended; git hooks with
+    no shebang already run under the shell's default anyway, so this changes
+    nothing about how the rest of the script executes.
+    """
+    lines = existing.splitlines(keepends=True)
+    if lines and lines[0].startswith("#!"):
+        return lines[0] + _HOOK_BLOCK + "".join(lines[1:])
+    return "#!/bin/sh\n" + _HOOK_BLOCK + existing
+
+
 def install_hooks(root: Path) -> list[Path]:
     """Write (or extend) `post-commit`, `post-checkout`, and `post-merge`
     hooks that warm the codegraph cache in the background.
 
     Idempotent: re-running never double-appends the codegraph block. A
-    pre-existing hook is never overwritten -- the codegraph block is
-    appended after whatever was already there, guarded so it can only ever
-    add a background warm-up, never change the hook's own exit status.
+    pre-existing hook is never overwritten -- the codegraph block is spliced
+    in right after the shebang, so whatever the rest of the script does
+    (including its own `exit`) runs exactly as before, just after ours.
 
     Returns the paths of all three hooks (written or already present).
     """
@@ -123,11 +140,7 @@ def install_hooks(root: Path) -> list[Path]:
         existing = path.read_text() if path.exists() else ""
 
         if _BEGIN_MARKER not in existing:
-            if not existing:
-                existing = "#!/bin/sh\n"
-            elif not existing.endswith("\n"):
-                existing += "\n"
-            path.write_text(existing + _HOOK_BLOCK)
+            path.write_text(_insert_after_shebang(existing))
 
         mode = path.stat().st_mode
         path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)

--- a/src/codegraph/maintenance.py
+++ b/src/codegraph/maintenance.py
@@ -6,6 +6,14 @@ ever warm Layer 1 in the background. Per D5 in the design doc, every
 `codegraph` query reconciles the working tree itself before answering, so
 neither of these is ever required for correctness -- only for speed. If a
 hook never fires, or `gc` is never run, results are byte-identical.
+
+Installing hooks is deliberately conservative: anything about a pre-existing
+hook that this module can't confidently reason about (a binary file, an
+interpreter it doesn't recognize as shell-compatible, a half-formed marker
+from some prior mishap, any other unexpected error) is a loud skip, never a
+guess. D5 is what licenses that: warming is optional, so skipping a hook
+only ever costs speed, and a corrupted user hook is a strictly worse outcome
+than one that stays un-warmed.
 """
 
 from __future__ import annotations
@@ -41,6 +49,15 @@ _HOOK_BLOCK = f"""{_BEGIN_MARKER}
 # the allowlist of interpreters `_HOOK_BLOCK`'s POSIX-shell syntax is safe
 # to land inside; anything else is left completely untouched.
 _SHELL_INTERPRETERS = {"sh", "bash", "dash", "ash", "ksh", "zsh"}
+
+
+class _MalformedMarker(Exception):
+    """A codegraph marker line was found without its matching partner --
+    a lone BEGIN with no END, a lone END with no BEGIN, or two BEGINs
+    with no END between them. This is damage from a previous run gone
+    wrong, or a hand-edited file, and guessing how much surrounding
+    content to delete risks eating real statements. The caller must
+    refuse to touch the file, not repair around it."""
 
 
 def _chunks(items: list[str], size: int) -> list[list[str]]:
@@ -114,15 +131,22 @@ def _hooks_dir(root: Path) -> Path:
 
 def _shebang_interpreter(shebang_line: str) -> str:
     """The interpreter name a `#!...` line claims, resolving
-    `#!/usr/bin/env <interp> [flags]` to `<interp>` the same as
-    `#!/path/to/<interp> [flags]`. Empty string if the line names nothing
-    (a bare `#!`)."""
+    `#!/usr/bin/env [flags] <interp> [flags]` to `<interp>` the same as a
+    direct `#!/path/to/<interp> [flags]`. `env`'s own flags (`-S`, `-i`, ...)
+    are `-`-prefixed and skipped when looking for the interpreter token, so
+    `#!/usr/bin/env -S bash -e` resolves to `bash`, not `-S`. Empty string
+    if the line names nothing usable (a bare `#!`, or `env` followed by
+    nothing but its own flags)."""
     tokens = shebang_line[2:].split()
     if not tokens:
         return ""
     name = Path(tokens[0]).name
-    if name == "env" and len(tokens) > 1:
-        name = Path(tokens[1]).name
+    if name == "env":
+        name = ""
+        for token in tokens[1:]:
+            if not token.startswith("-"):
+                name = Path(token).name
+                break
     return name
 
 
@@ -130,23 +154,57 @@ def _is_shell_shebang(shebang_line: str) -> bool:
     return _shebang_interpreter(shebang_line) in _SHELL_INTERPRETERS
 
 
-def _strip_existing_block(text: str) -> str:
-    """Remove a previously-installed codegraph block, wherever it sits and
-    whatever its interior looks like (this repairs a stale block from an
-    older version of `install_hooks` -- e.g. one still doing `$?`
-    preservation, or one appended at the end after a pre-existing `exit` --
-    just as readily as a current one). A malformed/truncated marker pair
-    (no matching end) is left alone rather than guessed at."""
-    start = text.find(_BEGIN_MARKER)
-    if start == -1:
+def _is_marker_line(line: str, marker: str) -> bool:
+    """True only if `line` (ignoring surrounding whitespace) is *exactly*
+    the marker, not merely a line that happens to contain it somewhere --
+    a hook whose own comment or quoted string mentions this marker text
+    must never be mistaken for a real block boundary."""
+    return line.strip() == marker
+
+
+def _strip_existing_blocks(text: str) -> str:
+    """Remove every complete codegraph block (a BEGIN marker line, its
+    contents, and the following END marker line -- matched as whole lines
+    only, never a substring inside a longer line). Loops until every
+    marker pair is gone, so a file carrying more than one block (an old
+    one left at the end plus a newer one spliced at the top, say) converges
+    to zero, not one-fewer.
+
+    Raises `_MalformedMarker` if the marker lines found don't pair up
+    cleanly -- a BEGIN with no following END, an END with no preceding
+    BEGIN, or two BEGINs with no END between them. The caller must treat
+    that as damage to leave alone, not a shape to repair by guessing.
+    """
+    lines = text.splitlines(keepends=True)
+    marker_positions = [
+        (index, "begin")
+        for index, line in enumerate(lines)
+        if _is_marker_line(line, _BEGIN_MARKER)
+    ] + [
+        (index, "end") for index, line in enumerate(lines) if _is_marker_line(line, _END_MARKER)
+    ]
+    marker_positions.sort()
+
+    blocks: list[tuple[int, int]] = []
+    pending_begin: int | None = None
+    for index, kind in marker_positions:
+        if kind == "begin":
+            if pending_begin is not None:
+                raise _MalformedMarker
+            pending_begin = index
+        else:
+            if pending_begin is None:
+                raise _MalformedMarker
+            blocks.append((pending_begin, index))
+            pending_begin = None
+    if pending_begin is not None:
+        raise _MalformedMarker
+
+    if not blocks:
         return text
-    end = text.find(_END_MARKER, start)
-    if end == -1:
-        return text
-    end += len(_END_MARKER)
-    tail = text[end:]
-    tail = tail.removeprefix("\n")
-    return text[:start] + tail
+
+    removed = {index for start, end in blocks for index in range(start, end + 1)}
+    return "".join(line for index, line in enumerate(lines) if index not in removed)
 
 
 def _insert_after_shebang(existing: str) -> str:
@@ -175,26 +233,92 @@ class HookResult:
     reason: str | None = None
 
 
+def _plan_one_hook(name: str, path: Path) -> HookResult:
+    """Decide and apply the outcome for a single hook. Never raises for an
+    ordinary "can't safely touch this file" case -- those come back as a
+    skipped `HookResult` -- so any exception that does escape is a genuinely
+    unexpected failure, which `plan_hooks` isolates per-hook."""
+    if path.exists():
+        try:
+            existing = path.read_text()
+        except UnicodeDecodeError:
+            # A compiled/binary hook (pre-commit frameworks and compiled
+            # shims ship these). It IS a non-shell hook -- same refusal as
+            # Perl, just detected a layer earlier, before there's even a
+            # shebang line to read.
+            return HookResult(
+                name=name,
+                path=path,
+                installed=False,
+                reason=(
+                    "existing hook is not valid UTF-8 (binary or non-text hook); "
+                    "warming not installed"
+                ),
+            )
+    else:
+        existing = ""
+
+    lines = existing.splitlines()
+    if lines and lines[0].startswith("#!") and not _is_shell_shebang(lines[0]):
+        return HookResult(
+            name=name,
+            path=path,
+            installed=False,
+            reason=(
+                f"existing hook uses a non-shell interpreter ({lines[0].strip()}); "
+                "warming not installed"
+            ),
+        )
+
+    try:
+        stripped = _strip_existing_blocks(existing)
+    except _MalformedMarker:
+        return HookResult(
+            name=name,
+            path=path,
+            installed=False,
+            reason=(
+                "existing hook has a malformed codegraph marker (a begin marker with "
+                "no matching end, or vice versa); please repair or remove it by hand -- "
+                "warming not installed"
+            ),
+        )
+
+    content = _insert_after_shebang(stripped)
+    path.write_text(content)
+    mode = path.stat().st_mode
+    path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return HookResult(name=name, path=path, installed=True)
+
+
 def plan_hooks(root: Path) -> list[HookResult]:
     """Install (or repair) `post-commit`, `post-checkout`, and
     `post-merge`, one `HookResult` per hook.
 
     A pre-existing hook whose shebang names an interpreter outside
-    `_SHELL_INTERPRETERS` (Perl, Python, Ruby, Node, ...) is **left
-    completely untouched** and reported as skipped -- splicing POSIX-shell
-    syntax into it would corrupt the script outright, not just fail to warm
-    it. A file with no shebang at all makes no interpreter claim to
-    contradict, so it's treated the same as a shell script (a `#!/bin/sh`
-    is added). This refusal is safe precisely because of D5: warming is
-    optional, so a skipped hook only ever costs speed, never correctness.
+    `_SHELL_INTERPRETERS` (Perl, Python, Ruby, Node, ...), or that isn't
+    valid UTF-8 at all (a binary hook), is **left completely untouched**
+    and reported as skipped -- splicing POSIX-shell syntax into it would
+    corrupt the script outright, not just fail to warm it. A file with no
+    shebang at all makes no interpreter claim to contradict, so it's
+    treated the same as a shell script (a `#!/bin/sh` is added).
 
-    A hook already carrying a codegraph block -- from this run or an older
-    version of `install_hooks` -- has that block stripped and a fresh one
-    spliced in fresh each time. This is what makes repeated calls
-    idempotent (always converges to exactly one block) *and*
-    self-repairing (a block left dead by a since-fixed bug, e.g. one
-    appended after the pre-existing hook's own `exit 0`, is replaced with a
-    live one instead of staying broken forever).
+    A hook already carrying one or more codegraph blocks -- from this run
+    or an older version of `install_hooks` -- has all of them stripped and
+    a single fresh one spliced in. This is what makes repeated calls
+    idempotent (always converges to exactly one block, however many were
+    there before) *and* self-repairing (a block left dead by a since-fixed
+    bug, e.g. one appended after the pre-existing hook's own `exit 0`, is
+    replaced with a live one instead of staying broken forever). A hook
+    whose marker lines don't pair up cleanly is left untouched and skipped
+    instead -- that shape is damage, not something to guess a repair for.
+
+    One hook's unexpected failure (a permission error, anything not
+    already handled above) is isolated to that hook: it comes back as a
+    skipped result with the error as its reason, and the other hooks are
+    still processed. A maintenance command that half-runs because of one
+    bad hook, or dumps a raw traceback, is worse than one that skips
+    loudly and keeps going.
     """
     hooks_dir = _hooks_dir(root)
     hooks_dir.mkdir(parents=True, exist_ok=True)
@@ -202,28 +326,17 @@ def plan_hooks(root: Path) -> list[HookResult]:
     results: list[HookResult] = []
     for name in _HOOK_NAMES:
         path = hooks_dir / name
-        existing = path.read_text() if path.exists() else ""
-        lines = existing.splitlines()
-
-        if lines and lines[0].startswith("#!") and not _is_shell_shebang(lines[0]):
+        try:
+            results.append(_plan_one_hook(name, path))
+        except Exception as exc:  # noqa: BLE001 -- per-hook isolation net, see docstring
             results.append(
                 HookResult(
                     name=name,
                     path=path,
                     installed=False,
-                    reason=(
-                        f"existing hook uses a non-shell interpreter ({lines[0].strip()}); "
-                        "warming not installed"
-                    ),
+                    reason=f"unexpected error inspecting hook ({exc}); warming not installed",
                 )
             )
-            continue
-
-        content = _insert_after_shebang(_strip_existing_block(existing))
-        path.write_text(content)
-        mode = path.stat().st_mode
-        path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-        results.append(HookResult(name=name, path=path, installed=True))
 
     return results
 
@@ -231,9 +344,10 @@ def plan_hooks(root: Path) -> list[HookResult]:
 def install_hooks(root: Path) -> list[Path]:
     """Paths of the hooks actually installed or repaired.
 
-    Omits any hook skipped for using a non-shell interpreter -- see
-    `plan_hooks` for the reason behind each skip, which is what the CLI
-    surfaces to the user (a skip must be loud, never silent: D5 licenses
-    skipping a hook, not hiding that it happened).
+    Omits any hook skipped for using a non-shell interpreter, being
+    unreadable as text, carrying a malformed marker, or failing
+    unexpectedly -- see `plan_hooks` for the reason behind each skip,
+    which is what the CLI surfaces to the user (a skip must be loud, never
+    silent: D5 licenses skipping a hook, not hiding that it happened).
     """
     return [result.path for result in plan_hooks(root) if result.installed]

--- a/src/codegraph/maintenance.py
+++ b/src/codegraph/maintenance.py
@@ -1,0 +1,136 @@
+"""Blob-cache garbage collection and warming-only git hooks.
+
+Both operations are pure housekeeping: `gc` never touches Layer 2 (the
+materialized per-revision graph), and the hooks `install_hooks` writes only
+ever warm Layer 1 in the background. Per D5 in the design doc, every
+`codegraph` query reconciles the working tree itself before answering, so
+neither of these is ever required for correctness -- only for speed. If a
+hook never fires, or `gc` is never run, results are byte-identical.
+"""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+from codegraph.store import Store
+
+_CHUNK = 400  # stays well under SQLite's default 999-variable limit per statement
+
+_HOOK_NAMES = ("post-commit", "post-checkout", "post-merge")
+
+_BEGIN_MARKER = "# >>> codegraph (warming only; safe to remove) >>>"
+_END_MARKER = "# <<< codegraph (warming only; safe to remove) <<<"
+
+# Preserves `$?` from whatever ran before this block (0 at a fresh script's
+# start) so appending to a pre-existing hook can never flip its exit status:
+# our warming command is backgrounded and its own status discarded, then the
+# script exits with the status it already had.
+_HOOK_BLOCK = f"""{_BEGIN_MARKER}
+_codegraph_status=$?
+( cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" && codegraph index --quiet >/dev/null 2>&1 & ) >/dev/null 2>&1 || true
+exit $_codegraph_status
+{_END_MARKER}
+"""
+
+
+def _chunks(items: list[str], size: int) -> list[list[str]]:
+    return [items[i : i + size] for i in range(0, len(items), size)]
+
+
+def gc(store: Store, keep_revs: set[str]) -> int:
+    """Prune Layer 1 (the content-addressed parse cache) down to only the
+    blobs referenced by `keep_revs`'s materialized trees.
+
+    Layer 2 (`revisions`, `tree`, `nodes`, `edges`, `effects`, `imports`,
+    `unresolved`) is never touched -- it is already fully materialized for
+    every revision in the store, retained or not, and does not read back
+    through Layer 1. Losing a Layer 1 entry only costs a re-parse the next
+    time that blob's content is seen; it never invalidates an existing
+    answer.
+
+    `keep_revs` empty is well-defined, not accidental: nothing is retained,
+    so every Layer 1 row is unreferenced and gets removed.
+
+    Returns the number of Layer 1 blob rows removed.
+    """
+    connection = store.connection
+
+    keep_shas: set[str] = set()
+    if keep_revs:
+        for batch in _chunks(sorted(keep_revs), _CHUNK):
+            placeholders = ",".join("?" * len(batch))
+            rows = connection.execute(
+                f"SELECT DISTINCT blob_sha FROM tree WHERE rev IN ({placeholders})",
+                tuple(batch),
+            )
+            keep_shas.update(row["blob_sha"] for row in rows)
+
+    all_shas = {row["blob_sha"] for row in connection.execute("SELECT blob_sha FROM blobs")}
+    remove_shas = sorted(all_shas - keep_shas)
+    if not remove_shas:
+        return 0
+
+    with connection:
+        for batch in _chunks(remove_shas, _CHUNK):
+            placeholders = ",".join("?" * len(batch))
+            params = tuple(batch)
+            connection.execute(f"DELETE FROM blob_nodes WHERE blob_sha IN ({placeholders})", params)
+            connection.execute(f"DELETE FROM blob_refs WHERE blob_sha IN ({placeholders})", params)
+            connection.execute(
+                f"DELETE FROM blob_imports WHERE blob_sha IN ({placeholders})", params
+            )
+            connection.execute(f"DELETE FROM blobs WHERE blob_sha IN ({placeholders})", params)
+
+    return len(remove_shas)
+
+
+def _hooks_dir(root: Path) -> Path:
+    """Resolve `root`'s git hooks directory, honoring `.git`-as-a-file
+    (worktrees, submodules) as well as the ordinary `.git`-as-a-directory
+    case that every test in this repo uses."""
+    git_path = root / ".git"
+    if git_path.is_dir():
+        return git_path / "hooks"
+    if git_path.is_file():
+        text = git_path.read_text().strip()
+        prefix = "gitdir:"
+        if text.startswith(prefix):
+            gitdir = Path(text[len(prefix) :].strip())
+            if not gitdir.is_absolute():
+                gitdir = (root / gitdir).resolve()
+            return gitdir / "hooks"
+    raise FileNotFoundError(f"not a git repository: {root}")
+
+
+def install_hooks(root: Path) -> list[Path]:
+    """Write (or extend) `post-commit`, `post-checkout`, and `post-merge`
+    hooks that warm the codegraph cache in the background.
+
+    Idempotent: re-running never double-appends the codegraph block. A
+    pre-existing hook is never overwritten -- the codegraph block is
+    appended after whatever was already there, guarded so it can only ever
+    add a background warm-up, never change the hook's own exit status.
+
+    Returns the paths of all three hooks (written or already present).
+    """
+    hooks_dir = _hooks_dir(root)
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+
+    written: list[Path] = []
+    for name in _HOOK_NAMES:
+        path = hooks_dir / name
+        existing = path.read_text() if path.exists() else ""
+
+        if _BEGIN_MARKER not in existing:
+            if not existing:
+                existing = "#!/bin/sh\n"
+            elif not existing.endswith("\n"):
+                existing += "\n"
+            path.write_text(existing + _HOOK_BLOCK)
+
+        mode = path.stat().st_mode
+        path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        written.append(path)
+
+    return written

--- a/src/codegraph/parse.py
+++ b/src/codegraph/parse.py
@@ -74,6 +74,44 @@ def _dotted_name(node: ast.AST) -> str | None:
     return ".".join(reversed(parts))
 
 
+#: Any of these appearing in a literal `open(...)` mode string makes the
+#: call a write (or write-capable, for `+`): 'w'rite, 'a'ppend, e'x'clusive
+#: create, or read-'+'-write.
+_WRITE_MODE_CHARS = frozenset("wax+")
+
+
+def _open_call_marker(node: ast.Call) -> str:
+    """`open`'s effect kind (FS_READ vs FS_WRITE) depends on its `mode`
+    argument, which a plain dotted-name catalog match can never see --
+    this is the one place in the parser that still has the call site's
+    AST, so it is the one place this can be decided. Three outcomes,
+    encoded as three distinct synthetic names the built-in catalog
+    (`builtin.toml`) maps separately:
+
+    - no mode argument at all, or a literal mode with none of w/a/x/+:
+      a genuine read (`open` unchanged -- the plain, and by far the most
+      common, case).
+    - a literal mode containing w/a/x/+: a genuine write (`open!write`).
+    - a mode argument that isn't a string literal (a variable, an
+      f-string, ...): honestly unknown, so it keeps the conservative
+      FS_READ default (`open!ambiguous`) but at lower confidence, since
+      unlike the first case the evidence doesn't actually support it.
+    """
+    mode_node = node.args[1] if len(node.args) >= 2 else None
+    if mode_node is None:
+        for keyword in node.keywords:
+            if keyword.arg == "mode":
+                mode_node = keyword.value
+                break
+    if mode_node is None:
+        return "open"
+    if isinstance(mode_node, ast.Constant) and isinstance(mode_node.value, str):
+        if any(char in _WRITE_MODE_CHARS for char in mode_node.value):
+            return "open!write"
+        return "open"
+    return "open!ambiguous"
+
+
 def _decorator_names(node: ast.AST) -> tuple[str, ...]:
     decorators = getattr(node, "decorator_list", [])
     names = []
@@ -233,17 +271,47 @@ class _Collector(ast.NodeVisitor):
     # -- references ------------------------------------------------------
     def visit_Call(self, node: ast.Call) -> None:
         name = _dotted_name(node.func)
-        if name:
-            self.refs.append(
-                ParsedRef(
-                    ordinal=len(self.refs),
-                    from_qualname=self._current_owner.removesuffix(".<locals>"),
-                    ref_kind="call",
-                    raw_name=name,
-                    dotted=name if "." in name else None,
-                    line=node.lineno,
-                )
+        if name is None:
+            # The receiver isn't a flattenable Name/Attribute chain --
+            # `super().go()`, `PaymentService().charge(x)`,
+            # `self.items[0].run()`, `(a or b).fire()`, `d["k"].m()`. Losing
+            # the resolved target is fine; losing the ref entirely is not,
+            # since that would drop it from both the call graph AND the
+            # `unresolved` count with no signal at all (the failure mode
+            # this branch exists to close).
+            #
+            # Record whatever IS known: when `node.func` is itself an
+            # `Attribute` (true of all five examples above -- only its
+            # `.value` chain fails to flatten), that's the attribute name.
+            # It is deliberately given the synthetic `<attr>.` prefix rather
+            # than the bare name: `<attr>.go` still contains a "." so it
+            # flows through `resolve.py`'s existing `dotted`-gated pipeline
+            # exactly like any other qualified call, which routes it past
+            # the HIGH-confidence steps (imported-name, module-local,
+            # self-through-MRO -- none of which have any real basis for a
+            # receiver we know nothing about) and into the *existing*
+            # repo-wide by-last-segment step, unresolved-heuristic MEDIUM/LOW
+            # match on `go` alone. No new resolution logic. `<` can never
+            # appear in a real Python identifier, so this can never collide
+            # with a genuine dotted call. A call with no attribute at all
+            # (e.g. `handlers[i]()`) has nothing to key on and is recorded
+            # under a synthetic placeholder instead, purely so the COUNT is
+            # never silently lost.
+            name = (
+                f"<attr>.{node.func.attr}" if isinstance(node.func, ast.Attribute) else "<dynamic>"
             )
+        elif name == "open":
+            name = _open_call_marker(node)
+        self.refs.append(
+            ParsedRef(
+                ordinal=len(self.refs),
+                from_qualname=self._current_owner.removesuffix(".<locals>"),
+                ref_kind="call",
+                raw_name=name,
+                dotted=name if "." in name else None,
+                line=node.lineno,
+            )
+        )
         self.generic_visit(node)
 
     def visit_Global(self, node: ast.Global) -> None:

--- a/src/codegraph/parse.py
+++ b/src/codegraph/parse.py
@@ -197,6 +197,30 @@ class _Collector(ast.NodeVisitor):
             )
         self.generic_visit(node)
 
+    def visit_Global(self, node: ast.Global) -> None:
+        self._record_global(node, node.names)
+
+    def visit_Nonlocal(self, node: ast.Nonlocal) -> None:
+        self._record_global(node, node.names)
+
+    def _record_global(self, node: ast.AST, names: list[str]) -> None:
+        # `global`/`nonlocal` both bind the name to an outer scope, so a
+        # write to it after this statement is a mutation of shared state --
+        # GLOBAL_MUTATE has no catalog pattern to match against; this is
+        # the syntactic detection Task 10 hooks into.
+        owner = self._current_owner.removesuffix(".<locals>")
+        for name in names:
+            self.refs.append(
+                ParsedRef(
+                    ordinal=len(self.refs),
+                    from_qualname=owner,
+                    ref_kind="global",
+                    raw_name=name,
+                    dotted=None,
+                    line=node.lineno,
+                )
+            )
+
     def visit_Import(self, node: ast.Import) -> None:
         for alias in node.names:
             self.imports.append(

--- a/src/codegraph/parse.py
+++ b/src/codegraph/parse.py
@@ -7,10 +7,11 @@ paths, and the parse cache is keyed on content alone.
 from __future__ import annotations
 
 import ast
+import copy
 import hashlib
 from dataclasses import dataclass, field
 
-PARSER_VERSION = "1"
+PARSER_VERSION = "2"
 
 _DEF_TYPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
 
@@ -53,6 +54,10 @@ class ParseResult:
     nodes: tuple[ParsedNode, ...] = ()
     refs: tuple[ParsedRef, ...] = ()
     imports: tuple[ParsedImport, ...] = ()
+    #: Structural hash of the module's top-level statements, with every
+    #: nested function/class BODY elided (see `_module_skeleton`). Empty on
+    #: a parse error, since there is no tree to hash.
+    module_body_hash: str = ""
     error: str | None = None
 
 
@@ -84,6 +89,50 @@ def _body_hash(node: ast.AST) -> str:
     # ast.dump omits lineno/col_offset unless include_attributes=True, so this
     # hash is invariant to where the definition sits in the file.
     return hashlib.blake2b(ast.dump(node).encode(), digest_size=16).hexdigest()
+
+
+class _BodyElider(ast.NodeTransformer):
+    """Replace every function/class def's `body` with a single placeholder
+    statement, without recursing into the original body first.
+
+    Used to build the module-level structural hash: a def/class's own
+    `body_hash` already covers everything inside it (via `_body_hash` on
+    the untouched node), so folding that same content into the module hash
+    too would double-count it and reintroduce the exact line-shift churn
+    `body_hash` comparison exists to avoid (an edit two functions away from
+    a def would ripple into every def nested inside it, transitively, all
+    the way up to the module). Not recursing into the original body before
+    replacing it also means a closure nested inside a top-level function
+    is dropped for free -- it is already inside that function's own
+    (unelided) `body_hash`.
+
+    Everything else about the def -- its name, decorators, arguments,
+    base classes, and its position among the module's other top-level
+    statements -- is left intact, so renaming a def, changing its
+    signature, or reordering top-level statements still changes the
+    module hash.
+    """
+
+    def _elide(self, node: ast.AST) -> ast.AST:
+        clone = copy.copy(node)
+        clone.body = [ast.Pass()]
+        return clone
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.AST:
+        return self._elide(node)
+
+    visit_AsyncFunctionDef = visit_FunctionDef  # type: ignore[assignment]
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> ast.AST:
+        return self._elide(node)
+
+
+def _module_body_hash(tree: ast.Module) -> str:
+    """Structural hash of `tree`'s top-level statements, reusing
+    `_body_hash` (the same dump-and-hash `parse.py` already uses for a
+    def/class's own body) over a copy with nested def/class bodies elided."""
+    skeleton = _BodyElider().visit(copy.deepcopy(tree))
+    return _body_hash(skeleton)
 
 
 class _Collector(ast.NodeVisitor):
@@ -286,5 +335,6 @@ def parse_blob(source: bytes) -> ParseResult:
         nodes=_apply_shadowing(collector.nodes),
         refs=tuple(collector.refs),
         imports=tuple(collector.imports),
+        module_body_hash=_module_body_hash(tree),
         error=None,
     )

--- a/src/codegraph/parse.py
+++ b/src/codegraph/parse.py
@@ -173,6 +173,33 @@ def _module_body_hash(tree: ast.Module) -> str:
     return _body_hash(skeleton)
 
 
+def _class_body_hash(node: ast.ClassDef) -> str:
+    """Structural hash of a class def, with every nested method/nested
+    class's OWN body elided -- the same treatment `_module_body_hash`
+    gives a module's top-level statements, applied one level down.
+
+    Without this, a class's `body_hash` covers its methods' bodies too, so
+    editing one line inside a single method changes both that method's own
+    `body_hash` (correctly) AND the class's (incorrectly) -- exactly the
+    line-shift-insensitivity `body_hash` comparison exists to provide, but
+    one level higher, and it matters for the same reason `diff` cares
+    about module-level churn: an editor touching `PaymentService.charge`
+    should not also report `PaymentService` itself as changed.
+
+    `_BodyElider().generic_visit(skeleton)` (not `.visit(skeleton)`) is the
+    deliberate difference from `_module_body_hash`: `generic_visit` walks
+    `skeleton`'s children without ever calling `visit_ClassDef` on
+    `skeleton` itself, so the class's own body list, bases, decorators,
+    and name stay intact -- only a `FunctionDef`/`ClassDef` found AMONG
+    its children (a method, a nested class) gets its body replaced with a
+    single `Pass`. Bases and decorators live in separate AST fields from
+    `body`, so they're hashed as-is regardless.
+    """
+    skeleton = copy.deepcopy(node)
+    _BodyElider().generic_visit(skeleton)
+    return _body_hash(skeleton)
+
+
 class _Collector(ast.NodeVisitor):
     def __init__(self) -> None:
         self.nodes: list[ParsedNode] = []
@@ -220,6 +247,13 @@ class _Collector(ast.NodeVisitor):
     def _visit_def(self, node: ast.AST, kind: str) -> None:
         decorators = _decorator_names(node)
         is_overload = any(d.split(".")[-1] == "overload" for d in decorators)
+        # A class's own body_hash elides its nested defs' bodies (mirroring
+        # _module_body_hash), since each method already carries its own
+        # unelided body_hash -- otherwise editing one line inside a single
+        # method would also change the class's hash. A function/method has
+        # no nested defs to elide out this way: its own body IS the thing
+        # body_hash is comparing.
+        body_hash = _class_body_hash(node) if kind == "class" else _body_hash(node)
         self.nodes.append(
             ParsedNode(
                 ordinal=len(self.nodes),
@@ -227,7 +261,7 @@ class _Collector(ast.NodeVisitor):
                 kind=kind,
                 line_start=node.lineno,
                 line_end=getattr(node, "end_lineno", node.lineno),
-                body_hash=_body_hash(node),
+                body_hash=body_hash,
                 name_binding="live",
                 shadow_index=None,
                 conditional=int(bool(self._conditional_depth) or is_overload),

--- a/src/codegraph/query/__init__.py
+++ b/src/codegraph/query/__init__.py
@@ -1,0 +1,7 @@
+"""Query layer: convert graph state into `Report`s for CLI commands."""
+
+from __future__ import annotations
+
+from codegraph.query.effects import effects_report
+
+__all__ = ["effects_report"]

--- a/src/codegraph/query/__init__.py
+++ b/src/codegraph/query/__init__.py
@@ -3,5 +3,6 @@
 from __future__ import annotations
 
 from codegraph.query.effects import effects_report
+from codegraph.query.impact import impact_report
 
-__all__ = ["effects_report"]
+__all__ = ["effects_report", "impact_report"]

--- a/src/codegraph/query/diff.py
+++ b/src/codegraph/query/diff.py
@@ -1,0 +1,192 @@
+"""The `diff` report: what changed between two revisions, compared on
+`body_hash` -- never on line span.
+
+The whole point of this module is that moving a symbol's lines around (an
+inserted blank line, a reordered file) must not read as a change. Every
+symbol's identity is its node id (`path::qualname`); every symbol's
+"did it change" question is answered by comparing `body_hash` (and, for a
+symbol present in both revisions, its outgoing edge set) rather than line
+numbers.
+
+The base revision is read through `Indexer.reconcile`, which in turn reads
+trees and blobs through `gitio`'s `ls-tree`/`cat-file` plumbing -- it is
+never checked out, so a diff against an arbitrary commit leaves the
+working tree and `HEAD` untouched.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from codegraph import gitio
+from codegraph.indexer import Indexer
+from codegraph.query.impact import impact_report
+from codegraph.render import Group, Report, Row, budget
+from codegraph.store import Store
+
+#: `Indexer._materialize_nodes` also writes one synthetic module-scope node
+#: per path (`path::<module>`), whose `body_hash` is the *file's* blob sha --
+#: a file-changed signal, not a symbol-changed one. Comparing those would
+#: mean any touch to a file (including a pure line-shift) shows up as a
+#: "changed" row, defeating the point of this module. They are excluded
+#: from every set below.
+_MODULE_KIND = "module"
+
+
+class MissingRevisionError(Exception):
+    """A requested revision could not be resolved to a real commit.
+
+    Raised instead of silently falling back to some other base -- a
+    shallow clone missing history, a detached `HEAD` with no default
+    branch, or a non-git directory should fail loudly, by name.
+    """
+
+    def __init__(self, rev: str) -> None:
+        super().__init__(f"revision not found: {rev}")
+        self.rev = rev
+
+
+def _resolve(indexer: Indexer, rev: str) -> str:
+    """Resolve `rev` to a commit sha, verifying the commit actually exists.
+
+    `git rev-parse <40-hex-chars>` alone echoes back a well-formed-looking
+    sha without checking the object exists -- appending `^{commit}` forces
+    git to dereference it, which fails loudly for a sha (or shallow-missing
+    ref) with no backing object, instead of letting a later `ls-tree` fail
+    with a confusing "not a tree object".
+    """
+    root = indexer.root
+    if not gitio.is_repo(root):
+        raise MissingRevisionError(rev)
+    try:
+        return gitio.rev_parse(root, f"{rev}^{{commit}}")
+    except gitio.GitError as exc:
+        raise MissingRevisionError(rev) from exc
+
+
+def _nodes(store: Store, rev: str) -> dict[str, sqlite3.Row]:
+    return {
+        row["id"]: row
+        for row in store.connection.execute(
+            "SELECT id, path, qualname, kind, line_start, body_hash FROM nodes"
+            " WHERE rev=? AND kind != ?",
+            (rev, _MODULE_KIND),
+        )
+    }
+
+
+def _edges_by_src(store: Store, rev: str) -> dict[str, set[tuple[str, str]]]:
+    edges: dict[str, set[tuple[str, str]]] = {}
+    for row in store.connection.execute("SELECT src, dst, kind FROM edges WHERE rev=?", (rev,)):
+        edges.setdefault(row["src"], set()).add((row["dst"], row["kind"]))
+    return edges
+
+
+def _effect_kinds(store: Store, rev: str, node_id: str) -> set[str]:
+    return {
+        row["kind"]
+        for row in store.connection.execute(
+            "SELECT DISTINCT kind FROM effects WHERE rev=? AND node_id=?", (rev, node_id)
+        )
+    }
+
+
+def _dependent_count(store: Store, rev: str, node_id: str) -> int:
+    """Blast radius of `node_id` at `rev`, via the same walk `impact`
+    itself uses -- not reimplemented here."""
+    return impact_report(store, rev, node_id, limit=10_000).summary["symbols"]
+
+
+def diff_report(store: Store, indexer: Indexer, base: str, head: str, limit: int = 40) -> Report:
+    """Compare `base` and `head`, reconciling both first.
+
+    Symbol identity is the node id; the only question asked of a symbol
+    present in both revisions is whether its `body_hash` or its outgoing
+    edge set (`(src, dst, kind)`) changed -- never where its lines sit.
+    """
+    resolved_base = _resolve(indexer, base)
+
+    indexer.reconcile(resolved_base)
+    indexer.reconcile(head)
+
+    base_nodes = _nodes(store, resolved_base)
+    head_nodes = _nodes(store, head)
+    base_edges = _edges_by_src(store, resolved_base)
+    head_edges = _edges_by_src(store, head)
+
+    added_ids = set(head_nodes) - set(base_nodes)
+    removed_ids = set(base_nodes) - set(head_nodes)
+    common_ids = set(head_nodes) & set(base_nodes)
+    changed_ids = {
+        node_id
+        for node_id in common_ids
+        if head_nodes[node_id]["body_hash"] != base_nodes[node_id]["body_hash"]
+        or head_edges.get(node_id, set()) != base_edges.get(node_id, set())
+    }
+
+    added_rows = [
+        Row(
+            id=node_id,
+            location=f"{head_nodes[node_id]['path']}:{head_nodes[node_id]['line_start']}",
+            detail=head_nodes[node_id]["kind"],
+            score=1.0,
+        )
+        for node_id in added_ids
+    ]
+    removed_rows = [
+        Row(
+            id=node_id,
+            location=f"{base_nodes[node_id]['path']}:{base_nodes[node_id]['line_start']}",
+            detail=(
+                f"{base_nodes[node_id]['kind']}, "
+                f"{_dependent_count(store, resolved_base, node_id)} dependent(s)"
+            ),
+            score=1.0,
+        )
+        for node_id in removed_ids
+    ]
+    changed_rows = [
+        Row(
+            id=node_id,
+            location=f"{head_nodes[node_id]['path']}:{head_nodes[node_id]['line_start']}",
+            detail=(
+                f"{head_nodes[node_id]['kind']}, "
+                f"{_dependent_count(store, head, node_id)} dependent(s)"
+            ),
+            score=1.0,
+        )
+        for node_id in changed_ids
+    ]
+
+    groups: list[Group] = []
+    truncated = False
+    for title, group_rows in (
+        ("added", added_rows),
+        ("removed", removed_rows),
+        ("changed", changed_rows),
+    ):
+        if not group_rows:
+            continue
+        kept, was_truncated = budget(group_rows, limit)
+        groups.append(Group(title, kept))
+        truncated = truncated or was_truncated
+
+    new_effects: set[str] = set()
+    for node_id in changed_ids:
+        new_effects |= _effect_kinds(store, head, node_id) - _effect_kinds(
+            store, resolved_base, node_id
+        )
+
+    summary = {
+        "new_effects": sorted(new_effects),
+        "added": len(added_ids),
+        "removed": len(removed_ids),
+        "changed": len(changed_ids),
+        "base": resolved_base,
+        "head": head,
+    }
+
+    return Report(summary=summary, groups=groups, truncated=truncated)
+
+
+__all__ = ["MissingRevisionError", "diff_report"]

--- a/src/codegraph/query/diff.py
+++ b/src/codegraph/query/diff.py
@@ -24,14 +24,6 @@ from codegraph.query.impact import impact_report
 from codegraph.render import Group, Report, Row, budget
 from codegraph.store import Store
 
-#: `Indexer._materialize_nodes` also writes one synthetic module-scope node
-#: per path (`path::<module>`), whose `body_hash` is the *file's* blob sha --
-#: a file-changed signal, not a symbol-changed one. Comparing those would
-#: mean any touch to a file (including a pure line-shift) shows up as a
-#: "changed" row, defeating the point of this module. They are excluded
-#: from every set below.
-_MODULE_KIND = "module"
-
 
 class MissingRevisionError(Exception):
     """A requested revision could not be resolved to a real commit.
@@ -65,12 +57,19 @@ def _resolve(indexer: Indexer, rev: str) -> str:
 
 
 def _nodes(store: Store, rev: str) -> dict[str, sqlite3.Row]:
+    """Every node at `rev`, including the synthetic per-path module-scope
+    node (`path::<module>`, `kind="module"`). It is not special-cased out:
+    `parse.py` gives it a `body_hash` over the module's top-level
+    statements with nested def/class bodies elided, so it is exactly as
+    line-shift-insensitive as every other node here -- and it is where a
+    new import or a module-level side-effecting call (code with no def of
+    its own to attach to) actually lives, so excluding it would make the
+    single most effect-dense kind of change invisible to `diff`."""
     return {
         row["id"]: row
         for row in store.connection.execute(
-            "SELECT id, path, qualname, kind, line_start, body_hash FROM nodes"
-            " WHERE rev=? AND kind != ?",
-            (rev, _MODULE_KIND),
+            "SELECT id, path, qualname, kind, line_start, body_hash FROM nodes WHERE rev=?",
+            (rev,),
         )
     }
 

--- a/src/codegraph/query/diff.py
+++ b/src/codegraph/query/diff.py
@@ -170,8 +170,16 @@ def diff_report(store: Store, indexer: Indexer, base: str, head: str, limit: int
         groups.append(Group(title, kept))
         truncated = truncated or was_truncated
 
+    # A newly-added symbol is exactly as "newly reachable" as an edited
+    # one -- Task 12's fix for this same blind spot at module scope. A
+    # brand-new function that calls `requests.post` has no entry in
+    # `base_nodes` at all, so `changed_ids` alone (which only ever
+    # contains ids present in BOTH revisions) can never surface it;
+    # `_effect_kinds(store, resolved_base, node_id)` against a nonexistent
+    # node id is just an empty result set, so folding `added_ids` in here
+    # costs nothing for ids that legitimately have no base side.
     new_effects: set[str] = set()
-    for node_id in changed_ids:
+    for node_id in changed_ids | added_ids:
         new_effects |= _effect_kinds(store, head, node_id) - _effect_kinds(
             store, resolved_base, node_id
         )

--- a/src/codegraph/query/effects.py
+++ b/src/codegraph/query/effects.py
@@ -49,7 +49,7 @@ def effects_report(store: Store, rev: str, node_id: str) -> Report:
     groups: list[Group] = []
     for rank, kind in enumerate(ordered):
         confidence = node_kinds[kind]
-        chain = witness_path(store, rev, node_id, kind)
+        chain = witness_path(store, rev, node_id, kind, confidence)
         cause = chain[-1] if chain else node_id
         location = _evidence_location(store, rev, cause, kind)
         detail = f"{kind} {confidence} via {' -> '.join(chain)}"

--- a/src/codegraph/query/effects.py
+++ b/src/codegraph/query/effects.py
@@ -1,0 +1,78 @@
+"""The `effects` report: every side-effect kind reachable from a symbol,
+with a witness path a user can verify in one click.
+
+Groups by effect kind (one row per kind), sorted worst-first by severity
+then by confidence. `Row.detail` is `f"{kind} {confidence} via {chain}"` --
+the effect kind must stay the first whitespace-separated token, since this
+module's own tests and Task 11's both split on it.
+"""
+
+from __future__ import annotations
+
+from codegraph.effects.propagate import witness_path
+from codegraph.render import Group, Report, Row
+from codegraph.store import Store
+
+#: Worst-first. DB writes and network calls are the effects a reviewer
+#: should see before anything else; nondeterminism is the mildest of the nine.
+_SEVERITY: tuple[str, ...] = (
+    "DB_WRITE",
+    "NETWORK",
+    "PROCESS",
+    "FS_WRITE",
+    "GLOBAL_MUTATE",
+    "DB_READ",
+    "FS_READ",
+    "ENV_READ",
+    "NONDETERMINISM",
+)
+_SEVERITY_RANK = {kind: rank for rank, kind in enumerate(_SEVERITY)}
+_CONFIDENCE_RANK = {"HIGH": 0, "MEDIUM": 1, "LOW": 2}
+
+
+def effects_report(store: Store, rev: str, node_id: str) -> Report:
+    """Every effect kind reachable from `node_id`, one group per kind."""
+    connection = store.connection
+    node_kinds: dict[str, str] = {}
+    for row in connection.execute(
+        "SELECT kind, confidence FROM effects WHERE rev=? AND node_id=?", (rev, node_id)
+    ):
+        best = node_kinds.get(row["kind"])
+        if best is None or _CONFIDENCE_RANK[row["confidence"]] < _CONFIDENCE_RANK[best]:
+            node_kinds[row["kind"]] = row["confidence"]
+
+    ordered = sorted(
+        node_kinds,
+        key=lambda k: (_SEVERITY_RANK.get(k, len(_SEVERITY)), _CONFIDENCE_RANK[node_kinds[k]]),
+    )
+
+    groups: list[Group] = []
+    for rank, kind in enumerate(ordered):
+        confidence = node_kinds[kind]
+        chain = witness_path(store, rev, node_id, kind)
+        cause = chain[-1] if chain else node_id
+        location = _evidence_location(store, rev, cause, kind)
+        detail = f"{kind} {confidence} via {' -> '.join(chain)}"
+        score = float(len(ordered) - rank)
+        row = Row(id=f"{node_id}::{kind}", location=location, detail=detail, score=score)
+        groups.append(Group(kind, [row]))
+
+    return Report(
+        summary={"symbol": node_id, "effect_kinds": len(ordered)},
+        groups=groups,
+        truncated=False,
+    )
+
+
+def _evidence_location(store: Store, rev: str, direct_node_id: str, kind: str) -> str:
+    """The concrete `path:line` of the direct call site causing `kind` at
+    `direct_node_id` -- the tail of the witness chain."""
+    row = store.connection.execute(
+        "SELECT evidence_path, evidence_line FROM effects"
+        " WHERE rev=? AND node_id=? AND kind=? AND direct=1"
+        " ORDER BY evidence_line LIMIT 1",
+        (rev, direct_node_id, kind),
+    ).fetchone()
+    if row is None:
+        return ""
+    return f"{row['evidence_path']}:{row['evidence_line']}"

--- a/src/codegraph/query/effects.py
+++ b/src/codegraph/query/effects.py
@@ -55,7 +55,7 @@ def effects_report(store: Store, rev: str, node_id: str) -> Report:
         confidence = node_kinds[kind]
         chain = witness_path(store, rev, node_id, kind, confidence)
         cause = chain[-1] if chain else node_id
-        location = _evidence_location(store, rev, cause, kind)
+        location = _evidence_location(store, rev, cause, kind, confidence)
         detail = f"{kind} {confidence} via {' -> '.join(chain)}"
         score = float(len(ordered) - rank)
         row = Row(id=f"{node_id}::{kind}", location=location, detail=detail, score=score)
@@ -68,15 +68,36 @@ def effects_report(store: Store, rev: str, node_id: str) -> Report:
     )
 
 
-def _evidence_location(store: Store, rev: str, direct_node_id: str, kind: str) -> str:
+def _evidence_location(
+    store: Store, rev: str, direct_node_id: str, kind: str, confidence: str
+) -> str:
     """The concrete `path:line` of the direct call site causing `kind` at
-    `direct_node_id` -- the tail of the witness chain."""
-    row = store.connection.execute(
-        "SELECT evidence_path, evidence_line FROM effects"
-        " WHERE rev=? AND node_id=? AND kind=? AND direct=1"
-        " ORDER BY evidence_line LIMIT 1",
+    `direct_node_id` -- the tail of the witness chain.
+
+    `direct_node_id` can carry more than one `direct=1` row for the same
+    `kind`, at different confidences and different lines (no UNIQUE
+    constraint on `effects`, and `detect_direct` writes one row per call
+    site -- two `open()` calls in one function, one with a literal mode and
+    one with a variable mode, is enough). Picking the earliest line with no
+    confidence filter can print evidence that contradicts the reported
+    confidence: an ambiguous MEDIUM call that happens to sit on an earlier
+    line than the HIGH call that actually earns the tier being printed. So
+    this only considers rows whose OWN confidence supports `confidence`
+    (rank >= it) -- the same eligibility test `witness_path` applies to a
+    chain's endpoint -- and picks the earliest line among those.
+    """
+    target_rank = CONFIDENCE_RANK[confidence]
+    best: tuple[int, str] | None = None
+    for row in store.connection.execute(
+        "SELECT evidence_path, evidence_line, confidence FROM effects"
+        " WHERE rev=? AND node_id=? AND kind=? AND direct=1",
         (rev, direct_node_id, kind),
-    ).fetchone()
-    if row is None:
+    ):
+        if CONFIDENCE_RANK[row["confidence"]] < target_rank:
+            continue
+        if best is None or row["evidence_line"] < best[0]:
+            best = (row["evidence_line"], row["evidence_path"])
+    if best is None:
         return ""
-    return f"{row['evidence_path']}:{row['evidence_line']}"
+    line, path = best
+    return f"{path}:{line}"

--- a/src/codegraph/query/effects.py
+++ b/src/codegraph/query/effects.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from codegraph.effects.propagate import witness_path
 from codegraph.render import Group, Report, Row
+from codegraph.resolve import CONFIDENCE_RANK, stronger
 from codegraph.store import Store
 
 #: Worst-first. DB writes and network calls are the effects a reviewer
@@ -27,7 +28,6 @@ _SEVERITY: tuple[str, ...] = (
     "NONDETERMINISM",
 )
 _SEVERITY_RANK = {kind: rank for rank, kind in enumerate(_SEVERITY)}
-_CONFIDENCE_RANK = {"HIGH": 0, "MEDIUM": 1, "LOW": 2}
 
 
 def effects_report(store: Store, rev: str, node_id: str) -> Report:
@@ -38,12 +38,16 @@ def effects_report(store: Store, rev: str, node_id: str) -> Report:
         "SELECT kind, confidence FROM effects WHERE rev=? AND node_id=?", (rev, node_id)
     ):
         best = node_kinds.get(row["kind"])
-        if best is None or _CONFIDENCE_RANK[row["confidence"]] < _CONFIDENCE_RANK[best]:
-            node_kinds[row["kind"]] = row["confidence"]
+        node_kinds[row["kind"]] = (
+            row["confidence"] if best is None else stronger(best, row["confidence"])
+        )
 
+    # Worst severity first, then strongest confidence first within a
+    # severity -- `CONFIDENCE_RANK` is higher-is-stronger, so this sorts on
+    # its negation to put HIGH ahead of LOW.
     ordered = sorted(
         node_kinds,
-        key=lambda k: (_SEVERITY_RANK.get(k, len(_SEVERITY)), _CONFIDENCE_RANK[node_kinds[k]]),
+        key=lambda k: (_SEVERITY_RANK.get(k, len(_SEVERITY)), -CONFIDENCE_RANK[node_kinds[k]]),
     )
 
     groups: list[Group] = []

--- a/src/codegraph/query/impact.py
+++ b/src/codegraph/query/impact.py
@@ -1,0 +1,180 @@
+"""The `impact` report: everything downstream of a symbol that a change to
+it could break, ranked by how urgently each dependent deserves review.
+
+A reverse BFS over `edges(rev, dst)`, starting at the queried symbol and
+walking CALLS edges backward to its callers, its callers' callers, and so
+on up to `max_hops`. Each dependent is recorded the first time it is
+reached (fewest hops), and among the edges available at that hop the
+strongest achievable path confidence wins -- the same widest-path bias
+`effects/propagate.py` uses for effect reachability, applied here to
+dependents. Duplicate edge rows for the same `(src, dst)` pair (the same
+call written twice in a body, or the same candidate reached through two
+import aliases) collapse to a single edge of their strongest confidence
+before the walk starts, so they can never count as two distinct hops or
+inflate `rank.salience`'s fan-in term.
+
+Rows whose path starts with `tests/` or whose qualname's last segment
+starts with `test_` are split into their own `tests` group -- a change
+breaking a test is worth knowing, but it should never crowd out production
+callers in the ranked list. `LOW`-confidence dependents are counted in the
+summary but held back from both groups unless `include_low` is set: the
+resolver's least certain guesses are real information, but they should not
+read as confirmed impact by default.
+"""
+
+from __future__ import annotations
+
+from codegraph.query.rank import salience, score
+from codegraph.render import Group, Report, Row, budget
+from codegraph.resolve import HIGH, LOW, MEDIUM
+from codegraph.store import Store
+
+_RANK = {LOW: 0, MEDIUM: 1, HIGH: 2}
+
+
+def _stronger(a: str, b: str) -> str:
+    return a if _RANK[a] >= _RANK[b] else b
+
+
+def _weaker(a: str, b: str) -> str:
+    return a if _RANK[a] <= _RANK[b] else b
+
+
+def _reverse_edges(store: Store, rev: str) -> dict[str, dict[str, str]]:
+    """dst -> {src: confidence}, one entry per (src, dst) pair at its
+    strongest confidence -- duplicate edge rows collapsed before the walk."""
+    edge_confidence: dict[tuple[str, str], str] = {}
+    for row in store.connection.execute(
+        "SELECT src, dst, confidence FROM edges WHERE rev=? AND kind='CALLS'", (rev,)
+    ):
+        key = (row["src"], row["dst"])
+        edge_confidence[key] = _stronger(
+            edge_confidence.get(key, row["confidence"]), row["confidence"]
+        )
+
+    reverse: dict[str, dict[str, str]] = {}
+    for (src, dst), confidence in edge_confidence.items():
+        reverse.setdefault(dst, {})[src] = confidence
+    return reverse
+
+
+def _walk(
+    reverse: dict[str, dict[str, str]], node_id: str, max_hops: int
+) -> dict[str, tuple[int, str]]:
+    """Reverse BFS from `node_id`: node -> (hop, path confidence), each node
+    recorded once at its shortest hop, with the strongest confidence
+    achievable among the edges reaching it at that hop."""
+    found: dict[str, tuple[int, str]] = {}
+    level_confidence: dict[str, str] = {node_id: HIGH}
+    current_level = {node_id}
+    visited = {node_id}
+    hop = 0
+    while current_level and hop < max_hops:
+        next_level: dict[str, str] = {}
+        for current in current_level:
+            path_confidence = level_confidence[current]
+            for src, edge_confidence in reverse.get(current, {}).items():
+                if src in visited:
+                    continue
+                candidate = _weaker(path_confidence, edge_confidence)
+                best = next_level.get(src)
+                if best is None or _RANK[candidate] > _RANK[best]:
+                    next_level[src] = candidate
+        hop += 1
+        for src, confidence in next_level.items():
+            visited.add(src)
+            found[src] = (hop, confidence)
+        level_confidence = next_level
+        current_level = set(next_level)
+    return found
+
+
+def _is_test(path: str, qualname: str) -> bool:
+    return path.startswith("tests/") or qualname.rpartition(".")[2].startswith("test_")
+
+
+def impact_report(
+    store: Store,
+    rev: str,
+    node_id: str,
+    max_hops: int = 3,
+    limit: int = 40,
+    include_low: bool = False,
+) -> Report:
+    """Everything reachable from `node_id` by walking CALLS edges backward,
+    ranked by `rank.score` and split into `dependents` and `tests` groups."""
+    connection = store.connection
+    reverse = _reverse_edges(store, rev)
+    found = _walk(reverse, node_id, max_hops)
+
+    node_info: dict[str, tuple[str, str, int]] = {}
+    if found:
+        placeholders = ",".join("?" * len(found))
+        for row in connection.execute(
+            f"SELECT id, path, qualname, line_start FROM nodes WHERE rev=? AND id IN ({placeholders})",
+            (rev, *found),
+        ):
+            node_info[row["id"]] = (row["path"], row["qualname"], row["line_start"])
+
+    dependent_rows: list[Row] = []
+    test_rows: list[Row] = []
+    low_confidence_hidden = 0
+    entry_points = 0
+    modules: set[str] = set()
+
+    for dependent_id, (hop, confidence) in found.items():
+        info = node_info.get(dependent_id)
+        if info is None:
+            # Should not happen: every edge endpoint owns a node row for a
+            # revision that resolve.py just resolved.
+            continue
+        path, qualname, line_start = info
+
+        if confidence == LOW and not include_low:
+            low_confidence_hidden += 1
+            continue
+
+        salience_value = salience(store, rev, dependent_id)
+        if salience_value >= 0.5:
+            entry_points += 1
+        modules.add(path)
+
+        row = Row(
+            id=dependent_id,
+            location=f"{path}:{line_start}",
+            detail=f"hop {hop}, {confidence} confidence",
+            score=score(hop, confidence, salience_value),
+        )
+        if _is_test(path, qualname):
+            test_rows.append(row)
+        else:
+            dependent_rows.append(row)
+
+    kept, truncated = budget(dependent_rows, limit)
+    groups = [Group("dependents", kept)] if kept else []
+    if test_rows:
+        kept_tests, tests_truncated = budget(test_rows, limit)
+        groups.append(Group("tests", kept_tests))
+        truncated = truncated or tests_truncated
+
+    effects_reachable = sorted(
+        {
+            row["kind"]
+            for row in connection.execute(
+                "SELECT DISTINCT kind FROM effects WHERE rev=? AND node_id=?", (rev, node_id)
+            )
+        }
+    )
+
+    summary = {
+        "symbols": len(dependent_rows) + len(test_rows),
+        "modules": len(modules),
+        "entry_points": entry_points,
+        "low_confidence_hidden": low_confidence_hidden,
+        "effects_reachable": effects_reachable,
+    }
+
+    return Report(summary=summary, groups=groups, truncated=truncated)
+
+
+__all__ = ["impact_report"]

--- a/src/codegraph/query/impact.py
+++ b/src/codegraph/query/impact.py
@@ -24,7 +24,7 @@ read as confirmed impact by default.
 
 from __future__ import annotations
 
-from codegraph.query.rank import salience, score
+from codegraph.query.rank import fan_in, salience, score
 from codegraph.render import Group, Report, Row, budget
 from codegraph.resolve import HIGH, LOW, MEDIUM
 from codegraph.store import Store
@@ -135,7 +135,7 @@ def impact_report(
             continue
 
         salience_value = salience(store, rev, dependent_id)
-        if salience_value >= 0.5:
+        if fan_in(store, rev, dependent_id) == 0:
             entry_points += 1
         modules.add(path)
 

--- a/src/codegraph/query/impact.py
+++ b/src/codegraph/query/impact.py
@@ -26,18 +26,10 @@ from __future__ import annotations
 
 from codegraph.query.rank import fan_in, salience, score
 from codegraph.render import Group, Report, Row, budget
-from codegraph.resolve import HIGH, LOW, MEDIUM
+from codegraph.resolve import CONFIDENCE_RANK, HIGH, LOW, stronger, weaker
 from codegraph.store import Store
 
-_RANK = {LOW: 0, MEDIUM: 1, HIGH: 2}
-
-
-def _stronger(a: str, b: str) -> str:
-    return a if _RANK[a] >= _RANK[b] else b
-
-
-def _weaker(a: str, b: str) -> str:
-    return a if _RANK[a] <= _RANK[b] else b
+_RANK = CONFIDENCE_RANK
 
 
 def _reverse_edges(store: Store, rev: str) -> dict[str, dict[str, str]]:
@@ -48,7 +40,7 @@ def _reverse_edges(store: Store, rev: str) -> dict[str, dict[str, str]]:
         "SELECT src, dst, confidence FROM edges WHERE rev=? AND kind='CALLS'", (rev,)
     ):
         key = (row["src"], row["dst"])
-        edge_confidence[key] = _stronger(
+        edge_confidence[key] = stronger(
             edge_confidence.get(key, row["confidence"]), row["confidence"]
         )
 
@@ -76,7 +68,7 @@ def _walk(
             for src, edge_confidence in reverse.get(current, {}).items():
                 if src in visited:
                     continue
-                candidate = _weaker(path_confidence, edge_confidence)
+                candidate = weaker(path_confidence, edge_confidence)
                 best = next_level.get(src)
                 if best is None or _RANK[candidate] > _RANK[best]:
                     next_level[src] = candidate
@@ -150,11 +142,16 @@ def impact_report(
         else:
             dependent_rows.append(row)
 
+    # `limit` is a TOTAL budget across both groups, not `limit` rows each --
+    # `dependents` gets first claim on it (production callers should never
+    # be crowded out by tests), and whatever's left over budgets `tests`.
     kept, truncated = budget(dependent_rows, limit)
     groups = [Group("dependents", kept)] if kept else []
+    remaining = limit - len(kept)
     if test_rows:
-        kept_tests, tests_truncated = budget(test_rows, limit)
-        groups.append(Group("tests", kept_tests))
+        kept_tests, tests_truncated = budget(test_rows, remaining)
+        if kept_tests:
+            groups.append(Group("tests", kept_tests))
         truncated = truncated or tests_truncated
 
     effects_reachable = sorted(

--- a/src/codegraph/query/rank.py
+++ b/src/codegraph/query/rank.py
@@ -28,6 +28,20 @@ def score(hop: int, confidence: str, salience_value: float) -> float:
     return (1.0 / hop) * _CONFIDENCE_WEIGHT[confidence] * (1.0 + salience_value)
 
 
+def fan_in(store: Store, rev: str, node_id: str) -> int:
+    """Count of DISTINCT callers of `node_id` -- never raw edge rows, since
+    the `edges` table can hold more than one row for the same (src, dst)
+    pair. `salience` folds this into its composite score; callers that need
+    the raw fan-in itself (e.g. to test whether a node is a true entry
+    point, `fan_in == 0`) should call this directly rather than
+    reverse-engineering it out of `salience`'s combined value, which a
+    public, well-called node can also cross via its other two terms alone."""
+    row = store.connection.execute(
+        "SELECT COUNT(DISTINCT src) AS n FROM edges WHERE rev=? AND dst=?", (rev, node_id)
+    ).fetchone()
+    return row["n"]
+
+
 def salience(store: Store, rev: str, node_id: str) -> float:
     """How much a node deserves attention on its own merits: 0.5 if it has
     no callers of its own (an entry point), 0.3 if its qualname's last
@@ -35,12 +49,10 @@ def salience(store: Store, rev: str, node_id: str) -> float:
     capped at `_FAN_IN_CAP` distinct callers."""
     connection = store.connection
 
-    fan_in = connection.execute(
-        "SELECT COUNT(DISTINCT src) AS n FROM edges WHERE rev=? AND dst=?", (rev, node_id)
-    ).fetchone()["n"]
+    callers = fan_in(store, rev, node_id)
 
     value = 0.0
-    if fan_in == 0:
+    if callers == 0:
         value += 0.5
 
     row = connection.execute(
@@ -50,9 +62,9 @@ def salience(store: Store, rev: str, node_id: str) -> float:
     if not last_segment.startswith("_"):
         value += 0.3
 
-    value += min(fan_in, _FAN_IN_CAP) / 20
+    value += min(callers, _FAN_IN_CAP) / 20
 
     return value
 
 
-__all__ = ["salience", "score"]
+__all__ = ["fan_in", "salience", "score"]

--- a/src/codegraph/query/rank.py
+++ b/src/codegraph/query/rank.py
@@ -1,0 +1,58 @@
+"""Scoring for the `impact` report: how urgently a dependent deserves a
+human's attention, given how far it sits from the changed symbol, how
+confident the resolver was about the path, and how salient the dependent
+itself is.
+
+`salience` counts fan-in over DISTINCT source nodes, never edge rows: the
+`edges` table can hold more than one row for the same `(src, dst)` pair --
+the same call written twice in a body, or the same candidate reached
+through two import aliases -- and none of that should inflate how many
+distinct callers a node has.
+"""
+
+from __future__ import annotations
+
+from codegraph.resolve import HIGH, LOW, MEDIUM
+from codegraph.store import Store
+
+_CONFIDENCE_WEIGHT = {HIGH: 1.0, MEDIUM: 0.6, LOW: 0.25}
+
+#: Fan-in is capped before it contributes to salience, so one extremely
+#: popular utility cannot dwarf every other salience term.
+_FAN_IN_CAP = 10
+
+
+def score(hop: int, confidence: str, salience_value: float) -> float:
+    """Rank a dependent: closer hops and higher resolver confidence score
+    higher, boosted by how salient the dependent itself is."""
+    return (1.0 / hop) * _CONFIDENCE_WEIGHT[confidence] * (1.0 + salience_value)
+
+
+def salience(store: Store, rev: str, node_id: str) -> float:
+    """How much a node deserves attention on its own merits: 0.5 if it has
+    no callers of its own (an entry point), 0.3 if its qualname's last
+    segment is not private (does not start with `_`), plus a fan-in term
+    capped at `_FAN_IN_CAP` distinct callers."""
+    connection = store.connection
+
+    fan_in = connection.execute(
+        "SELECT COUNT(DISTINCT src) AS n FROM edges WHERE rev=? AND dst=?", (rev, node_id)
+    ).fetchone()["n"]
+
+    value = 0.0
+    if fan_in == 0:
+        value += 0.5
+
+    row = connection.execute(
+        "SELECT qualname FROM nodes WHERE rev=? AND id=?", (rev, node_id)
+    ).fetchone()
+    last_segment = row["qualname"].rpartition(".")[2] if row else node_id.rpartition(".")[2]
+    if not last_segment.startswith("_"):
+        value += 0.3
+
+    value += min(fan_in, _FAN_IN_CAP) / 20
+
+    return value
+
+
+__all__ = ["salience", "score"]

--- a/src/codegraph/render.py
+++ b/src/codegraph/render.py
@@ -1,0 +1,100 @@
+"""Presentation layer: convert reports to text and JSON."""
+
+import dataclasses
+import json
+
+
+@dataclasses.dataclass(frozen=True)
+class Row:
+    """A single result row."""
+
+    id: str
+    location: str
+    detail: str
+    score: float
+
+
+@dataclasses.dataclass(frozen=True)
+class Group:
+    """A group of rows with a title."""
+
+    title: str
+    rows: list[Row]
+
+
+@dataclasses.dataclass(frozen=True)
+class Report:
+    """A full report with summary, groups, and truncation flag."""
+
+    summary: dict
+    groups: list[Group]
+    truncated: bool
+
+
+def budget(rows: list[Row], limit: int) -> tuple[list[Row], bool]:
+    """Sort rows by score descending, keep top limit, return (kept, truncated).
+
+    Args:
+        rows: List of Row objects to budget.
+        limit: Maximum number of rows to keep.
+
+    Returns:
+        Tuple of (kept rows sorted by score descending, was_truncated).
+        was_truncated is True if len(rows) > limit.
+    """
+    was_truncated = len(rows) > limit
+    sorted_rows = sorted(rows, key=lambda r: r.score, reverse=True)
+    kept = sorted_rows[:limit]
+    return kept, was_truncated
+
+
+def render_text(report: Report) -> str:
+    """Render report as human-readable text.
+
+    Format:
+    - First line: summary items joined with ' · '
+    - Then each group as a heading followed by indented rows
+
+    Args:
+        report: Report to render.
+
+    Returns:
+        Formatted text string.
+    """
+    lines = []
+
+    # Summary line: join all values with ' · '
+    summary_items = [str(v) for v in report.summary.values()]
+    summary_line = " · ".join(summary_items)
+    lines.append(summary_line)
+
+    # Groups
+    for group in report.groups:
+        lines.append(group.title)
+        for row in group.rows:
+            lines.append(f"  {row.id}  {row.location}  {row.detail}")
+
+    return "\n".join(lines)
+
+
+def render_json(report: Report) -> str:
+    """Render report as JSON.
+
+    Args:
+        report: Report to render.
+
+    Returns:
+        JSON string with indent=2.
+    """
+    report_dict = dataclasses.asdict(report)
+    return json.dumps(report_dict, indent=2)
+
+
+__all__ = [
+    "Group",
+    "Report",
+    "Row",
+    "budget",
+    "render_json",
+    "render_text",
+]

--- a/src/codegraph/render.py
+++ b/src/codegraph/render.py
@@ -48,11 +48,22 @@ def budget(rows: list[Row], limit: int) -> tuple[list[Row], bool]:
     return kept, was_truncated
 
 
+def _format_summary_value(value: object) -> str:
+    """Render one summary value for the text format. A list (e.g.
+    `effects_reachable: ["DB_WRITE", "PROCESS"]`) is joined with ', ' rather
+    than shown as Python's `repr` (`['DB_WRITE', 'PROCESS']`) -- readable
+    output, not a debugger dump. An empty list reads as 'none' rather than
+    a blank field, so `key: ` never appears with nothing after the colon."""
+    if isinstance(value, list):
+        return ", ".join(str(item) for item in value) if value else "none"
+    return str(value)
+
+
 def render_text(report: Report) -> str:
     """Render report as human-readable text.
 
     Format:
-    - First line: summary items joined with ' · '
+    - First line: summary items as 'key: value', joined with ' · '
     - Then each group as a heading followed by indented rows
 
     Args:
@@ -63,8 +74,12 @@ def render_text(report: Report) -> str:
     """
     lines = []
 
-    # Summary line: join all values with ' · '
-    summary_items = [str(v) for v in report.summary.values()]
+    # Summary line: 'key: value' pairs joined with ' · ', so every field is
+    # labeled -- unlabeled positional values (`2 · 1 · 1 · 0 · ['DB_WRITE']`)
+    # are meaningless without cross-referencing the producer's source.
+    summary_items = [
+        f"{key}: {_format_summary_value(value)}" for key, value in report.summary.items()
+    ]
     summary_line = " · ".join(summary_items)
     lines.append(summary_line)
 

--- a/src/codegraph/resolve.py
+++ b/src/codegraph/resolve.py
@@ -26,6 +26,28 @@ from codegraph.store import Store
 
 HIGH, MEDIUM, LOW = "HIGH", "MEDIUM", "LOW"
 
+#: Canonical rank for comparing confidence tiers: higher is stronger. This
+#: is the one place the tier order is defined -- `effects/propagate.py`,
+#: `query/impact.py`, and `query/effects.py` all compare confidence tiers
+#: and used to each redefine this table locally, with no guarantee they
+#: agreed: two copies used higher-is-stronger, one used the opposite
+#: polarity with the tiers spelled out as separate string literals rather
+#: than these constants, so renaming a tier would have silently produced a
+#: `KeyError` in whichever copy nobody happened to update. Importing this
+#: one table (and `stronger`/`weaker` below) is the fix.
+CONFIDENCE_RANK: dict[str, int] = {LOW: 0, MEDIUM: 1, HIGH: 2}
+
+
+def stronger(a: str, b: str) -> str:
+    """The more confident of two tiers (ties favor `a`)."""
+    return a if CONFIDENCE_RANK[a] >= CONFIDENCE_RANK[b] else b
+
+
+def weaker(a: str, b: str) -> str:
+    """The less confident of two tiers (ties favor `a`)."""
+    return a if CONFIDENCE_RANK[a] <= CONFIDENCE_RANK[b] else b
+
+
 PROVENANCE = "static"
 
 #: `src` for a reference made at module scope, which owns no node of its own.
@@ -443,11 +465,23 @@ def dependents(store: Store, rev: str, modules: set[str]) -> set[str]:
 
 
 def find_symbol(store: Store, rev: str, query: str) -> list[sqlite3.Row]:
-    """Fuzzy lookup: exact id, then exact qualname, then suffix match."""
+    """Fuzzy lookup: exact id, then exact qualname, then suffix match.
+
+    All three steps compare case-insensitively (`COLLATE NOCASE` for the
+    two exact steps; `LIKE`'s own ASCII case-folding, already the default,
+    for the suffix step), so a query's case can never change which set of
+    symbols comes back -- `resolve charge` and `resolve CHARGE` return the
+    identical result. Before this, steps 1-2 compared with binary `=`
+    while step 3 was already case-insensitive, so a query differing only
+    in case from the real name could fall straight through the (missed)
+    exact steps and land on step 3's dot-anchored suffix pattern -- which
+    can never match a top-level, dot-free qualname at all -- producing a
+    completely different, disjoint match set instead of the same one.
+    """
     columns = "id, path, qualname, kind, line_start, line_end, name_binding"
     for clause, parameters in (
-        ("id=?", (query,)),
-        ("qualname=?", (query,)),
+        ("id=? COLLATE NOCASE", (query,)),
+        ("qualname=? COLLATE NOCASE", (query,)),
         ("qualname LIKE ? ESCAPE '\\'", (f"%.{_escape_like(query)}",)),
     ):
         rows = store.connection.execute(

--- a/src/codegraph/resolve.py
+++ b/src/codegraph/resolve.py
@@ -206,6 +206,7 @@ class AstResolver:
 class ResolveStats:
     edges: int = 0
     unresolved: int = 0
+    ambiguous: int = 0
 
 
 def build_import_maps(
@@ -379,17 +380,51 @@ def _source_id(ref: ParsedRef, table: _SymbolTable, path: str) -> str:
     return table.qualname_index.get((path, ref.from_qualname), candidates[-1][0])
 
 
+def split_by_ambiguity_limit(
+    hits: list[tuple[str, str]], limit: int
+) -> tuple[list[tuple[str, str]], int]:
+    """Split a resolver's candidates into the ones to materialize and the count
+    of low-confidence ones being collapsed instead.
+
+    The over-approximation bias says a candidate is never dropped to improve
+    precision, and this does not drop one: when a bare name matches hundreds of
+    definitions, the N edges and the single "ambiguous, N candidates" record
+    make exactly the same claim. Enumerating it is what is being declined, not
+    asserting it -- and enumerating it is quadratic in repo size while saying
+    nothing a reader could act on.
+
+    Only LOW candidates are ever collapsed. A HIGH or MEDIUM hit means the
+    resolver actually distinguished something, and is always materialized --
+    including alongside a collapsed LOW set, so a call site with one confident
+    answer and a long ambiguous tail keeps the answer.
+
+    `limit <= 0` disables the cap entirely.
+    """
+    if limit <= 0 or len(hits) <= limit:
+        return hits, 0
+    weak = [hit for hit in hits if hit[1] == LOW]
+    if len(weak) <= limit:
+        return hits, 0
+    return [hit for hit in hits if hit[1] != LOW], len(weak)
+
+
 def resolve_revision(
     store: Store, rev: str, config: Config, resolver: Resolver | None = None
 ) -> ResolveStats:
     """Rewrite `edges`, `imports` and `unresolved` for one revision.
 
-    v1 re-resolves the whole revision rather than narrowing to
-    `dependents()`; resolution is cheap next to parsing and a whole-revision
-    rewrite cannot leave a stale edge behind.
+    Still re-resolves the whole revision rather than narrowing to
+    `dependents()`: a whole-revision rewrite cannot leave a stale edge behind.
+    That is the one half of the cost guarantee this does not yet honour --
+    tracked, and stated in the README rather than glossed.
+
+    `config.ambiguity_limit` bounds how many indistinguishable LOW candidates a
+    single reference will be expanded into; past it the reference is recorded
+    once in `unresolved` as ambiguous. See `split_by_ambiguity_limit`.
     """
     resolver = resolver or AstResolver()
     connection = store.connection
+    limit = config.ambiguity_limit
     table = _SymbolTable(store, rev, config)
 
     connection.execute("DELETE FROM edges WHERE rev=?", (rev,))
@@ -406,6 +441,7 @@ def resolve_revision(
 
     edge_rows: list[tuple] = []
     unresolved_rows: list[tuple] = []
+    ambiguous_rows: list[tuple] = []
 
     # Inheritance first: `self.X` walks the class hierarchy, so the hierarchy
     # has to exist before any call is resolved.
@@ -415,7 +451,14 @@ def resolve_revision(
         ctx = table.context(rev, path, bases)
         for ref in base_refs.get(path, ()):
             src = _source_id(ref, table, path)
-            for node_id, confidence in resolver.resolve_call(ref, ctx):
+            # A base named by a bare, repo-wide-ambiguous name fans out exactly
+            # like a call does, and on a large repo it is the larger half of the
+            # blowup. Capping it cannot affect the MRO: only HIGH links feed
+            # `bases`, and the cap only ever collapses LOW ones.
+            kept, ambiguous_count = split_by_ambiguity_limit(
+                resolver.resolve_call(ref, ctx), limit
+            )
+            for node_id, confidence in kept:
                 edge_rows.append(
                     (rev, src, node_id, "INHERITS", confidence, PROVENANCE, path, ref.line)
                 )
@@ -424,6 +467,10 @@ def resolve_revision(
                 # the walk falls through to the repo-wide name match anyway.
                 if confidence == HIGH:
                     bases.setdefault(src, []).append(node_id)
+            if ambiguous_count:
+                ambiguous_rows.append(
+                    (rev, path, ref.line, ref.raw_name, "base", "ambiguous", ambiguous_count)
+                )
 
     call_refs = _refs_by_path(store, rev, "call")
     for path in table.paths:
@@ -431,14 +478,19 @@ def resolve_revision(
         for ref in call_refs.get(path, ()):
             src = _source_id(ref, table, path)
             hits = resolver.resolve_call(ref, ctx)
-            for node_id, confidence in hits:
+            kept, ambiguous_count = split_by_ambiguity_limit(hits, limit)
+            for node_id, confidence in kept:
                 edge_rows.append(
                     (rev, src, node_id, "CALLS", confidence, PROVENANCE, path, ref.line)
                 )
-            if not hits:
+            if ambiguous_count:
+                ambiguous_rows.append(
+                    (rev, path, ref.line, ref.raw_name, "call", "ambiguous", ambiguous_count)
+                )
+            elif not hits:
                 # Never dropped: the ref stays in `blob_refs` for effect
                 # detection, and the gap is counted as a health signal.
-                unresolved_rows.append((rev, path, ref.line, ref.raw_name))
+                unresolved_rows.append((rev, path, ref.line, ref.raw_name, "call", "unknown", 0))
 
     connection.executemany(
         "INSERT INTO edges(rev, src, dst, kind, confidence, provenance, callsite_path,"
@@ -446,10 +498,15 @@ def resolve_revision(
         edge_rows,
     )
     connection.executemany(
-        "INSERT INTO unresolved(rev, path, line, raw_name) VALUES(?, ?, ?, ?)",
-        unresolved_rows,
+        "INSERT INTO unresolved(rev, path, line, raw_name, ref_kind, reason, candidates)"
+        " VALUES(?, ?, ?, ?, ?, ?, ?)",
+        unresolved_rows + ambiguous_rows,
     )
-    return ResolveStats(edges=len(edge_rows), unresolved=len(unresolved_rows))
+    return ResolveStats(
+        edges=len(edge_rows),
+        unresolved=len(unresolved_rows),
+        ambiguous=len(ambiguous_rows),
+    )
 
 
 def dependents(store: Store, rev: str, modules: set[str]) -> set[str]:

--- a/src/codegraph/resolve.py
+++ b/src/codegraph/resolve.py
@@ -186,6 +186,53 @@ class ResolveStats:
     unresolved: int = 0
 
 
+def build_import_maps(
+    connection: sqlite3.Connection, rev: str, config: Config
+) -> tuple[dict[str, dict[str, str]], dict[str, set[str]]]:
+    """Per-path local-alias -> absolute-dotted-module map, and the set of
+    modules each path imports (feeds `dependents()`).
+
+    The one place a raw `import`/`from ... import` row -- with its
+    relative-import `level` -- gets expanded into an absolute dotted module
+    name. Both the resolver (`_SymbolTable`, below) and effect detection's
+    catalog expansion (`effects/detect.py`) build on this rather than each
+    repeating the expansion, so the two cannot silently drift apart.
+    """
+    paths = [
+        row["path"]
+        for row in connection.execute("SELECT DISTINCT path FROM tree WHERE rev=?", (rev,))
+    ]
+    module_for = {path: module_for_path(path, config.source_roots) for path in paths}
+    alias_maps: dict[str, dict[str, str]] = {path: {} for path in paths}
+    imported_modules: dict[str, set[str]] = {path: set() for path in paths}
+
+    rows = connection.execute(
+        "SELECT t.path, i.module, i.level, i.name, i.alias FROM blob_imports i"
+        " JOIN tree t ON t.blob_sha = i.blob_sha WHERE t.rev=? ORDER BY t.path, i.ordinal",
+        (rev,),
+    )
+    for row in rows:
+        path = row["path"]
+        alias_map = alias_maps[path]
+        modules = imported_modules[path]
+        package = package_for_module(module_for[path], path)
+        module = absolute_module(row["module"], row["level"], package)
+        if row["name"] is None:
+            # `import a.b` / `import a.b as c`: the alias names the module,
+            # and a plain import also makes the full dotted path usable.
+            alias_map[row["alias"] or module] = module
+            if row["alias"] is None:
+                alias_map.setdefault(module.partition(".")[0], module.partition(".")[0])
+        else:
+            target = f"{module}.{row['name']}" if module else row["name"]
+            alias_map[row["alias"] or row["name"]] = target
+            # `from a.b import c` may name a module or a symbol; record both.
+            modules.add(target)
+        if module:
+            modules.add(module)
+    return alias_maps, imported_modules
+
+
 class _SymbolTable:
     """The revision's live symbol table, plus the per-file import maps."""
 
@@ -235,37 +282,7 @@ class _SymbolTable:
             if found:
                 self.enclosing_class[row["id"]] = found
 
-        self.import_maps: dict[str, dict[str, str]] = {path: {} for path in self.paths}
-        self.imported_modules: dict[str, set[str]] = {path: set() for path in self.paths}
-        self._build_imports(connection, rev)
-
-    def _build_imports(self, connection: sqlite3.Connection, rev: str) -> None:
-        """One pass over the revision's imports, expanding relative ones."""
-        rows = connection.execute(
-            "SELECT t.path, i.module, i.level, i.name, i.alias FROM blob_imports i"
-            " JOIN tree t ON t.blob_sha = i.blob_sha"
-            " WHERE t.rev=? ORDER BY t.path, i.ordinal",
-            (rev,),
-        )
-        for row in rows:
-            path = row["path"]
-            alias_map = self.import_maps[path]
-            modules = self.imported_modules[path]
-            package = package_for_module(self.module_for[path], path)
-            module = absolute_module(row["module"], row["level"], package)
-            if row["name"] is None:
-                # `import a.b` / `import a.b as c`: the alias names the module,
-                # and a plain import also makes the full dotted path usable.
-                alias_map[row["alias"] or module] = module
-                if row["alias"] is None:
-                    alias_map.setdefault(module.partition(".")[0], module.partition(".")[0])
-            else:
-                target = f"{module}.{row['name']}" if module else row["name"]
-                alias_map[row["alias"] or row["name"]] = target
-                # `from a.b import c` may name a module or a symbol; record both.
-                modules.add(target)
-            if module:
-                modules.add(module)
+        self.import_maps, self.imported_modules = build_import_maps(connection, rev, config)
 
     def context(self, rev: str, path: str, bases: dict[str, list[str]]) -> ResolveContext:
         return ResolveContext(

--- a/src/codegraph/store.py
+++ b/src/codegraph/store.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 WORKTREE = "WORKTREE"
 
@@ -107,8 +107,20 @@ CREATE TABLE IF NOT EXISTS effects (
 CREATE TABLE IF NOT EXISTS imports (
     rev TEXT NOT NULL, importer_path TEXT NOT NULL, module TEXT NOT NULL
 );
+-- A call site that produced no edge, and why. `reason` is 'unknown' when no
+-- candidate was found at all, or 'ambiguous' when too many equally-weak ones
+-- were (see config.DEFAULT_AMBIGUITY_LIMIT); `candidates` carries the count the
+-- ambiguous case declined to enumerate, and is 0 for 'unknown'. Separating the
+-- two matters because they are opposite problems: 'unknown' means the resolver
+-- is blind to something, 'ambiguous' means it sees too much.
 CREATE TABLE IF NOT EXISTS unresolved (
-    rev TEXT NOT NULL, path TEXT NOT NULL, line INTEGER NOT NULL, raw_name TEXT NOT NULL
+    rev TEXT NOT NULL,
+    path TEXT NOT NULL,
+    line INTEGER NOT NULL,
+    raw_name TEXT NOT NULL,
+    ref_kind TEXT NOT NULL DEFAULT 'call',
+    reason TEXT NOT NULL DEFAULT 'unknown',
+    candidates INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE INDEX IF NOT EXISTS idx_edges_dst ON edges(rev, dst);

--- a/src/codegraph/store.py
+++ b/src/codegraph/store.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 WORKTREE = "WORKTREE"
 
@@ -25,7 +25,8 @@ CREATE TABLE IF NOT EXISTS blobs (
     blob_sha TEXT PRIMARY KEY,
     status TEXT NOT NULL,
     error TEXT,
-    parser_version TEXT NOT NULL
+    parser_version TEXT NOT NULL,
+    module_body_hash TEXT NOT NULL DEFAULT ''
 );
 CREATE TABLE IF NOT EXISTS blob_nodes (
     blob_sha TEXT NOT NULL,

--- a/tests/fixtures/labelled_calls.json
+++ b/tests/fixtures/labelled_calls.json
@@ -1,0 +1,47 @@
+{
+  "_readme": "Ground truth is hand-derived by reasoning about (and, where noted in task-15-report.md, executing) what these modules actually do at runtime -- never by running codegraph and recording its output. See task-15-report.md for the derivation of every entry below.",
+  "files": {
+    "pkg/__init__.py": "",
+    "pkg/utils.py": "def helper():\n    return \"utils.helper\"\n",
+    "pkg/plain_import.py": "import pkg.utils\n\n\ndef call_helper():\n    return pkg.utils.helper()\n",
+    "pkg/from_alias.py": "from pkg.utils import helper as h\n\n\ndef call_via_alias():\n    return h()\n",
+    "pkg/relative.py": "from .utils import helper\n\n\ndef call_relative():\n    return helper()\n",
+    "pkg/counter.py": "class Counter:\n    def __init__(self):\n        self.value = 0\n\n    def increment(self):\n        self.value += 1\n        return self._report()\n\n    def _report(self):\n        return f\"value={self.value}\"\n",
+    "pkg/inherit.py": "class Named:\n    def identify(self):\n        return f\"I am {self.__class__.__name__}\"\n\n\nclass Widget(Named):\n    def report(self):\n        return self.identify()\n",
+    "pkg/duck_unique.py": "class Renderer:\n    def render(self):\n        return \"rendered\"\n\n\ndef show(widget):\n    return widget.render()\n",
+    "pkg/duck_ambiguous.py": "class Document:\n    def save(self):\n        return \"document saved\"\n\n\nclass Settings:\n    def save(self):\n        return \"settings saved\"\n\n\ndef persist(item):\n    return item.save()\n"
+  },
+  "calls": [
+    {
+      "src": "pkg/plain_import.py::call_helper",
+      "expected": ["pkg/utils.py::helper"]
+    },
+    {
+      "src": "pkg/from_alias.py::call_via_alias",
+      "expected": ["pkg/utils.py::helper"]
+    },
+    {
+      "src": "pkg/relative.py::call_relative",
+      "expected": ["pkg/utils.py::helper"]
+    },
+    {
+      "src": "pkg/counter.py::Counter.increment",
+      "expected": ["pkg/counter.py::Counter._report"]
+    },
+    {
+      "src": "pkg/inherit.py::Widget.report",
+      "expected": ["pkg/inherit.py::Named.identify"]
+    },
+    {
+      "src": "pkg/duck_unique.py::show",
+      "expected": ["pkg/duck_unique.py::Renderer.render"]
+    },
+    {
+      "src": "pkg/duck_ambiguous.py::persist",
+      "expected": [
+        "pkg/duck_ambiguous.py::Document.save",
+        "pkg/duck_ambiguous.py::Settings.save"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/labelled_calls.json
+++ b/tests/fixtures/labelled_calls.json
@@ -9,7 +9,8 @@
     "pkg/counter.py": "class Counter:\n    def __init__(self):\n        self.value = 0\n\n    def increment(self):\n        self.value += 1\n        return self._report()\n\n    def _report(self):\n        return f\"value={self.value}\"\n",
     "pkg/inherit.py": "class Named:\n    def identify(self):\n        return f\"I am {self.__class__.__name__}\"\n\n\nclass Widget(Named):\n    def report(self):\n        return self.identify()\n",
     "pkg/duck_unique.py": "class Renderer:\n    def render(self):\n        return \"rendered\"\n\n\ndef show(widget):\n    return widget.render()\n",
-    "pkg/duck_ambiguous.py": "class Document:\n    def save(self):\n        return \"document saved\"\n\n\nclass Settings:\n    def save(self):\n        return \"settings saved\"\n\n\ndef persist(item):\n    return item.save()\n"
+    "pkg/duck_ambiguous.py": "class Document:\n    def save(self):\n        return \"document saved\"\n\n\nclass Settings:\n    def save(self):\n        return \"settings saved\"\n\n\ndef persist(item):\n    return item.save()\n",
+    "pkg/shapes.py": "class Shape:\n    def area(self):\n        return 0\n\n    def describe(self):\n        return f\"area={self.area()}\"\n\n\nclass Square(Shape):\n    def __init__(self, side):\n        self.side = side\n\n    def area(self):\n        return self.side * self.side\n"
   },
   "calls": [
     {
@@ -41,6 +42,13 @@
       "expected": [
         "pkg/duck_ambiguous.py::Document.save",
         "pkg/duck_ambiguous.py::Settings.save"
+      ]
+    },
+    {
+      "src": "pkg/shapes.py::Shape.describe",
+      "expected": [
+        "pkg/shapes.py::Shape.area",
+        "pkg/shapes.py::Square.area"
       ]
     }
   ]

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -1,0 +1,60 @@
+"""Resolution accuracy harness.
+
+The ground truth in `tests/fixtures/labelled_calls.json` is hand-derived by
+reasoning (and, where noted in the task-15 report, by executing a throwaway
+script) about what these modules actually do at runtime -- it is never
+produced by running codegraph and recording its own output. Recall is the
+assertion that matters: the resolver's design deliberately over-approximates
+(a candidate is never dropped to improve precision), so precision is floored
+low and recall is floored high. Do not "fix" a low score by loosening a
+label; a failing floor here is a real finding about the resolver.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codegraph.indexer import GitTreeSource, Indexer
+from codegraph.store import Store
+
+LABELS = Path(__file__).parent / "fixtures" / "labelled_calls.json"
+
+
+def measure_accuracy(store, rev, labels):
+    """labels: [{"src": node_id, "expected": [node_id, ...]}]"""
+    true_positive = predicted = actual = 0
+    for label in labels:
+        got = {
+            row["dst"]
+            for row in store.connection.execute(
+                "SELECT dst FROM edges WHERE rev=? AND src=? AND kind='CALLS'",
+                (rev, label["src"]),
+            )
+        }
+        expected = set(label["expected"])
+        true_positive += len(got & expected)
+        predicted += len(got)
+        actual += len(expected)
+    precision = true_positive / predicted if predicted else 1.0
+    recall = true_positive / actual if actual else 1.0
+    return precision, recall
+
+
+@pytest.mark.slow
+def test_resolution_accuracy_meets_floor(repo, write):
+    labels = json.loads(LABELS.read_text())
+    for name, source in labels["files"].items():
+        write(name, source)
+    from tests.conftest import git
+
+    git(repo, "add", "-A")
+    git(repo, "commit", "-qm", "accuracy fixture")
+
+    store = Store.open(repo)
+    Indexer(repo, store, GitTreeSource(repo)).reconcile("HEAD")
+    precision, recall = measure_accuracy(store, "HEAD", labels["calls"])
+    print(f"precision={precision:.2f} recall={recall:.2f}")
+    assert recall >= 0.90, "over-approximation is the design bias; recall must stay high"
+    assert precision >= 0.60
+    store.close()

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -22,3 +22,63 @@ def test_console_script_runs():
         check=False,
     )
     assert proc.returncode == 0
+
+
+# -- B2: a bad --rev must fail with a clear one-line message, never a raw
+# traceback -- matching the shape `diff` already had ("revision not
+# found: X", exit 1). Covers every command that reconciles a revision.
+
+
+def test_status_with_bad_rev_reports_cleanly(repo, capsys):
+    assert main(["status", "--path", str(repo), "--rev", "nosuchrev"]) == 1
+    err = capsys.readouterr().err
+    assert err.strip() == "revision not found: nosuchrev"
+
+
+def test_index_with_bad_rev_reports_cleanly(repo, capsys):
+    assert main(["index", "--path", str(repo), "--rev", "nosuchrev"]) == 1
+    err = capsys.readouterr().err
+    assert err.strip() == "revision not found: nosuchrev"
+
+
+def test_resolve_with_bad_rev_reports_cleanly(repo, capsys):
+    assert main(["resolve", "alpha", "--path", str(repo), "--rev", "nosuchrev"]) == 1
+    err = capsys.readouterr().err
+    assert err.strip() == "revision not found: nosuchrev"
+
+
+def test_effects_with_bad_rev_reports_cleanly(repo, capsys):
+    assert main(["effects", "alpha", "--path", str(repo), "--rev", "nosuchrev"]) == 1
+    err = capsys.readouterr().err
+    assert err.strip() == "revision not found: nosuchrev"
+
+
+def test_impact_with_bad_rev_reports_cleanly(repo, capsys):
+    assert main(["impact", "alpha", "--path", str(repo), "--rev", "nosuchrev"]) == 1
+    err = capsys.readouterr().err
+    assert err.strip() == "revision not found: nosuchrev"
+
+
+def test_install_hooks_outside_git_repo_reports_cleanly(tmp_path, capsys):
+    assert main(["install-hooks", "--path", str(tmp_path)]) == 1
+    err = capsys.readouterr().err
+    assert "not a git repository" in err
+    assert "Traceback" not in err
+
+
+# -- B4: `--hops 0` (or negative) must be rejected, not silently answered
+# as an empty (and misleadingly confident) report.
+
+
+def test_impact_rejects_hops_zero(repo, write, capsys):
+    write("m.py", "def target():\n    pass\n", commit="m")
+    assert main(["impact", "m.py::target", "--path", str(repo), "--hops", "0"]) == 1
+    err = capsys.readouterr().err
+    assert "--hops" in err
+
+
+def test_impact_rejects_negative_hops(repo, write, capsys):
+    write("m.py", "def target():\n    pass\n", commit="m")
+    assert main(["impact", "m.py::target", "--path", str(repo), "--hops", "-1"]) == 1
+    err = capsys.readouterr().err
+    assert "--hops" in err

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,39 @@
+import pytest
+
+from codegraph.cli import main
+from codegraph.config import DEFAULT_AMBIGUITY_LIMIT, Config
+
+
+def test_defaults_apply_when_there_is_no_config_file(tmp_path):
+    config = Config.load(tmp_path)
+    assert config.source_roots == ("", "src")
+    assert config.ambiguity_limit == DEFAULT_AMBIGUITY_LIMIT
+    assert config.effect_overrides == ()
+
+
+def test_ambiguity_limit_is_read_from_the_config_file(tmp_path):
+    (tmp_path / "codegraph.toml").write_text("ambiguity_limit = 100\n")
+    assert Config.load(tmp_path).ambiguity_limit == 100
+
+
+def test_ambiguity_limit_zero_is_accepted_as_no_limit(tmp_path):
+    (tmp_path / "codegraph.toml").write_text("ambiguity_limit = 0\n")
+    assert Config.load(tmp_path).ambiguity_limit == 0
+
+
+@pytest.mark.parametrize("value", ["-1", '"25"', "2.5", "true"])
+def test_a_nonsense_ambiguity_limit_is_rejected_rather_than_coerced(tmp_path, value):
+    """`true` is in here on purpose: `isinstance(True, int)` is True in Python,
+    so a bool would otherwise silently configure a limit of 1."""
+    (tmp_path / "codegraph.toml").write_text(f"ambiguity_limit = {value}\n")
+    with pytest.raises(ValueError, match="ambiguity_limit"):
+        Config.load(tmp_path)
+
+
+def test_a_bad_config_fails_the_command_with_one_line_not_a_traceback(repo, write, capsys):
+    write("codegraph.toml", "ambiguity_limit = -3\n", commit="cfg")
+    assert main(["status", "--path", str(repo)]) != 0
+    err = capsys.readouterr().err
+    assert "ambiguity_limit" in err
+    assert "Traceback" not in err
+    assert len(err.strip().splitlines()) == 1

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -108,6 +108,28 @@ def test_deleted_module_only_file_appears_in_removed(repo, write):
     store.close()
 
 
+def test_new_symbols_effects_are_reported_as_new(repo, write):
+    """B6 regression: `new_effects` used to union `_effect_kinds` over
+    `changed_ids` only, so a brand-new function's effects were invisible
+    -- `changed_ids` by construction only ever contains ids present in
+    BOTH revisions, so a symbol that didn't exist at `base` could never
+    land in it, no matter what it reaches. This is the same blind-spot
+    class Task 12 already fixed once for module scope
+    (`test_module_level_effect_addition_is_changed_and_new_effect`); here
+    it's a whole new function, not an edit to an existing one."""
+    store, indexer = build(repo)
+    base = git(repo, "rev-parse", "HEAD").strip()
+    write(
+        "m.py",
+        "def alpha():\n    return 1\n\n\ndef beta():\n    import requests\n    requests.post('u')\n",
+        commit="add a function with a network call",
+    )
+    report = diff_report(store, indexer, base, "HEAD")
+    assert "m.py::beta" in rows(report, "added")
+    assert "NETWORK" in report.summary["new_effects"]
+    store.close()
+
+
 def test_module_level_effect_addition_is_changed_and_new_effect(repo, write):
     write("m.py", "TIMEOUT = 30\n", commit="m")
     store, indexer = build(repo)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,88 @@
+from codegraph.indexer import GitTreeSource, Indexer
+from codegraph.query.diff import diff_report
+from codegraph.store import Store
+from tests.conftest import git
+
+
+def build(repo):
+    store = Store.open(repo)
+    return store, Indexer(repo, store, GitTreeSource(repo))
+
+
+def rows(report, title):
+    return {r.id for g in report.groups if g.title == title for r in g.rows}
+
+
+def test_blank_line_insertion_produces_empty_diff(repo, write):
+    store, indexer = build(repo)
+    base = git(repo, "rev-parse", "HEAD").strip()
+    write("a.py", "\n\n\ndef alpha():\n    return 1\n", commit="shift lines")
+    report = diff_report(store, indexer, base, "HEAD")
+    assert report.groups == []
+    store.close()
+
+
+def test_added_symbol_reported(repo, write):
+    store, indexer = build(repo)
+    base = git(repo, "rev-parse", "HEAD").strip()
+    write("a.py", "def alpha():\n    return 1\n\n\ndef added():\n    pass\n", commit="add")
+    report = diff_report(store, indexer, base, "HEAD")
+    assert "a.py::added" in rows(report, "added")
+    store.close()
+
+
+def test_removed_symbol_reported(repo, write):
+    write("b.py", "def beta():\n    pass\n", commit="b")
+    store, indexer = build(repo)
+    base = git(repo, "rev-parse", "HEAD").strip()
+    (repo / "b.py").unlink()
+    git(repo, "add", "-A"); git(repo, "commit", "-qm", "remove b")
+    report = diff_report(store, indexer, base, "HEAD")
+    assert "b.py::beta" in rows(report, "removed")
+    store.close()
+
+
+def test_changed_body_reported(repo, write):
+    store, indexer = build(repo)
+    base = git(repo, "rev-parse", "HEAD").strip()
+    write("a.py", "def alpha():\n    return 999\n", commit="change body")
+    report = diff_report(store, indexer, base, "HEAD")
+    assert "a.py::alpha" in rows(report, "changed")
+    store.close()
+
+
+def test_newly_reachable_effect_is_headlined(repo, write):
+    write("m.py", "def charge():\n    pass\n\n\ndef checkout():\n    charge()\n", commit="m")
+    store, indexer = build(repo)
+    base = git(repo, "rev-parse", "HEAD").strip()
+    write(
+        "m.py",
+        "import requests\n\n\ndef charge():\n    requests.post('u')\n\n\ndef checkout():\n    charge()\n",
+        commit="add network call",
+    )
+    report = diff_report(store, indexer, base, "HEAD")
+    assert "NETWORK" in str(report.summary)
+    store.close()
+
+
+def test_base_revision_is_not_checked_out(repo, write):
+    store, indexer = build(repo)
+    base = git(repo, "rev-parse", "HEAD").strip()
+    write("a.py", "def alpha():\n    return 2\n", commit="edit")
+    before = (repo / "a.py").read_text()
+    diff_report(store, indexer, base, "HEAD")
+    assert (repo / "a.py").read_text() == before
+    assert git(repo, "rev-parse", "--abbrev-ref", "HEAD").strip() == "main"
+    store.close()
+
+
+def test_missing_base_revision_reports_name_and_raises(repo, write):
+    store, indexer = build(repo)
+    write("a.py", "def alpha():\n    return 2\n", commit="edit")
+    import pytest
+
+    from codegraph.query.diff import MissingRevisionError
+
+    with pytest.raises(MissingRevisionError, match="deadbeef"):
+        diff_report(store, indexer, "deadbeef" * 5, "HEAD")
+    store.close()

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -86,3 +86,38 @@ def test_missing_base_revision_reports_name_and_raises(repo, write):
     with pytest.raises(MissingRevisionError, match="deadbeef"):
         diff_report(store, indexer, "deadbeef" * 5, "HEAD")
     store.close()
+
+
+def test_new_module_only_file_appears_in_added(repo, write):
+    store, indexer = build(repo)
+    base = git(repo, "rev-parse", "HEAD").strip()
+    write("config.py", "TIMEOUT = 30\n", commit="add config")
+    report = diff_report(store, indexer, base, "HEAD")
+    assert "config.py::<module>" in rows(report, "added")
+    store.close()
+
+
+def test_deleted_module_only_file_appears_in_removed(repo, write):
+    write("config.py", "TIMEOUT = 30\n", commit="add config")
+    store, indexer = build(repo)
+    base = git(repo, "rev-parse", "HEAD").strip()
+    (repo / "config.py").unlink()
+    git(repo, "add", "-A"); git(repo, "commit", "-qm", "remove config")
+    report = diff_report(store, indexer, base, "HEAD")
+    assert "config.py::<module>" in rows(report, "removed")
+    store.close()
+
+
+def test_module_level_effect_addition_is_changed_and_new_effect(repo, write):
+    write("m.py", "TIMEOUT = 30\n", commit="m")
+    store, indexer = build(repo)
+    base = git(repo, "rev-parse", "HEAD").strip()
+    write(
+        "m.py",
+        "import requests\n\nTIMEOUT = 30\nrequests.post('u')\n",
+        commit="add module-level network call",
+    )
+    report = diff_report(store, indexer, base, "HEAD")
+    assert "m.py::<module>" in rows(report, "changed")
+    assert "NETWORK" in str(report.summary)
+    store.close()

--- a/tests/test_effect_catalog.py
+++ b/tests/test_effect_catalog.py
@@ -1,5 +1,7 @@
+import pytest
+
 from codegraph.config import Config
-from codegraph.effects.catalog import EFFECT_KINDS, Catalog
+from codegraph.effects.catalog import EFFECT_KINDS, Catalog, Rule
 
 
 def test_nine_effect_kinds_exactly():
@@ -47,3 +49,31 @@ def test_fingerprint_changes_with_overrides():
         Config(effect_overrides=({"match": "x.*", "kind": "NETWORK"},))
     ).fingerprint()
     assert base != other
+
+
+def test_execute_on_a_namespaced_db_client_is_still_a_write():
+    """`*.execute` (prefix 0) and a namespace rule like `psycopg*` (prefix 7)
+    can both match a fully-qualified name; the namespace rule must not win
+    and silently turn a write into a read."""
+    catalog = Catalog.load(Config())
+    assert catalog.match("psycopg2.extensions.cursor.execute") == "DB_WRITE"
+    assert catalog.match("psycopg2.cursor.execute") == "DB_WRITE"
+    assert catalog.match("cursor.execute") == "DB_WRITE"
+
+
+def test_fetch_family_is_a_db_read():
+    catalog = Catalog.load(Config())
+    assert catalog.match("cursor.fetchall") == "DB_READ"
+    assert catalog.match("cursor.fetchone") == "DB_READ"
+    assert catalog.match("cursor.fetchmany") == "DB_READ"
+
+
+def test_rule_rejects_unknown_kind():
+    with pytest.raises(ValueError, match="NOT_A_KIND"):
+        Rule(match="app.thing", kind="NOT_A_KIND")
+
+
+def test_catalog_load_rejects_unknown_kind_in_override():
+    config = Config(effect_overrides=({"match": "app.thing", "kind": "NOT_A_KIND"},))
+    with pytest.raises(ValueError, match="NOT_A_KIND"):
+        Catalog.load(config)

--- a/tests/test_effect_catalog.py
+++ b/tests/test_effect_catalog.py
@@ -1,0 +1,49 @@
+from codegraph.config import Config
+from codegraph.effects.catalog import EFFECT_KINDS, Catalog
+
+
+def test_nine_effect_kinds_exactly():
+    assert set(EFFECT_KINDS) == {
+        "DB_READ",
+        "DB_WRITE",
+        "NETWORK",
+        "FS_READ",
+        "FS_WRITE",
+        "PROCESS",
+        "ENV_READ",
+        "GLOBAL_MUTATE",
+        "NONDETERMINISM",
+    }
+
+
+def test_builtin_rules_cover_common_libraries():
+    catalog = Catalog.load(Config())
+    assert catalog.match("requests.get") == "NETWORK"
+    assert catalog.match("httpx.post") == "NETWORK"
+    assert catalog.match("subprocess.run") == "PROCESS"
+    assert catalog.match("os.environ.get") == "ENV_READ"
+    assert catalog.match("open") == "FS_READ"
+
+
+def test_unknown_name_matches_nothing():
+    assert Catalog.load(Config()).match("my.own.helper") is None
+
+
+def test_project_override_adds_house_abstractions():
+    config = Config(effect_overrides=({"match": "app.db.*", "kind": "DB_WRITE"},))
+    assert Catalog.load(config).match("app.db.save") == "DB_WRITE"
+
+
+def test_override_beats_builtin_on_longer_prefix():
+    config = Config(effect_overrides=({"match": "requests.get", "kind": "DB_READ"},))
+    catalog = Catalog.load(config)
+    assert catalog.match("requests.get") == "DB_READ"
+    assert catalog.match("requests.post") == "NETWORK"
+
+
+def test_fingerprint_changes_with_overrides():
+    base = Catalog.load(Config()).fingerprint()
+    other = Catalog.load(
+        Config(effect_overrides=({"match": "x.*", "kind": "NETWORK"},))
+    ).fingerprint()
+    assert base != other

--- a/tests/test_effect_catalog.py
+++ b/tests/test_effect_catalog.py
@@ -88,10 +88,48 @@ def test_fully_literal_match_is_high_confidence():
 
 def test_partial_prefix_match_is_medium_confidence():
     """`requests.*` and `boto3.*` have a real but partial literal prefix --
-    more specific than a bare wildcard head, but not a literal name."""
+    more specific than a bare wildcard head, but not a literal name. Uses
+    `requests.codes`, not `requests.get`: the literal HTTP-verb rules below
+    make `.get` HIGH now, so `.codes` -- a catch-all-only member with no
+    verb-specific rule of its own -- is the one that still exercises the
+    bare `requests.*` MEDIUM tier."""
     catalog = Catalog.load(Config())
-    assert catalog.match_with_confidence("requests.get") == ("NETWORK", MEDIUM)
+    assert catalog.match_with_confidence("requests.codes") == ("NETWORK", MEDIUM)
     assert catalog.match_with_confidence("boto3.client") == ("DB_WRITE", MEDIUM)
+
+
+@pytest.mark.parametrize(
+    "dotted",
+    [
+        "requests.get",
+        "requests.post",
+        "requests.put",
+        "requests.patch",
+        "requests.delete",
+        "requests.head",
+        "requests.options",
+        "requests.request",
+    ],
+)
+def test_requests_http_verbs_are_high_confidence(dotted):
+    """C3 follow-up: the literal HTTP verbs are the most common and least
+    ambiguous network call in Python and must not be worse-labeled than
+    before `requests.*` was tiered MEDIUM."""
+    catalog = Catalog.load(Config())
+    assert catalog.match_with_confidence(dotted) == ("NETWORK", HIGH)
+
+
+def test_requests_verb_literal_beats_requests_namespace_catchall():
+    """Longest-literal-prefix-wins must actually favor the literal verb
+    rule over the `requests.*` catch-all, not just declare it in a
+    docstring -- `requests.get`'s prefix (13 chars, no wildcard) is longer
+    than `requests.*`'s (9 chars, up to the `*`), so it wins regardless of
+    declaration order in builtin.toml."""
+    catalog = Catalog.load(Config())
+    kind, confidence = catalog.match_with_confidence("requests.get")
+    assert (kind, confidence) == ("NETWORK", HIGH)
+    # And the catch-all is still there for everything else in the namespace.
+    assert catalog.match_with_confidence("requests.codes") == ("NETWORK", MEDIUM)
 
 
 def test_indexers_own_source_reconcile_is_no_longer_a_high_confidence_db_write():

--- a/tests/test_effect_catalog.py
+++ b/tests/test_effect_catalog.py
@@ -2,6 +2,7 @@ import pytest
 
 from codegraph.config import Config
 from codegraph.effects.catalog import EFFECT_KINDS, Catalog, Rule
+from codegraph.resolve import HIGH, LOW, MEDIUM
 
 
 def test_nine_effect_kinds_exactly():
@@ -66,6 +67,56 @@ def test_fetch_family_is_a_db_read():
     assert catalog.match("cursor.fetchall") == "DB_READ"
     assert catalog.match("cursor.fetchone") == "DB_READ"
     assert catalog.match("cursor.fetchmany") == "DB_READ"
+
+
+def test_wildcard_head_match_is_not_high_confidence():
+    """Regression for F3: `*.execute` matches a completely uninferable
+    receiver -- it must not claim the same HIGH tier as a literal name
+    like `requests.post`."""
+    catalog = Catalog.load(Config())
+    kind, confidence = catalog.match_with_confidence("cursor.execute")
+    assert kind == "DB_WRITE"
+    assert confidence == LOW
+
+
+def test_fully_literal_match_is_high_confidence():
+    catalog = Catalog.load(Config())
+    kind, confidence = catalog.match_with_confidence("os.getenv")
+    assert kind == "ENV_READ"
+    assert confidence == HIGH
+
+
+def test_partial_prefix_match_is_medium_confidence():
+    """`requests.*` and `boto3.*` have a real but partial literal prefix --
+    more specific than a bare wildcard head, but not a literal name."""
+    catalog = Catalog.load(Config())
+    assert catalog.match_with_confidence("requests.get") == ("NETWORK", MEDIUM)
+    assert catalog.match_with_confidence("boto3.client") == ("DB_WRITE", MEDIUM)
+
+
+def test_indexers_own_source_reconcile_is_no_longer_a_high_confidence_db_write():
+    """The concrete repro from the finding: `Indexer.reconcile` calling
+    `cursor.execute("SELECT path, blob_sha FROM tree")` used to be reported
+    as `DB_WRITE HIGH` -- the same tier as a literal call -- purely because
+    `*.execute` matched. It is still DB_WRITE (never drop a candidate), but
+    now LOW."""
+    catalog = Catalog.load(Config())
+    assert catalog.match_with_confidence("connection.execute") == ("DB_WRITE", LOW)
+
+
+def test_rule_confidence_override_is_honored_over_derived_specificity():
+    rule = Rule(match="app.thing", kind="NETWORK", confidence=LOW)
+    catalog = Catalog((rule,), 0)
+    assert catalog.match_with_confidence("app.thing") == ("NETWORK", LOW)
+
+
+def test_rule_rejects_unknown_confidence():
+    with pytest.raises(ValueError, match="NOT_A_TIER"):
+        Rule(match="app.thing", kind="NETWORK", confidence="NOT_A_TIER")
+
+
+def test_no_match_returns_none_with_confidence():
+    assert Catalog.load(Config()).match_with_confidence("my.own.helper") is None
 
 
 def test_rule_rejects_unknown_kind():

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1,3 +1,6 @@
+import pytest
+
+from codegraph.effects.propagate import propagate, witness_path
 from codegraph.indexer import GitTreeSource, Indexer
 from codegraph.query.effects import effects_report
 from codegraph.store import Store
@@ -110,4 +113,121 @@ def test_witness_follows_the_path_that_supports_the_reported_confidence(repo, wr
     assert row.detail.startswith("NETWORK HIGH via")
     assert "b.py::c" in row.detail
     assert "one.py::One.shared" not in row.detail
+    store.close()
+
+
+def test_cycle_confidence_is_the_bottleneck_out_of_the_asking_node(tmp_path):
+    """Direct schema seeding, not a mock: the same `nodes`/`edges`/`effects`
+    tables `propagate` and `witness_path` read and write, populated by hand
+    so the shape is exact. `A` can only leave via a LOW edge to `B`; `B`
+    can call back to `A` at HIGH, but that never gives `A` a *new* way out
+    -- A's own only exit is still the LOW edge. `B` carries the direct
+    effect. This is the round-2 review shape: SCC condensation used to
+    merge B's direct HIGH straight into the shared `{A, B}` component set
+    without accounting for the LOW edge needed to reach B from A at all,
+    handing out a HIGH confidence that no real path leaving A supported."""
+    store = Store.open(tmp_path)
+    rev = "HEAD"
+    connection = store.connection
+    connection.executemany(
+        "INSERT INTO nodes(rev, id, path, qualname, kind, line_start, line_end, body_hash,"
+        " name_binding) VALUES(?,?,?,?,?,?,?,?,?)",
+        [
+            (rev, "m.py::A", "m.py", "A", "function", 1, 1, "x", "live"),
+            (rev, "m.py::B", "m.py", "B", "function", 2, 2, "x", "live"),
+        ],
+    )
+    connection.executemany(
+        "INSERT INTO edges(rev, src, dst, kind, confidence, provenance, callsite_path,"
+        " callsite_line) VALUES(?,?,?,?,?,?,?,?)",
+        [
+            (rev, "m.py::A", "m.py::B", "CALLS", "LOW", "static", "m.py", 1),
+            (rev, "m.py::B", "m.py::A", "CALLS", "HIGH", "static", "m.py", 2),
+        ],
+    )
+    connection.execute(
+        "INSERT INTO effects(rev, node_id, kind, direct, evidence_path, evidence_line,"
+        " confidence) VALUES(?,?,?,?,?,?,?)",
+        (rev, "m.py::B", "NETWORK", 1, "m.py", 2, "HIGH"),
+    )
+    connection.commit()
+
+    propagate(store, rev)
+
+    report = effects_report(store, rev, "m.py::A")
+    row = next(r for g in report.groups for r in g.rows)
+    assert row.detail == "NETWORK LOW via m.py::A -> m.py::B"
+    assert row.location == "m.py:2"
+
+    chain = witness_path(store, rev, "m.py::A", "NETWORK", "LOW")
+    assert chain == ["m.py::A", "m.py::B"]
+    store.close()
+
+
+_GUARD_FIXTURES = {
+    "acyclic_chain": (
+        {
+            "chain.py": (
+                "import requests\n\n\n"
+                "def low():\n    requests.get('u')\n\n\n"
+                "def mid():\n    low()\n\n\n"
+                "def high():\n    mid()\n"
+            ),
+        },
+        "chain.py::high",
+    ),
+    "recursion_cycle": (
+        {
+            "recur.py": (
+                "import requests\n\n\n"
+                "def ping(n):\n    requests.get('u')\n    return pong(n)\n\n\n"
+                "def pong(n):\n    return ping(n)\n"
+            ),
+        },
+        "recur.py::pong",
+    ),
+    "mixed_confidence_acyclic": (
+        {
+            "one.py": (
+                "import requests\n\n\nclass One:\n    def shared(self):\n        requests.get('u')\n"
+            ),
+            "two.py": "class Two:\n    def shared(self):\n        pass\n",
+            "b.py": "import requests\n\n\ndef c():\n    requests.get('u')\n\n\ndef b():\n    c()\n",
+            "caller.py": "from b import b\n\n\ndef query(thing):\n    thing.shared()\n    b()\n",
+        },
+        "caller.py::query",
+    ),
+    "mixed_confidence_cycle": (
+        {
+            "decoy.py": "def b():\n    pass\n",
+            "cyc_a.py": "def a():\n    return b()\n",
+            "cyc_b.py": (
+                "import requests\n\nfrom cyc_a import a\n\n\n"
+                "def b():\n    requests.get('u')\n    a()\n"
+            ),
+        },
+        "cyc_a.py::a",
+    ),
+}
+
+
+@pytest.mark.parametrize("files, node_id", _GUARD_FIXTURES.values(), ids=_GUARD_FIXTURES.keys())
+def test_no_effect_row_has_an_empty_witness_or_location(repo, write, files, node_id):
+    """Regression guard for the round-2 Critical: if `propagate` ever again
+    hands a node a confidence no real path out of it supports, `witness_path`
+    (correctly) comes back empty and the report degrades to `"KIND CONF via "`
+    with no chain and no location -- exactly the shape that shipped and was
+    only caught by manual review. Exercise every shape this module cares
+    about (a plain chain, a same-confidence recursion cycle, an acyclic mix
+    of confidences, and a genuine mixed-confidence cycle) and make that
+    degenerate output structurally impossible to ship again unnoticed."""
+    for path, source in files.items():
+        write(path, source, commit=path)
+    store = build(repo)
+    report = effects_report(store, "HEAD", node_id)
+    for group in report.groups:
+        for row in group.rows:
+            assert row.location, f"empty location: {row!r}"
+            chain_text = row.detail.split(" via ", 1)[-1]
+            assert chain_text.strip(), f"empty witness chain: {row.detail!r}"
     store.close()

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -78,3 +78,36 @@ def test_project_override_tags_house_abstraction(repo, write):
     store = build(repo)
     assert "DB_WRITE" in kinds(effects_report(store, "HEAD", "svc.py::run"))
     store.close()
+
+
+def test_witness_follows_the_path_that_supports_the_reported_confidence(repo, write):
+    """`query` has two outgoing calls: a LOW-confidence ambiguous call
+    (`thing.shared()`, matching both One.shared and Two.shared) that reaches
+    a direct effect through One.shared, and a HIGH-confidence call chain
+    (query -> b -> c) that reaches a direct effect through c. The best
+    achievable confidence is HIGH (via b -> c); the printed chain must be
+    the one that actually supports HIGH, not the shorter LOW one."""
+    write(
+        "one.py",
+        "import requests\n\n\nclass One:\n    def shared(self):\n        requests.get('u')\n",
+        commit="one",
+    )
+    write("two.py", "class Two:\n    def shared(self):\n        pass\n", commit="two")
+    write(
+        "b.py",
+        "import requests\n\n\ndef c():\n    requests.get('u')\n\n\ndef b():\n    c()\n",
+        commit="b",
+    )
+    write(
+        "caller.py",
+        "from b import b\n\n\ndef query(thing):\n    thing.shared()\n    b()\n",
+        commit="caller",
+    )
+    store = build(repo)
+    report = effects_report(store, "HEAD", "caller.py::query")
+    group = next(g for g in report.groups if g.title == "NETWORK")
+    row = group.rows[0]
+    assert row.detail.startswith("NETWORK HIGH via")
+    assert "b.py::c" in row.detail
+    assert "one.py::One.shared" not in row.detail
+    store.close()

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -73,6 +73,67 @@ def test_global_mutation_detected_syntactically(repo, write):
     store.close()
 
 
+def direct_effects(store, path):
+    return {
+        (row["kind"], row["confidence"])
+        for row in store.connection.execute(
+            "SELECT kind, confidence FROM effects WHERE rev='HEAD' AND direct=1"
+            " AND evidence_path=?",
+            (path,),
+        )
+    }
+
+
+def test_write_mode_open_is_an_fs_write(repo, write):
+    """Regression for F3: `open` used to map to FS_READ regardless of mode.
+    A literal write mode must be a genuine FS_WRITE, at HIGH confidence
+    (the mode is a literal, so the evidence really does support it)."""
+    write("m.py", "def save(p):\n    open(p, 'w')\n", commit="m")
+    store = build(repo)
+    assert ("FS_WRITE", "HIGH") in direct_effects(store, "m.py")
+    assert "FS_READ" not in {kind for kind, _ in direct_effects(store, "m.py")}
+    store.close()
+
+
+def test_read_mode_open_stays_fs_read_at_high_confidence(repo, write):
+    write("m.py", "def load(p):\n    open(p)\n    open(p, 'r')\n", commit="m")
+    store = build(repo)
+    assert direct_effects(store, "m.py") == {("FS_READ", "HIGH")}
+    store.close()
+
+
+def test_non_literal_open_mode_stays_read_but_at_lower_confidence(repo, write):
+    """The mode isn't a literal, so the FS_READ default is kept (never drop
+    a candidate) but the evidence doesn't actually establish it -- unlike
+    the literal cases, this must not claim HIGH."""
+    write("m.py", "def load(p, mode):\n    open(p, mode)\n", commit="m")
+    store = build(repo)
+    assert direct_effects(store, "m.py") == {("FS_READ", "MEDIUM")}
+    store.close()
+
+
+def test_super_delegation_chain_reports_effects(repo, write):
+    """Regression for F2 end-to-end: before the fix, a handler whose entire
+    call chain ran through `super()` reported ZERO effects -- the call ref
+    was dropped by the parser (unflattenable receiver), so no edge was ever
+    recorded from the override to the base method carrying the direct
+    effect, and propagation had nothing to walk."""
+    write(
+        "base.py",
+        "import requests\n\n\nclass Base:\n    def helper(self):\n        requests.get('u')\n",
+        commit="base",
+    )
+    write(
+        "child.py",
+        "from base import Base\n\n\n"
+        "class Child(Base):\n    def go(self):\n        super().helper()\n",
+        commit="child",
+    )
+    store = build(repo)
+    assert "NETWORK" in kinds(effects_report(store, "HEAD", "child.py::Child.go"))
+    store.close()
+
+
 def test_project_override_tags_house_abstraction(repo, write):
     write("codegraph.toml", '[[effect]]\nmatch = "app.db.*"\nkind = "DB_WRITE"\n')
     write("app/__init__.py", "", commit="pkg")

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -148,18 +148,23 @@ def test_witness_follows_the_path_that_supports_the_reported_confidence(repo, wr
     """`query` has two outgoing calls: a LOW-confidence ambiguous call
     (`thing.shared()`, matching both One.shared and Two.shared) that reaches
     a direct effect through One.shared, and a HIGH-confidence call chain
-    (query -> b -> c) that reaches a direct effect through c. The best
-    achievable confidence is HIGH (via b -> c); the printed chain must be
-    the one that actually supports HIGH, not the shorter LOW one."""
+    (query -> b -> c) that reaches a direct effect through c. Both direct
+    effects use `os.getenv`, a fully-literal (no wildcard) catalog pattern
+    that is HIGH on its own -- so the only thing distinguishing the two
+    paths is the CALLS-edge confidence, not the direct effect's own tier
+    (see `test_direct_effect_confidence_bounds_the_propagated_confidence`
+    for that case). The best achievable confidence is HIGH (via b -> c);
+    the printed chain must be the one that actually supports HIGH, not the
+    shorter LOW one."""
     write(
         "one.py",
-        "import requests\n\n\nclass One:\n    def shared(self):\n        requests.get('u')\n",
+        "import os\n\n\nclass One:\n    def shared(self):\n        os.getenv('u')\n",
         commit="one",
     )
     write("two.py", "class Two:\n    def shared(self):\n        pass\n", commit="two")
     write(
         "b.py",
-        "import requests\n\n\ndef c():\n    requests.get('u')\n\n\ndef b():\n    c()\n",
+        "import os\n\n\ndef c():\n    os.getenv('u')\n\n\ndef b():\n    c()\n",
         commit="b",
     )
     write(
@@ -169,9 +174,9 @@ def test_witness_follows_the_path_that_supports_the_reported_confidence(repo, wr
     )
     store = build(repo)
     report = effects_report(store, "HEAD", "caller.py::query")
-    group = next(g for g in report.groups if g.title == "NETWORK")
+    group = next(g for g in report.groups if g.title == "ENV_READ")
     row = group.rows[0]
-    assert row.detail.startswith("NETWORK HIGH via")
+    assert row.detail.startswith("ENV_READ HIGH via")
     assert "b.py::c" in row.detail
     assert "one.py::One.shared" not in row.detail
     store.close()
@@ -222,6 +227,56 @@ def test_cycle_confidence_is_the_bottleneck_out_of_the_asking_node(tmp_path):
 
     chain = witness_path(store, rev, "m.py::A", "NETWORK", "LOW")
     assert chain == ["m.py::A", "m.py::B"]
+    store.close()
+
+
+def test_direct_effect_confidence_bounds_the_propagated_confidence(tmp_path):
+    """B0: a caller reached only by HIGH `CALLS` edges must not inherit HIGH
+    for an effect whose own direct detection is LOW -- the binding
+    constraint here is the direct effect's own tier, not any edge. Schema
+    seeded by hand (same tables `propagate`/`witness_path` read and write):
+    `A --HIGH--> B --HIGH--> C`, `C` carries a LOW-confidence direct effect
+    (the shape a bare-wildcard-head catalog match like `*.execute`
+    produces). Every edge on the only path out of A is HIGH, so before the
+    fix A reported HIGH; the direct detection at the end of the chain is
+    the true bottleneck and both A and B must report LOW."""
+    store = Store.open(tmp_path)
+    rev = "HEAD"
+    connection = store.connection
+    connection.executemany(
+        "INSERT INTO nodes(rev, id, path, qualname, kind, line_start, line_end, body_hash,"
+        " name_binding) VALUES(?,?,?,?,?,?,?,?,?)",
+        [
+            (rev, "m.py::A", "m.py", "A", "function", 1, 1, "x", "live"),
+            (rev, "m.py::B", "m.py", "B", "function", 2, 2, "x", "live"),
+            (rev, "m.py::C", "m.py", "C", "function", 3, 3, "x", "live"),
+        ],
+    )
+    connection.executemany(
+        "INSERT INTO edges(rev, src, dst, kind, confidence, provenance, callsite_path,"
+        " callsite_line) VALUES(?,?,?,?,?,?,?,?)",
+        [
+            (rev, "m.py::A", "m.py::B", "CALLS", "HIGH", "static", "m.py", 1),
+            (rev, "m.py::B", "m.py::C", "CALLS", "HIGH", "static", "m.py", 2),
+        ],
+    )
+    connection.execute(
+        "INSERT INTO effects(rev, node_id, kind, direct, evidence_path, evidence_line,"
+        " confidence) VALUES(?,?,?,?,?,?,?)",
+        (rev, "m.py::C", "DB_WRITE", 1, "m.py", 3, "LOW"),
+    )
+    connection.commit()
+
+    propagate(store, rev)
+
+    for asking_node in ("m.py::A", "m.py::B"):
+        report = effects_report(store, rev, asking_node)
+        row = next(r for g in report.groups for r in g.rows)
+        assert row.detail.startswith("DB_WRITE LOW via")
+        assert row.location == "m.py:3"
+
+    chain = witness_path(store, rev, "m.py::A", "DB_WRITE", "LOW")
+    assert chain == ["m.py::A", "m.py::B", "m.py::C"]
     store.close()
 
 
@@ -291,4 +346,40 @@ def test_no_effect_row_has_an_empty_witness_or_location(repo, write, files, node
             assert row.location, f"empty location: {row!r}"
             chain_text = row.detail.split(" via ", 1)[-1]
             assert chain_text.strip(), f"empty witness chain: {row.detail!r}"
+    store.close()
+
+
+def test_effects_report_picks_the_strongest_confidence_for_a_repeated_kind(tmp_path):
+    """B8 regression: `query/effects.py` used to define its own
+    `_CONFIDENCE_RANK` with the OPPOSITE polarity from `effects/
+    propagate.py` and `query/impact.py` (lower-is-stronger there, versus
+    higher-is-stronger everywhere else), using bare string literals
+    instead of importing `HIGH`/`MEDIUM`/`LOW` from `resolve.py`. Two rows
+    for the same node/kind at different confidence (a direct HIGH
+    detection plus a weaker LOW propagated row that would not normally
+    coexist, but the code has to pick correctly regardless) must resolve
+    to the STRONGER one, HIGH -- exercising the same `stronger()` helper
+    and `CONFIDENCE_RANK` table `propagate.py` and `impact.py` use, now
+    imported from `resolve.py` rather than redefined."""
+    store = Store.open(tmp_path)
+    rev = "HEAD"
+    connection = store.connection
+    connection.execute(
+        "INSERT INTO nodes(rev, id, path, qualname, kind, line_start, line_end, body_hash,"
+        " name_binding) VALUES(?,?,?,?,?,?,?,?,?)",
+        (rev, "m.py::A", "m.py", "A", "function", 1, 1, "x", "live"),
+    )
+    connection.executemany(
+        "INSERT INTO effects(rev, node_id, kind, direct, evidence_path, evidence_line,"
+        " confidence) VALUES(?,?,?,?,?,?,?)",
+        [
+            (rev, "m.py::A", "NETWORK", 1, "m.py", 1, "LOW"),
+            (rev, "m.py::A", "NETWORK", 1, "m.py", 1, "HIGH"),
+        ],
+    )
+    connection.commit()
+
+    report = effects_report(store, rev, "m.py::A")
+    row = next(r for g in report.groups for r in g.rows)
+    assert row.detail.startswith("NETWORK HIGH")
     store.close()

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1,0 +1,80 @@
+from codegraph.indexer import GitTreeSource, Indexer
+from codegraph.query.effects import effects_report
+from codegraph.store import Store
+
+
+def build(repo):
+    store = Store.open(repo)
+    Indexer(repo, store, GitTreeSource(repo)).reconcile("HEAD")
+    return store
+
+
+def kinds(report):
+    return {row.detail.split()[0] for group in report.groups for row in group.rows}
+
+
+def test_direct_network_effect_detected(repo, write):
+    write("m.py", "import requests\n\n\ndef fetch():\n    requests.get('u')\n", commit="m")
+    store = build(repo)
+    assert "NETWORK" in kinds(effects_report(store, "HEAD", "m.py::fetch"))
+    store.close()
+
+
+def test_effect_propagates_through_call_chain(repo, write):
+    source = (
+        "import requests\n\n\n"
+        "def low():\n    requests.get('u')\n\n\n"
+        "def mid():\n    low()\n\n\n"
+        "def high():\n    mid()\n"
+    )
+    write("m.py", source, commit="m")
+    store = build(repo)
+    assert "NETWORK" in kinds(effects_report(store, "HEAD", "m.py::high"))
+    store.close()
+
+
+def test_pure_function_reports_no_effects(repo, write):
+    write("m.py", "def pure(x):\n    return x + 1\n", commit="m")
+    store = build(repo)
+    assert effects_report(store, "HEAD", "m.py::pure").groups == []
+    store.close()
+
+
+def test_recursion_cycle_does_not_hang(repo, write):
+    source = (
+        "import requests\n\n\n"
+        "def ping(n):\n    requests.get('u')\n    return pong(n)\n\n\n"
+        "def pong(n):\n    return ping(n)\n"
+    )
+    write("m.py", source, commit="m")
+    store = build(repo)
+    assert "NETWORK" in kinds(effects_report(store, "HEAD", "m.py::pong"))
+    store.close()
+
+
+def test_witness_path_reaches_the_causing_callsite(repo, write):
+    source = "import requests\n\n\ndef low():\n    requests.get('u')\n\n\ndef high():\n    low()\n"
+    write("m.py", source, commit="m")
+    store = build(repo)
+    report = effects_report(store, "HEAD", "m.py::high")
+    row = report.groups[0].rows[0]
+    assert "m.py::low" in row.detail
+    assert row.location.startswith("m.py:")
+    store.close()
+
+
+def test_global_mutation_detected_syntactically(repo, write):
+    write("m.py", "COUNT = 0\n\n\ndef bump():\n    global COUNT\n    COUNT += 1\n", commit="m")
+    store = build(repo)
+    assert "GLOBAL_MUTATE" in kinds(effects_report(store, "HEAD", "m.py::bump"))
+    store.close()
+
+
+def test_project_override_tags_house_abstraction(repo, write):
+    write("codegraph.toml", '[[effect]]\nmatch = "app.db.*"\nkind = "DB_WRITE"\n')
+    write("app/__init__.py", "", commit="pkg")
+    write("app/db.py", "def save():\n    pass\n", commit="db")
+    write("svc.py", "from app import db\n\n\ndef run():\n    db.save()\n", commit="svc")
+    store = build(repo)
+    assert "DB_WRITE" in kinds(effects_report(store, "HEAD", "svc.py::run"))
+    store.close()

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -383,3 +383,131 @@ def test_effects_report_picks_the_strongest_confidence_for_a_repeated_kind(tmp_p
     row = next(r for g in report.groups for r in g.rows)
     assert row.detail.startswith("NETWORK HIGH")
     store.close()
+
+
+def test_evidence_location_picks_a_row_that_supports_the_reported_confidence(tmp_path):
+    """C1 regression (final verification, HIGH): `m.py::load` carries two
+    direct FS_READ rows for the SAME node -- `open(path, mode)` (ambiguous
+    mode, MEDIUM) on line 2, `open(path2)` (fully literal, HIGH) on line 3.
+    The reported confidence is the strongest across both rows (HIGH), so
+    the printed evidence must be the HIGH row at line 3. Before the fix,
+    `_evidence_location` picked `ORDER BY evidence_line LIMIT 1` with no
+    confidence filter and printed line 2 -- the MEDIUM, ambiguous call --
+    next to a HIGH label. Different lines AND different confidences is the
+    whole bug: B0's regression test seeded both rows at the same line and
+    never exercised this."""
+    store = Store.open(tmp_path)
+    rev = "HEAD"
+    connection = store.connection
+    connection.execute(
+        "INSERT INTO nodes(rev, id, path, qualname, kind, line_start, line_end, body_hash,"
+        " name_binding) VALUES(?,?,?,?,?,?,?,?,?)",
+        (rev, "m.py::load", "m.py", "load", "function", 1, 3, "x", "live"),
+    )
+    connection.executemany(
+        "INSERT INTO effects(rev, node_id, kind, direct, evidence_path, evidence_line,"
+        " confidence) VALUES(?,?,?,?,?,?,?)",
+        [
+            (rev, "m.py::load", "FS_READ", 1, "m.py", 2, "MEDIUM"),
+            (rev, "m.py::load", "FS_READ", 1, "m.py", 3, "HIGH"),
+        ],
+    )
+    connection.commit()
+
+    report = effects_report(store, rev, "m.py::load")
+    row = next(r for g in report.groups for r in g.rows)
+    assert row.detail.startswith("FS_READ HIGH")
+    assert row.location == "m.py:3"
+    store.close()
+
+
+def test_evidence_at_the_end_of_a_propagated_witness_chain_justifies_its_tier(tmp_path):
+    """Same bug, propagated shape: the witness chain's terminal node (`c`)
+    carries two direct NETWORK rows at different lines and confidences.
+    `a` reaches `c` over two HIGH edges, so the reported confidence is
+    HIGH; the printed location must be `c`'s HIGH row (line 9), not its
+    earlier MEDIUM row (line 5) -- the evidence at the end of a witness
+    chain has to justify the tier the chain is reported at, not just direct
+    effects on the queried node itself."""
+    store = Store.open(tmp_path)
+    rev = "HEAD"
+    connection = store.connection
+    connection.executemany(
+        "INSERT INTO nodes(rev, id, path, qualname, kind, line_start, line_end, body_hash,"
+        " name_binding) VALUES(?,?,?,?,?,?,?,?,?)",
+        [
+            (rev, "m.py::a", "m.py", "a", "function", 1, 1, "x", "live"),
+            (rev, "m.py::b", "m.py", "b", "function", 2, 2, "x", "live"),
+            (rev, "m.py::c", "m.py", "c", "function", 3, 3, "x", "live"),
+        ],
+    )
+    connection.executemany(
+        "INSERT INTO edges(rev, src, dst, kind, confidence, provenance, callsite_path,"
+        " callsite_line) VALUES(?,?,?,?,?,?,?,?)",
+        [
+            (rev, "m.py::a", "m.py::b", "CALLS", "HIGH", "static", "m.py", 1),
+            (rev, "m.py::b", "m.py::c", "CALLS", "HIGH", "static", "m.py", 2),
+        ],
+    )
+    connection.executemany(
+        "INSERT INTO effects(rev, node_id, kind, direct, evidence_path, evidence_line,"
+        " confidence) VALUES(?,?,?,?,?,?,?)",
+        [
+            (rev, "m.py::c", "NETWORK", 1, "m.py", 5, "MEDIUM"),
+            (rev, "m.py::c", "NETWORK", 1, "m.py", 9, "HIGH"),
+        ],
+    )
+    connection.commit()
+
+    propagate(store, rev)
+
+    report = effects_report(store, rev, "m.py::a")
+    row = next(r for g in report.groups for r in g.rows)
+    assert row.detail.startswith("NETWORK HIGH via")
+    assert row.location == "m.py:9"
+    store.close()
+
+
+def test_propagate_reduces_duplicate_direct_rows_with_stronger_not_scan_order(tmp_path):
+    """C2 regression (final verification, MED): `propagate.py:102` used to
+    keep whichever `direct=1` row SQL scan order returned last for a given
+    (node_id, kind) rather than reducing with `stronger()`, the way
+    `witness_path`'s own `direct_confidence` does. `callee` carries a HIGH
+    NETWORK row inserted BEFORE a LOW one; a last-write-wins reduction
+    would leave `callee`'s own confidence at LOW, making it ineligible at
+    the HIGH tier and silently downgrading `caller` (reached over a HIGH
+    CALLS edge) to LOW -- proven order-dependent on an identical graph.
+    `stronger()` must pick HIGH regardless of insertion order."""
+    store = Store.open(tmp_path)
+    rev = "HEAD"
+    connection = store.connection
+    connection.executemany(
+        "INSERT INTO nodes(rev, id, path, qualname, kind, line_start, line_end, body_hash,"
+        " name_binding) VALUES(?,?,?,?,?,?,?,?,?)",
+        [
+            (rev, "m.py::caller", "m.py", "caller", "function", 1, 1, "x", "live"),
+            (rev, "m.py::callee", "m.py", "callee", "function", 2, 2, "x", "live"),
+        ],
+    )
+    connection.execute(
+        "INSERT INTO edges(rev, src, dst, kind, confidence, provenance, callsite_path,"
+        " callsite_line) VALUES(?,?,?,?,?,?,?,?)",
+        (rev, "m.py::caller", "m.py::callee", "CALLS", "HIGH", "static", "m.py", 1),
+    )
+    # HIGH row inserted BEFORE the LOW row -- last-write-wins would keep LOW.
+    connection.executemany(
+        "INSERT INTO effects(rev, node_id, kind, direct, evidence_path, evidence_line,"
+        " confidence) VALUES(?,?,?,?,?,?,?)",
+        [
+            (rev, "m.py::callee", "NETWORK", 1, "m.py", 5, "HIGH"),
+            (rev, "m.py::callee", "NETWORK", 1, "m.py", 1, "LOW"),
+        ],
+    )
+    connection.commit()
+
+    propagate(store, rev)
+
+    report = effects_report(store, rev, "m.py::caller")
+    row = next(r for g in report.groups for r in g.rows)
+    assert row.detail.startswith("NETWORK HIGH via")
+    store.close()

--- a/tests/test_gitio.py
+++ b/tests/test_gitio.py
@@ -2,6 +2,8 @@ import subprocess
 import threading
 from pathlib import Path
 
+import pytest
+
 from codegraph import gitio
 from tests.conftest import git
 
@@ -187,3 +189,28 @@ def test_merge_base_and_default_branch(repo, write):
     write("c.py", "def gamma():\n    pass\n", commit="feature work")
     assert gitio.merge_base(repo, "main", "feature") == base
     assert gitio.default_branch(repo) == "main"
+
+
+# -- B9: a `rev` value that happens to start with `-` must be treated as a
+# revision (fails as "not found"), never reinterpreted as a git option.
+# `rev_parse` is the sharpest case: verified against a scratch repo that
+# WITHOUT the `--end-of-options` guard, `git rev-parse --not-a-real-option`
+# doesn't error at all -- rev-parse doesn't recognize the flag, falls back
+# to its "echo unrecognized arguments back verbatim" behavior, and exits 0
+# with the literal string "--not-a-real-option" as if it were a resolved
+# sha. That is a silently wrong answer, not just a confusing one.
+
+
+def test_rev_parse_treats_a_dash_prefixed_value_as_a_revision(repo):
+    with pytest.raises(gitio.GitError):
+        gitio.rev_parse(repo, "--not-a-real-option")
+
+
+def test_ls_tree_treats_a_dash_prefixed_rev_as_a_revision(repo):
+    with pytest.raises(gitio.GitError):
+        gitio.ls_tree(repo, "--not-a-real-option")
+
+
+def test_merge_base_treats_a_dash_prefixed_rev_as_a_revision(repo):
+    with pytest.raises(gitio.GitError):
+        gitio.merge_base(repo, "--not-a-real-option", "HEAD")

--- a/tests/test_gitio.py
+++ b/tests/test_gitio.py
@@ -109,6 +109,44 @@ def test_cat_file_batch_survives_early_abandonment(repo, tmp_path):
     assert not runner.is_alive(), "cat_file_batch cleanup hung on early abandonment"
 
 
+def test_ls_tree_sees_non_ascii_paths(repo, write):
+    """Regression for F1: `ls-tree --format=...` C-quotes a non-ASCII path
+    even under `-z` (`"\\303\\274n\\303\\257code.py"`), which fails
+    `.endswith(".py")` and silently drops the file from the tree."""
+    write("ünïcode.py", "def u():\n    return 1\n", commit="add unicode path")
+    tree = gitio.ls_tree(repo, "HEAD")
+    assert "ünïcode.py" in tree
+
+
+def test_ls_tree_sees_paths_with_a_space(repo, write):
+    write("has space.py", "def s():\n    return 1\n", commit="add spaced path")
+    tree = gitio.ls_tree(repo, "HEAD")
+    assert "has space.py" in tree
+
+
+def test_ls_tree_sees_paths_with_embedded_quote_or_backslash(repo, write):
+    """`"` and `\\` are C-quoted by `--format` unconditionally, independent
+    of `core.quotePath` -- only dropping `--format` entirely avoids it."""
+    write('weird"quote.py', "def q():\n    return 1\n", commit="add quoted path")
+    write("weird\\slash.py", "def s():\n    return 1\n", commit="add backslash path")
+    tree = gitio.ls_tree(repo, "HEAD")
+    assert 'weird"quote.py' in tree
+    assert "weird\\slash.py" in tree
+
+
+def test_ls_tree_and_status_paths_agree_on_a_dirty_unicode_file(repo, write):
+    """The compound failure the review flagged: with `ls_tree` dropping the
+    unicode path, an `Indexer` overlay would see it as absent from the base
+    tree and `status_paths` would report it `??`/`M` forever, on every
+    single diff, even once committed and clean. Once `ls_tree` sees the
+    path, a clean checkout must show no dirty status for it at all."""
+    write("ünïcode.py", "def u():\n    return 1\n", commit="add unicode path")
+    tree = gitio.ls_tree(repo, "HEAD")
+    assert "ünïcode.py" in tree
+    status = gitio.status_paths(repo)
+    assert "ünïcode.py" not in status
+
+
 def test_status_paths_reports_dirty_files(repo, write):
     write("a.py", "def alpha():\n    return 99\n")
     write("new.py", "def gamma():\n    pass\n")

--- a/tests/test_impact.py
+++ b/tests/test_impact.py
@@ -151,3 +151,28 @@ def test_limit_sets_truncated_flag(repo, write):
     report = impact_report(store, "HEAD", "m.py::target", limit=10)
     assert report.truncated is True
     store.close()
+
+
+def test_limit_is_a_total_budget_across_dependents_and_tests(repo, write):
+    """B3 regression: `dependents` and `tests` used to each be budgeted at
+    `limit` independently, so a report could print up to 2x its documented
+    budget (52 rows against a limit of 40, observed on codegraph's own
+    source). 15 production callers plus 15 test callers against a limit of
+    20 must keep at most 20 rows TOTAL, with `dependents` -- production
+    callers should never be crowded out by tests -- claiming its rows
+    first."""
+    prod_lines = ["def target():\n    pass\n"]
+    prod_lines += [f"def c{i}():\n    target()\n" for i in range(15)]
+    write("m.py", "\n\n".join(prod_lines), commit="m")
+    write("tests/__init__.py", "", commit="pkg")
+    test_lines = ["from m import target\n"]
+    test_lines += [f"def test_{i}():\n    target()\n" for i in range(15)]
+    write("tests/test_m.py", "\n\n".join(test_lines), commit="t")
+    store = build(repo)
+    report = impact_report(store, "HEAD", "m.py::target", limit=20)
+    total_kept = sum(len(g.rows) for g in report.groups)
+    assert total_kept == 20
+    assert report.truncated is True
+    dependents_group = next(g for g in report.groups if g.title == "dependents")
+    assert len(dependents_group.rows) == 15
+    store.close()

--- a/tests/test_impact.py
+++ b/tests/test_impact.py
@@ -1,0 +1,134 @@
+import pytest
+
+from codegraph.indexer import GitTreeSource, Indexer
+from codegraph.query.impact import impact_report
+from codegraph.query.rank import salience, score
+from codegraph.store import Store
+
+
+def build(repo):
+    store = Store.open(repo)
+    Indexer(repo, store, GitTreeSource(repo)).reconcile("HEAD")
+    return store
+
+
+def listed(report):
+    return {row.id for group in report.groups for row in group.rows}
+
+
+def test_closer_hops_score_higher():
+    assert score(1, "HIGH", 1.0) > score(3, "HIGH", 1.0)
+
+
+def test_higher_confidence_scores_higher():
+    assert score(1, "HIGH", 1.0) > score(1, "LOW", 1.0)
+
+
+def test_direct_and_transitive_callers_are_found(repo, write):
+    source = (
+        "def target():\n    pass\n\n\n"
+        "def direct():\n    target()\n\n\n"
+        "def indirect():\n    direct()\n"
+    )
+    write("m.py", source, commit="m")
+    store = build(repo)
+    found = listed(impact_report(store, "HEAD", "m.py::target"))
+    assert {"m.py::direct", "m.py::indirect"} <= found
+    store.close()
+
+
+def test_hop_limit_is_respected(repo, write):
+    source = (
+        "def target():\n    pass\n\n\n"
+        "def h1():\n    target()\n\n\n"
+        "def h2():\n    h1()\n\n\n"
+        "def h3():\n    h2()\n\n\n"
+        "def h4():\n    h3()\n"
+    )
+    write("m.py", source, commit="m")
+    store = build(repo)
+    found = listed(impact_report(store, "HEAD", "m.py::target", max_hops=2))
+    assert "m.py::h2" in found
+    assert "m.py::h4" not in found
+    store.close()
+
+
+def test_tests_are_bucketed_separately(repo, write):
+    write("m.py", "def target():\n    pass\n", commit="m")
+    write("tests/__init__.py", "", commit="pkg")
+    write(
+        "tests/test_m.py",
+        "from m import target\n\n\ndef test_target():\n    target()\n",
+        commit="t",
+    )
+    store = build(repo)
+    report = impact_report(store, "HEAD", "m.py::target")
+    test_groups = [g for g in report.groups if g.title == "tests"]
+    assert test_groups and test_groups[0].rows
+    other = {row.id for g in report.groups if g.title != "tests" for row in g.rows}
+    assert "tests/test_m.py::test_target" not in other
+    store.close()
+
+
+def test_low_confidence_counted_but_not_listed(repo, write):
+    write("one.py", "class One:\n    def shared(self):\n        pass\n", commit="1")
+    write("two.py", "class Two:\n    def shared(self):\n        pass\n", commit="2")
+    write("caller.py", "def go(thing):\n    thing.shared()\n", commit="c")
+    store = build(repo)
+    report = impact_report(store, "HEAD", "one.py::One.shared")
+    assert "caller.py::go" not in listed(report)
+    assert report.summary["low_confidence_hidden"] >= 1
+    with_low = impact_report(store, "HEAD", "one.py::One.shared", include_low=True)
+    assert "caller.py::go" in listed(with_low)
+    store.close()
+
+
+def test_summary_reports_reachable_effects(repo, write):
+    source = (
+        "import requests\n\n\n"
+        "def target():\n    requests.get('u')\n\n\n"
+        "def caller():\n    target()\n"
+    )
+    write("m.py", source, commit="m")
+    store = build(repo)
+    report = impact_report(store, "HEAD", "m.py::target")
+    assert "NETWORK" in str(report.summary)
+    store.close()
+
+
+def test_duplicate_edge_rows_do_not_double_count_fan_in(tmp_path):
+    """A caller that calls the target twice (two rows in `edges` for the
+    same (src, dst) pair -- e.g. the same call appearing twice in a body)
+    must contribute fan_in 1, not 2. Schema seeded directly so the edge
+    duplication is exact, mirroring test_effects.py's direct-seed style."""
+    store = Store.open(tmp_path)
+    rev = "HEAD"
+    connection = store.connection
+    connection.execute(
+        "INSERT INTO nodes(rev, id, path, qualname, kind, line_start, line_end, body_hash,"
+        " name_binding) VALUES(?,?,?,?,?,?,?,?,?)",
+        (rev, "m.py::mid", "m.py", "mid", "function", 1, 1, "x", "live"),
+    )
+    connection.executemany(
+        "INSERT INTO edges(rev, src, dst, kind, confidence, provenance, callsite_path,"
+        " callsite_line) VALUES(?,?,?,?,?,?,?,?)",
+        [
+            (rev, "m.py::top", "m.py::mid", "CALLS", "HIGH", "static", "m.py", 1),
+            (rev, "m.py::top", "m.py::mid", "CALLS", "HIGH", "static", "m.py", 2),
+        ],
+    )
+    connection.commit()
+
+    # 0.3 (not private) + min(1, 10) / 20 (one distinct caller, not two rows).
+    assert salience(store, rev, "m.py::mid") == pytest.approx(0.35)
+    store.close()
+
+
+def test_limit_sets_truncated_flag(repo, write):
+    lines = ["def target():\n    pass\n"]
+    lines += [f"def c{i}():\n    target()\n" for i in range(60)]
+    write("m.py", "\n\n".join(lines), commit="m")
+    store = build(repo)
+    report = impact_report(store, "HEAD", "m.py::target", limit=10)
+    assert report.truncated is True
+    store.close()

--- a/tests/test_impact.py
+++ b/tests/test_impact.py
@@ -96,6 +96,25 @@ def test_summary_reports_reachable_effects(repo, write):
     store.close()
 
 
+def test_entry_points_excludes_popular_intermediaries(repo, write):
+    """Regression for the round-2 Major: `entry_points` must count nodes by
+    their OWN fan_in == 0, not by threshold-sniffing `salience`'s combined
+    score. `popular` is public and has 10 distinct callers -- its salience
+    (0 + 0.3 public + 0.5 fan-in-capped = 0.8) crosses 0.5 with no help from
+    the entry-point term at all, so it must NOT be counted. Each `callerN`
+    has no callers of its own and must be."""
+    lines = ["def target():\n    pass\n\n\ndef popular():\n    target()\n"]
+    lines += [f"def caller{i}():\n    popular()\n" for i in range(10)]
+    write("m.py", "\n\n".join(lines), commit="m")
+    store = build(repo)
+    report = impact_report(store, "HEAD", "m.py::target")
+    assert report.summary["entry_points"] == 10
+    found = listed(report)
+    assert "m.py::popular" in found
+    assert all(f"m.py::caller{i}" in found for i in range(10))
+    store.close()
+
+
 def test_duplicate_edge_rows_do_not_double_count_fan_in(tmp_path):
     """A caller that calls the target twice (two rows in `edges` for the
     same (src, dst) pair -- e.g. the same call appearing twice in a body)

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -103,6 +103,35 @@ def test_syntax_error_is_recorded_not_raised(repo, write):
     store.close()
 
 
+def test_parse_errors_persist_across_runs(repo, write):
+    """Regression for F4: `_ensure_parsed` only counted errors over blobs
+    parsed THIS pass, so `status` reported `parse errors: 1` on the first
+    run and then silently reported 0 on every later run, even though the
+    broken file is unchanged, still unparseable, and still excluded from
+    the graph -- the count must reflect the revision's actual broken files,
+    not just newly-parsed ones."""
+    write("bad.py", "def broken(:\n", commit="bad")
+    store, indexer = build(repo)
+    first = indexer.reconcile("HEAD")
+    assert first.parse_errors == 1
+    second = indexer.reconcile("HEAD")
+    assert second.parse_errors == 1
+    store.close()
+
+
+def test_parse_errors_reflects_current_tree_not_every_blob_ever_seen(repo, write):
+    """A blob that was broken in an earlier revision but isn't part of the
+    current tree must not inflate the count."""
+    write("bad.py", "def broken(:\n", commit="bad")
+    store, indexer = build(repo)
+    stats = indexer.reconcile("HEAD")
+    assert stats.parse_errors == 1
+    write("bad.py", "def fixed():\n    return 1\n", commit="fix")
+    fixed_stats = indexer.reconcile("HEAD")
+    assert fixed_stats.parse_errors == 0
+    store.close()
+
+
 def test_works_without_git(tmp_path):
     (tmp_path / "solo.py").write_text("def solo():\n    pass\n")
     store = Store.open(tmp_path)

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -4,6 +4,7 @@ import subprocess
 
 import pytest
 
+from codegraph.config import DEFAULT_AMBIGUITY_LIMIT
 from codegraph.indexer import GitTreeSource, Indexer
 from codegraph.store import WORKTREE, Store
 from tests.conftest import git
@@ -220,4 +221,83 @@ def test_switch_parses_at_most_the_changed_files(repo, write):
     git(repo, "add", "-A")
     git(repo, "commit", "-qm", "touch three")
     assert indexer.reconcile("HEAD").blobs_parsed == 3
+    store.close()
+
+
+# -- graph size ------------------------------------------------------------
+#
+# The last-resort resolution step matches a bare name against every live
+# definition in the revision, so before the ambiguity cap the edge table grew
+# with the SQUARE of the repo: 120 edges/file on flask (83 files), 740 on django
+# (2,930 files) -- 2.09M LOW edges, 96.6% of the graph, up to 971 for a single
+# call site. Nothing caught it because every test repo here is a handful of
+# files. This is that missing test, at a size a unit test can afford. See #6.
+
+
+def duck_typed_repo(repo, write, count):
+    """`count` files, each carrying one edge of each shape.
+
+    `local{i}()` is a module-local call: exactly one HIGH edge per file however
+    big the repo gets -- the linear term, and what keeps the graph non-empty
+    once the cap fires. `item.save()` is the quadratic term: `save` is defined
+    in every file, so without a cap each of the `count` callers matches all
+    `count` definitions.
+    """
+    for i in range(count):
+        write(
+            f"m{i}.py",
+            f"class C{i}:\n"
+            f"    def save(self):\n"
+            f"        return {i}\n"
+            f"\n\n"
+            f"def local{i}():\n"
+            f"    return {i}\n"
+            f"\n\n"
+            f"def persist{i}(item):\n"
+            f"    local{i}()\n"
+            f"    return item.save()\n",
+        )
+    git(repo, "add", "-A")
+    git(repo, "commit", "-qm", f"{count} files")
+
+
+def edge_count(repo):
+    store = Store.open(repo)
+    try:
+        return Indexer(repo, store, GitTreeSource(repo)).reconcile("HEAD").edges
+    finally:
+        store.close()
+
+
+def test_graph_size_grows_with_the_repo_not_with_its_square(repo, write, tmp_path_factory):
+    small_root, large_root = repo, tmp_path_factory.mktemp("large")
+    git(large_root, "init", "-q", "-b", "main")
+    git(large_root, "config", "user.email", "test@example.com")
+    git(large_root, "config", "user.name", "Test")
+
+    def write_large(rel, text, commit=None):
+        (large_root / rel).write_text(text)
+
+    duck_typed_repo(small_root, write, 40)
+    duck_typed_repo(large_root, write_large, 160)
+
+    small, large = edge_count(small_root), edge_count(large_root)
+    growth = large / small
+    # 4x the files. Linear growth is 4x; quadratic is 16x. The bound is loose on
+    # purpose -- it is a growth-RATE guard, not a size target, and must not be
+    # tightened into a benchmark.
+    assert growth < 6.0, f"{small} -> {large} edges for 4x the files ({growth:.1f}x growth)"
+
+
+def test_no_single_reference_is_expanded_past_the_ambiguity_limit(repo, write):
+    duck_typed_repo(repo, write, 60)
+    store = Store.open(repo)
+    Indexer(repo, store, GitTreeSource(repo)).reconcile("HEAD")
+    rows = store.connection.execute(
+        "SELECT COUNT(*) AS n FROM edges WHERE rev='HEAD' GROUP BY src, callsite_path,"
+        " callsite_line"
+    ).fetchall()
+    assert rows, "no edges at all — the fixture stopped exercising anything"
+    worst = max(row["n"] for row in rows)
+    assert worst <= DEFAULT_AMBIGUITY_LIMIT, f"a single call site produced {worst} edges"
     store.close()

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -2,6 +2,7 @@ import os
 import stat
 import time
 
+from codegraph.cli import main
 from codegraph.indexer import GitTreeSource, Indexer
 from codegraph.maintenance import gc, install_hooks
 from codegraph.query.impact import impact_report
@@ -123,6 +124,142 @@ def test_install_hooks_is_idempotent(repo):
     assert first == second
     assert second.count("codegraph index") == 1
     assert {p.name for p in written_again} == {"post-commit", "post-checkout", "post-merge"}
+
+
+# --- Interpreter allowlist and stale-install repair (2nd review round) ---
+
+
+def test_install_hooks_skips_perl_hook_untouched(repo):
+    """Splicing shell syntax into a hook written for a different
+    interpreter corrupts it outright, not just fails to warm it. A Perl
+    hook must be left byte-for-byte alone and absent from the returned
+    (installed) list."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    perl_hook = hooks_dir / "post-commit"
+    original = '#!/usr/bin/perl\nprint "perl-hook-ran\\n";\n'
+    perl_hook.write_text(original)
+    perl_hook.chmod(perl_hook.stat().st_mode | stat.S_IXUSR)
+
+    written = install_hooks(repo)
+
+    assert perl_hook not in written
+    assert perl_hook.read_text() == original
+
+
+def test_install_hooks_skips_env_python_hook_untouched(repo):
+    """`#!/usr/bin/env python3` is exactly as unsafe to splice into as a
+    direct `#!/usr/bin/perl` -- the `env` indirection must still resolve to
+    the real interpreter for the allowlist check."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    python_hook = hooks_dir / "post-checkout"
+    original = "#!/usr/bin/env python3\nprint('python-hook-ran')\n"
+    python_hook.write_text(original)
+    python_hook.chmod(python_hook.stat().st_mode | stat.S_IXUSR)
+
+    written = install_hooks(repo)
+
+    assert python_hook not in written
+    assert python_hook.read_text() == original
+
+
+def test_install_hooks_reports_skip_reason_on_cli(repo, capsys):
+    """A skip must be loud, not silent: the CLI names the skipped hook and
+    says why, on stderr, distinct from the installed paths on stdout."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    perl_hook = hooks_dir / "post-commit"
+    perl_hook.write_text('#!/usr/bin/perl\nprint "hi\\n";\n')
+    perl_hook.chmod(perl_hook.stat().st_mode | stat.S_IXUSR)
+
+    assert main(["install-hooks", "--path", str(repo)]) == 0
+
+    captured = capsys.readouterr()
+    assert "post-commit" not in captured.out
+    assert "post-checkout" in captured.out
+    assert "post-merge" in captured.out
+    assert "skipped post-commit" in captured.err
+    assert "perl" in captured.err.lower()
+
+
+def test_install_hooks_still_installs_allowlisted_shell_shapes(repo):
+    """`#!/bin/bash -e`, `#!/usr/bin/env bash`, and a fully absent shebang
+    all name (or don't contradict) a POSIX-shell-compatible interpreter and
+    must still install normally."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+
+    bash_flag_hook = hooks_dir / "post-commit"
+    bash_flag_hook.write_text("#!/bin/bash -e\necho bash-ran\n")
+    bash_flag_hook.chmod(bash_flag_hook.stat().st_mode | stat.S_IXUSR)
+
+    env_bash_hook = hooks_dir / "post-checkout"
+    env_bash_hook.write_text("#!/usr/bin/env bash\necho env-bash-ran\n")
+    env_bash_hook.chmod(env_bash_hook.stat().st_mode | stat.S_IXUSR)
+
+    # post-merge: no pre-existing file at all.
+
+    written = install_hooks(repo)
+
+    assert {p.name for p in written} == {"post-commit", "post-checkout", "post-merge"}
+    assert "codegraph index" in bash_flag_hook.read_text()
+    assert bash_flag_hook.read_text().startswith("#!/bin/bash -e\n")
+    assert "codegraph index" in env_bash_hook.read_text()
+    assert env_bash_hook.read_text().startswith("#!/usr/bin/env bash\n")
+
+
+def test_install_hooks_repairs_a_stale_pre_fix_install(repo):
+    """A hook carrying the OLD append-at-end block (with `$?` preservation,
+    installed after the pre-existing hook's own `exit 0`) must not be left
+    byte-identical -- it was silently dead. install_hooks repairs it into a
+    live, top-of-file block."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    stale_hook = hooks_dir / "post-commit"
+    stale_hook.write_text(
+        "#!/bin/sh\n"
+        "echo hi >> marker.txt\n"
+        "exit 0\n"
+        "# >>> codegraph (warming only; safe to remove) >>>\n"
+        "_codegraph_status=$?\n"
+        '( cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"'
+        ' && codegraph index --quiet >/dev/null 2>&1 & ) >/dev/null 2>&1 || true\n'
+        "exit $_codegraph_status\n"
+        "# <<< codegraph (warming only; safe to remove) <<<\n"
+    )
+    stale_hook.chmod(stale_hook.stat().st_mode | stat.S_IXUSR)
+
+    written = install_hooks(repo)
+
+    content = stale_hook.read_text()
+    assert stale_hook in written
+    assert "_codegraph_status" not in content  # old dead artifact is gone
+    assert content.count("codegraph index") == 1
+    assert content.index("codegraph index") < content.index("exit 0")
+    assert "echo hi >> marker.txt" in content
+
+
+def test_install_hooks_three_reruns_stay_at_one_invocation(repo):
+    """Repair and idempotency share one mechanism (strip-then-insert), so
+    repeated calls -- even against a hook that keeps ending in its own
+    `exit 0` -- must converge, not accumulate."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    hook = hooks_dir / "post-commit"
+    hook.write_text("#!/bin/sh\necho hi >> marker.txt\nexit 0\n")
+    hook.chmod(hook.stat().st_mode | stat.S_IXUSR)
+
+    install_hooks(repo)
+    first = hook.read_text()
+    install_hooks(repo)
+    second = hook.read_text()
+    install_hooks(repo)
+    third = hook.read_text()
+
+    assert first == second == third
+    assert third.count("codegraph index") == 1
+    assert third.count("# >>> codegraph") == 1
 
 
 def test_gc_does_not_corrupt_a_live_graph(repo, write):

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -1,5 +1,6 @@
 import os
 import stat
+import time
 
 from codegraph.indexer import GitTreeSource, Indexer
 from codegraph.maintenance import gc, install_hooks
@@ -64,13 +65,51 @@ def test_install_hooks_preserves_pre_existing_hook(repo):
     written = install_hooks(repo)
 
     content = existing_hook.read_text()
-    assert original.strip() in content
+    assert "echo ran >> marker.txt" in content
     assert "codegraph index" in content
     assert existing_hook in written
 
     # The pre-existing behavior must still actually fire.
     git(repo, "commit", "--allow-empty", "-qm", "trigger hooks")
     assert (repo / "marker.txt").read_text() == "ran\n"
+
+
+def test_install_hooks_fires_even_after_a_pre_existing_exit(repo, monkeypatch, tmp_path):
+    """A pre-existing hook that ends in `exit 0` -- a very common idiom -- is
+    exactly the case that was silently broken: code appended after that
+    `exit` is unreachable, so the warming block never ran even though
+    install_hooks reported success. It must fire regardless, by running
+    before the pre-existing script's own logic rather than after it."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    existing_hook = hooks_dir / "post-commit"
+    existing_hook.write_text("#!/bin/sh\necho hi >> marker.txt\nexit 0\n")
+    existing_hook.chmod(existing_hook.stat().st_mode | stat.S_IXUSR)
+
+    # A `codegraph` shim on PATH that just logs that it was invoked.
+    shim_dir = tmp_path / "shim"
+    shim_dir.mkdir()
+    log = tmp_path / "invoked.log"
+    shim = shim_dir / "codegraph"
+    shim.write_text(f'#!/bin/sh\necho invoked >> "{log}"\n')
+    shim.chmod(shim.stat().st_mode | stat.S_IXUSR)
+    monkeypatch.setenv("PATH", f"{shim_dir}{os.pathsep}{os.environ['PATH']}")
+
+    install_hooks(repo)
+    content = existing_hook.read_text()
+    # The codegraph block must precede the pre-existing `exit 0`, not follow it.
+    assert content.index("codegraph index") < content.index("exit 0")
+
+    git(repo, "commit", "--allow-empty", "-qm", "trigger hooks despite exit 0")
+
+    # The backgrounded warm-up may still be running when `git commit`
+    # returns; give it a short window to land before asserting it fired.
+    deadline = time.monotonic() + 2.0
+    while not log.exists() and time.monotonic() < deadline:
+        time.sleep(0.02)
+    assert log.exists(), "codegraph shim was never invoked -- warming block was skipped"
+    # The pre-existing hook's own behavior still ran too.
+    assert (repo / "marker.txt").read_text() == "hi\n"
 
 
 def test_install_hooks_is_idempotent(repo):

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -1,0 +1,127 @@
+import os
+import stat
+
+from codegraph.indexer import GitTreeSource, Indexer
+from codegraph.maintenance import gc, install_hooks
+from codegraph.query.impact import impact_report
+from codegraph.resolve import find_symbol
+from codegraph.store import Store
+from tests.conftest import git
+
+
+def test_gc_removes_unreferenced_blobs(repo, write):
+    store = Store.open(repo)
+    indexer = Indexer(repo, store, GitTreeSource(repo))
+    indexer.reconcile("HEAD")
+    write("a.py", "def alpha():\n    return 2\n", commit="edit")
+    indexer.reconcile("HEAD")
+    before = store.connection.execute("SELECT COUNT(*) c FROM blobs").fetchone()["c"]
+    removed = gc(store, {"HEAD"})
+    after = store.connection.execute("SELECT COUNT(*) c FROM blobs").fetchone()["c"]
+    assert removed >= 1
+    assert after < before
+    store.close()
+
+
+def test_gc_keeps_blobs_of_retained_revisions(repo):
+    store = Store.open(repo)
+    Indexer(repo, store, GitTreeSource(repo)).reconcile("HEAD")
+    gc(store, {"HEAD"})
+    rows = store.connection.execute("SELECT COUNT(*) c FROM blobs").fetchone()["c"]
+    assert rows == 1
+    store.close()
+
+
+def test_install_hooks_writes_executable_hooks(repo):
+    written = install_hooks(repo)
+    assert {p.name for p in written} == {"post-commit", "post-checkout", "post-merge"}
+    for path in written:
+        assert os.stat(path).st_mode & stat.S_IXUSR
+        assert "codegraph index" in path.read_text()
+
+
+def test_hooks_do_not_block_the_git_operation(repo, write):
+    install_hooks(repo)
+    write("c.py", "def gamma():\n    pass\n", commit="with hooks installed")
+    assert git(repo, "rev-parse", "--abbrev-ref", "HEAD").strip() == "main"
+
+
+# --- Extra tests per the brief -------------------------------------------
+
+
+def test_install_hooks_preserves_pre_existing_hook(repo):
+    """A repo may already have a post-commit hook (e.g. a linter). Installing
+    codegraph's hooks must not clobber it -- the existing script's own
+    behavior (here, appending to a marker file) must still run, and its
+    original source text must still be present in the file verbatim."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    existing_hook = hooks_dir / "post-commit"
+    original = "#!/bin/sh\necho ran >> marker.txt\n"
+    existing_hook.write_text(original)
+    existing_hook.chmod(existing_hook.stat().st_mode | stat.S_IXUSR)
+
+    written = install_hooks(repo)
+
+    content = existing_hook.read_text()
+    assert original.strip() in content
+    assert "codegraph index" in content
+    assert existing_hook in written
+
+    # The pre-existing behavior must still actually fire.
+    git(repo, "commit", "--allow-empty", "-qm", "trigger hooks")
+    assert (repo / "marker.txt").read_text() == "ran\n"
+
+
+def test_install_hooks_is_idempotent(repo):
+    """Running install_hooks twice must not double-append the codegraph
+    block or produce two invocations of `codegraph index`."""
+    install_hooks(repo)
+    first = (repo / ".git" / "hooks" / "post-commit").read_text()
+    written_again = install_hooks(repo)
+    second = (repo / ".git" / "hooks" / "post-commit").read_text()
+
+    assert first == second
+    assert second.count("codegraph index") == 1
+    assert {p.name for p in written_again} == {"post-commit", "post-checkout", "post-merge"}
+
+
+def test_gc_does_not_corrupt_a_live_graph(repo, write):
+    """After gc(store, {"HEAD"}), a query at HEAD must still return the same
+    answer it did before the gc: Layer 1 rows for retained revisions, and
+    everything Layer 2 needs, must survive."""
+    write(
+        "b.py",
+        "from a import alpha\n\ndef beta():\n    return alpha()\n",
+        commit="add beta",
+    )
+    store = Store.open(repo)
+    indexer = Indexer(repo, store, GitTreeSource(repo))
+    indexer.reconcile("HEAD")
+
+    node_id = find_symbol(store, "HEAD", "alpha")[0]["id"]
+    before = impact_report(store, "HEAD", node_id)
+
+    gc(store, {"HEAD"})
+
+    after = impact_report(store, "HEAD", node_id)
+    assert after == before
+    assert len(before.groups) > 0
+    store.close()
+
+
+def test_gc_with_empty_keep_revs_removes_everything(repo):
+    """An empty keep_revs retains nothing: every Layer 1 row is unreferenced
+    by definition, so gc removes it all. This is the defined behavior for
+    the empty case, not an accident of the query."""
+    store = Store.open(repo)
+    Indexer(repo, store, GitTreeSource(repo)).reconcile("HEAD")
+    before = store.connection.execute("SELECT COUNT(*) c FROM blobs").fetchone()["c"]
+    assert before > 0
+
+    removed = gc(store, set())
+
+    after = store.connection.execute("SELECT COUNT(*) c FROM blobs").fetchone()["c"]
+    assert removed == before
+    assert after == 0
+    store.close()

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -4,7 +4,7 @@ import time
 
 from codegraph.cli import main
 from codegraph.indexer import GitTreeSource, Indexer
-from codegraph.maintenance import gc, install_hooks
+from codegraph.maintenance import gc, install_hooks, plan_hooks
 from codegraph.query.impact import impact_report
 from codegraph.resolve import find_symbol
 from codegraph.store import Store
@@ -260,6 +260,131 @@ def test_install_hooks_three_reruns_stay_at_one_invocation(repo):
     assert first == second == third
     assert third.count("codegraph index") == 1
     assert third.count("# >>> codegraph") == 1
+
+
+# --- Binary hooks, env -S, multi-block convergence, marker anchoring,
+# --- and half-marker refusal (3rd review round) --------------------------
+
+
+def test_install_hooks_skips_binary_hook_but_installs_the_others(repo):
+    """A compiled/binary post-commit (pre-commit frameworks and compiled
+    shims ship these) must not crash the whole command -- it's a non-shell
+    hook, refused the same as Perl, and the other two hooks still install."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    binary_hook = hooks_dir / "post-commit"
+    original = bytes([0x7F, 0x45, 0x4C, 0x46, 0x02, 0x01, 0x01, 0x00, 0xFF, 0xFE, 0x00, 0x01])
+    binary_hook.write_bytes(original)
+    binary_hook.chmod(binary_hook.stat().st_mode | stat.S_IXUSR)
+
+    written = install_hooks(repo)
+
+    assert binary_hook not in written
+    assert {p.name for p in written} == {"post-checkout", "post-merge"}
+    assert binary_hook.read_bytes() == original
+
+
+def test_install_hooks_resolves_env_dash_capital_s_flag(repo):
+    """`#!/usr/bin/env -S bash -e` names bash, not `-S` -- env's own flags
+    must be skipped when hunting for the interpreter token."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    hook = hooks_dir / "post-commit"
+    hook.write_text("#!/usr/bin/env -S bash -e\necho bash-with-env-S-ran\n")
+    hook.chmod(hook.stat().st_mode | stat.S_IXUSR)
+
+    written = install_hooks(repo)
+
+    assert hook in written
+    content = hook.read_text()
+    assert content.startswith("#!/usr/bin/env -S bash -e\n")
+    assert "codegraph index" in content
+    assert "echo bash-with-env-S-ran" in content
+
+
+def test_install_hooks_converges_a_leading_and_trailing_double_block(repo):
+    """A file carrying two codegraph blocks (a current one spliced at the
+    top, plus a stale one still sitting at the end from an even older
+    install) must converge to exactly one block, not one-fewer."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    hook = hooks_dir / "post-commit"
+    hook.write_text(
+        "#!/bin/sh\n"
+        "# >>> codegraph (warming only; safe to remove) >>>\n"
+        '( cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"'
+        " && codegraph index --quiet >/dev/null 2>&1 & ) >/dev/null 2>&1 || true\n"
+        "# <<< codegraph (warming only; safe to remove) <<<\n"
+        "echo real-work\n"
+        "# >>> codegraph (warming only; safe to remove) >>>\n"
+        "_codegraph_status=$?\n"
+        '( cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"'
+        " && codegraph index --quiet >/dev/null 2>&1 & ) >/dev/null 2>&1 || true\n"
+        "exit $_codegraph_status\n"
+        "# <<< codegraph (warming only; safe to remove) <<<\n"
+    )
+    hook.chmod(hook.stat().st_mode | stat.S_IXUSR)
+
+    written = install_hooks(repo)
+
+    content = hook.read_text()
+    assert hook in written
+    assert content.count("# >>> codegraph (warming only; safe to remove) >>>") == 1
+    assert content.count("# <<< codegraph (warming only; safe to remove) <<<") == 1
+    assert content.count("codegraph index") == 1
+    assert "_codegraph_status" not in content
+    assert "echo real-work" in content
+
+
+def test_install_hooks_ignores_marker_text_embedded_in_other_lines(repo):
+    """Marker matching must be anchored to a whole line, not a substring
+    search -- a hook whose own comment or echoed string happens to contain
+    the marker text must keep every real statement around it."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    hook = hooks_dir / "post-commit"
+    hook.write_text(
+        "#!/bin/sh\n"
+        "do_important_setup_step\n"
+        'echo "reminder: # >>> codegraph (warming only; safe to remove) >>> not a real marker"\n'
+        "do_important_setup_step\n"
+    )
+    hook.chmod(hook.stat().st_mode | stat.S_IXUSR)
+
+    written = install_hooks(repo)
+
+    content = hook.read_text()
+    assert hook in written
+    assert content.count("do_important_setup_step") == 2
+    assert "not a real marker" in content
+    assert "codegraph index" in content
+
+
+def test_install_hooks_skips_half_marker_left_byte_identical(repo):
+    """A begin marker with no matching end is damage from some previous
+    mishap, not a shape to guess a repair for -- it must be skipped
+    loudly and left completely untouched, not silently grown a second
+    (also broken) block on the next run."""
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    hook = hooks_dir / "post-commit"
+    original = (
+        "#!/bin/sh\n"
+        "# >>> codegraph (warming only; safe to remove) >>>\n"
+        "echo oops-truncated-mid-block\n"
+    )
+    hook.write_text(original)
+    hook.chmod(hook.stat().st_mode | stat.S_IXUSR)
+
+    written = install_hooks(repo)
+
+    assert hook not in written
+    assert hook.read_text() == original
+
+    results = plan_hooks(repo)
+    result = next(r for r in results if r.name == "post-commit")
+    assert not result.installed
+    assert "malformed" in result.reason.lower()
 
 
 def test_gc_does_not_corrupt_a_live_graph(repo, write):

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,34 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_plugin_manifest_is_valid():
+    data = json.loads((ROOT / ".claude-plugin" / "plugin.json").read_text())
+    assert data["name"] == "codegraph"
+    assert data["version"]
+    assert data["description"]
+
+
+def test_marketplace_lists_the_plugin():
+    data = json.loads((ROOT / ".claude-plugin" / "marketplace.json").read_text())
+    names = {p["name"] for p in data["plugins"]}
+    assert "codegraph" in names
+    assert data["plugins"][0]["source"] == "./"
+
+
+def test_skill_has_frontmatter_and_covers_triggers():
+    text = (ROOT / "skills" / "codegraph" / "SKILL.md").read_text()
+    assert text.startswith("---")
+    assert "name: codegraph" in text
+    assert "description:" in text
+    lowered = text.lower()
+    for trigger in ["what breaks", "safe to change", "grep"]:
+        assert trigger in lowered
+
+
+def test_skill_documents_every_shipped_command():
+    text = (ROOT / "skills" / "codegraph" / "SKILL.md").read_text()
+    for command in ["codegraph resolve", "codegraph impact", "codegraph effects", "codegraph diff"]:
+        assert command in text

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -115,3 +115,34 @@ def test_syntax_error_returns_error_not_exception():
 def test_parse_is_deterministic():
     source = b"class A:\n    def m(self):\n        return other()\n"
     assert parse_blob(source) == parse_blob(source)
+
+
+def test_global_statement_recorded_as_ref():
+    source = b"COUNT = 0\n\n\ndef bump():\n    global COUNT\n    COUNT += 1\n"
+    result = parse_blob(source)
+    ref = next(r for r in result.refs if r.ref_kind == "global")
+    assert ref.from_qualname == "bump"
+    assert ref.raw_name == "COUNT"
+    assert ref.line == 5
+
+
+def test_nonlocal_statement_recorded_as_global_ref():
+    source = (
+        b"def outer():\n"
+        b"    x = 0\n"
+        b"    def inner():\n"
+        b"        nonlocal x\n"
+        b"        x += 1\n"
+        b"    return inner\n"
+    )
+    result = parse_blob(source)
+    ref = next(r for r in result.refs if r.ref_kind == "global")
+    assert ref.from_qualname == "outer.<locals>.inner"
+    assert ref.raw_name == "x"
+
+
+def test_global_statement_with_multiple_names_recorded_separately():
+    source = b"def bump():\n    global A, B\n    A += 1\n    B += 1\n"
+    result = parse_blob(source)
+    names = {r.raw_name for r in result.refs if r.ref_kind == "global"}
+    assert names == {"A", "B"}

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -32,6 +32,49 @@ def test_body_hash_changes_with_body():
     assert one.nodes[0].body_hash != two.nodes[0].body_hash
 
 
+def _class_hash(result):
+    return next(n.body_hash for n in result.nodes if n.qualname == "Beta")
+
+
+def _method_hash(result):
+    return next(n.body_hash for n in result.nodes if n.qualname == "Beta.gamma")
+
+
+def test_class_body_hash_ignores_a_method_body_edit():
+    """B7 regression: a class's body_hash used to include every nested
+    method's body verbatim, so editing one line inside a single method
+    reported BOTH the method AND its class as changed. `_BodyElider`
+    already solved exactly this for module nodes; it just wasn't applied
+    to classes too."""
+    one = parse_blob(b"class Beta:\n    def gamma(self):\n        return 1\n")
+    two = parse_blob(b"class Beta:\n    def gamma(self):\n        return 2\n")
+    assert _class_hash(one) == _class_hash(two)
+    # The method's own body_hash still changes -- only the class's doesn't.
+    assert _method_hash(one) != _method_hash(two)
+
+
+def test_class_body_hash_changes_when_a_method_is_added():
+    one = parse_blob(b"class Beta:\n    def gamma(self):\n        pass\n")
+    two = parse_blob(
+        b"class Beta:\n    def gamma(self):\n        pass\n\n    def delta(self):\n        pass\n"
+    )
+    assert _class_hash(one) != _class_hash(two)
+
+
+def test_class_body_hash_changes_with_bases_and_decorators():
+    plain = parse_blob(b"class Beta:\n    def gamma(self):\n        pass\n")
+    subclassed = parse_blob(b"class Beta(Base):\n    def gamma(self):\n        pass\n")
+    decorated = parse_blob(b"@final\nclass Beta:\n    def gamma(self):\n        pass\n")
+    assert _class_hash(plain) != _class_hash(subclassed)
+    assert _class_hash(plain) != _class_hash(decorated)
+
+
+def test_class_body_hash_ignores_line_position():
+    top = parse_blob(b"class Beta:\n    def gamma(self):\n        pass\n")
+    shifted = parse_blob(b"\n\n\nclass Beta:\n    def gamma(self):\n        pass\n")
+    assert _class_hash(top) == _class_hash(shifted)
+
+
 def test_shadowed_definitions_are_all_retained():
     result = parse_blob(b"def alpha():\n    return 1\n\n\ndef alpha():\n    return 2\n")
     alphas = [n for n in result.nodes if n.qualname == "alpha"]

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -88,6 +88,66 @@ def test_bare_call_and_self_call_recorded():
     assert raw == {"helper", "self.step"}
 
 
+def test_calls_on_non_flattenable_receivers_are_still_recorded():
+    """Regression for F2: a call whose receiver isn't a flattenable
+    Name/Attribute chain used to be dropped from `refs` entirely -- no edge
+    and no `unresolved` row, so the loss was invisible. `super().go()`,
+    `PaymentService().charge(x)`, `self.items[0].run()`, `(a or b).fire()`
+    and `d["k"].m()` must all still produce a `call` ref, carrying the
+    attribute name (marked with the synthetic `<attr>.` prefix so it is
+    routed past the HIGH-confidence resolver steps rather than falsely
+    matched as an imported/module-local/self name)."""
+    source = (
+        b"class Base:\n"
+        b"    def go(self):\n        pass\n\n\n"
+        b"class Child(Base):\n"
+        b"    def go(self):\n"
+        b"        super().go()\n"
+        b"        PaymentService().charge(1)\n"
+        b"        self.items[0].run()\n"
+        b"        (a or b).fire()\n"
+        b"        d['k'].m()\n"
+)
+    result = parse_blob(source)
+    raw = {r.raw_name for r in result.refs if r.ref_kind == "call"}
+    assert raw >= {
+        "<attr>.go",
+        "<attr>.charge",
+        "<attr>.run",
+        "<attr>.fire",
+        "<attr>.m",
+    }
+
+
+def test_call_with_no_attribute_at_all_is_recorded_under_a_placeholder():
+    """`handlers[i]()` -- the callable itself isn't even an attribute
+    access, so there is no name at all to key on; it must still be counted,
+    not silently dropped."""
+    source = b"def dispatch(handlers, i):\n    handlers[i]()\n"
+    result = parse_blob(source)
+    raw = {r.raw_name for r in result.refs if r.ref_kind == "call"}
+    assert raw == {"<dynamic>"}
+
+
+def test_open_call_mode_is_captured_in_raw_name():
+    """`open`'s effect kind depends on its mode argument, which the effect
+    catalog (a plain dotted-name matcher) can never see on its own -- the
+    parser is the one place with the call's AST, so it encodes what it
+    learns into the ref's `raw_name` for the catalog to key on."""
+    source = (
+        b"def f(mode):\n"
+        b"    open('a')\n"
+        b"    open('b', 'r')\n"
+        b"    open('c', 'w')\n"
+        b"    open('d', 'ab')\n"
+        b"    open('e', mode='x')\n"
+        b"    open('f', mode)\n"
+    )
+    result = parse_blob(source)
+    raw = [r.raw_name for r in result.refs if r.ref_kind == "call"]
+    assert raw == ["open", "open", "open!write", "open!write", "open!write", "open!ambiguous"]
+
+
 def test_imports_recorded_with_level():
     source = b"import os\nfrom . import sibling\nfrom pay.service import charge as c\n"
     result = parse_blob(source)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -146,3 +146,27 @@ def test_global_statement_with_multiple_names_recorded_separately():
     result = parse_blob(source)
     names = {r.raw_name for r in result.refs if r.ref_kind == "global"}
     assert names == {"A", "B"}
+
+
+def test_module_body_hash_ignores_line_shift():
+    top = parse_blob(b"def alpha():\n    return 1\n")
+    shifted = parse_blob(b"\n\n\ndef alpha():\n    return 1\n")
+    assert top.module_body_hash == shifted.module_body_hash
+
+
+def test_module_body_hash_ignores_nested_body_changes():
+    one = parse_blob(b"def alpha():\n    return 1\n")
+    two = parse_blob(b"def alpha():\n    return 2\n")
+    assert one.module_body_hash == two.module_body_hash
+
+
+def test_module_body_hash_changes_with_top_level_statement():
+    one = parse_blob(b"def alpha():\n    return 1\n")
+    two = parse_blob(b"import requests\n\n\ndef alpha():\n    return 1\n")
+    assert one.module_body_hash != two.module_body_hash
+
+
+def test_module_body_hash_changes_when_def_is_added():
+    one = parse_blob(b"def alpha():\n    return 1\n")
+    two = parse_blob(b"def alpha():\n    return 1\n\n\ndef beta():\n    return 2\n")
+    assert one.module_body_hash != two.module_body_hash

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -34,7 +34,7 @@ def test_cold_index_and_warm_query_are_fast(tmp_path):
 
 
 @pytest.mark.slow
-def test_branch_switch_is_under_a_second(tmp_path):
+def test_branch_switch_reparses_nothing(tmp_path):
     repo = tmp_path / "flask"
     git(tmp_path, "clone", "-q", "--depth", "50", "https://github.com/pallets/flask", str(repo))
     store = Store.open(repo)
@@ -45,6 +45,8 @@ def test_branch_switch_is_under_a_second(tmp_path):
     started = time.perf_counter()
     stats = indexer.reconcile("HEAD")
     elapsed = time.perf_counter() - started
-    assert stats.blobs_parsed == 0
-    assert elapsed < 1.0, f"branch switch took {elapsed:.2f}s"
+    assert stats.blobs_parsed == 0  # the cost guarantee: branch creation re-parses nothing
+    # Wall-clock is an order-of-magnitude guard against a real regression, not a
+    # performance target - it must not be tightened back down to chase a benchmark.
+    assert elapsed < 3.0, f"branch switch took {elapsed:.2f}s"
     store.close()

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -1,0 +1,50 @@
+import time
+
+import pytest
+
+from codegraph.indexer import GitTreeSource, Indexer
+from codegraph.query.impact import impact_report
+from codegraph.store import Store
+from tests.conftest import git
+
+
+@pytest.mark.slow
+def test_cold_index_and_warm_query_are_fast(tmp_path):
+    repo = tmp_path / "flask"
+    git(tmp_path, "clone", "-q", "--depth", "50", "https://github.com/pallets/flask", str(repo))
+
+    store = Store.open(repo)
+    indexer = Indexer(repo, store, GitTreeSource(repo))
+
+    started = time.perf_counter()
+    stats = indexer.reconcile("HEAD")
+    cold = time.perf_counter() - started
+    assert stats.paths_total > 50
+    assert cold < 60.0, f"cold index took {cold:.1f}s"
+
+    node = store.connection.execute(
+        "SELECT id FROM nodes WHERE rev='HEAD' AND kind='function' LIMIT 1"
+    ).fetchone()["id"]
+
+    started = time.perf_counter()
+    impact_report(store, "HEAD", node)
+    warm = time.perf_counter() - started
+    assert warm < 0.3, f"warm query took {warm * 1000:.0f}ms"
+    store.close()
+
+
+@pytest.mark.slow
+def test_branch_switch_is_under_a_second(tmp_path):
+    repo = tmp_path / "flask"
+    git(tmp_path, "clone", "-q", "--depth", "50", "https://github.com/pallets/flask", str(repo))
+    store = Store.open(repo)
+    indexer = Indexer(repo, store, GitTreeSource(repo))
+    indexer.reconcile("HEAD")
+    git(repo, "checkout", "-q", "-b", "probe")
+
+    started = time.perf_counter()
+    stats = indexer.reconcile("HEAD")
+    elapsed = time.perf_counter() - started
+    assert stats.blobs_parsed == 0
+    assert elapsed < 1.0, f"branch switch took {elapsed:.2f}s"
+    store.close()

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,46 @@
+import json
+
+from codegraph.render import Group, Report, Row, budget, render_json, render_text
+
+
+def sample():
+    return Report(
+        summary={"symbols": 47, "modules": 12, "entry_points": 9, "low_confidence_hidden": 31},
+        groups=[
+            Group("hop 1", [Row("a.py::one", "a.py:10", "HIGH", 9.0)]),
+            Group("tests", [Row("tests/test_a.py::test_one", "tests/test_a.py:3", "HIGH", 1.0)]),
+        ],
+        truncated=True,
+    )
+
+
+def test_budget_truncates_and_flags():
+    rows = [Row(f"m.py::f{i}", "m.py:1", "HIGH", float(i)) for i in range(10)]
+    kept, truncated = budget(rows, 4)
+    assert len(kept) == 4
+    assert truncated is True
+
+
+def test_budget_keeps_highest_scores_first():
+    rows = [Row(f"m.py::f{i}", "m.py:1", "HIGH", float(i)) for i in range(5)]
+    kept, _ = budget(rows, 2)
+    assert [r.score for r in kept] == [4.0, 3.0]
+
+
+def test_text_leads_with_summary():
+    text = render_text(sample())
+    first = text.splitlines()[0]
+    assert "47" in first and "12" in first
+
+
+def test_text_keeps_tests_in_their_own_group():
+    text = render_text(sample())
+    assert "tests" in text
+    assert text.index("hop 1") < text.index("tests")
+
+
+def test_json_is_machine_readable_and_flags_truncation():
+    payload = json.loads(render_json(sample()))
+    assert payload["truncated"] is True
+    assert payload["summary"]["symbols"] == 47
+    assert payload["groups"][0]["rows"][0]["id"] == "a.py::one"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -44,3 +44,31 @@ def test_json_is_machine_readable_and_flags_truncation():
     assert payload["truncated"] is True
     assert payload["summary"]["symbols"] == 47
     assert payload["groups"][0]["rows"][0]["id"] == "a.py::one"
+
+
+def test_text_summary_labels_every_field():
+    """B1 regression: the old text format joined `summary.values()` with no
+    keys, so every field was an unlabeled number -- `47 · 12 · 9 · 31` gives
+    no way to tell which count is which without reading the source."""
+    text = render_text(sample())
+    first = text.splitlines()[0]
+    assert first == "symbols: 47 · modules: 12 · entry_points: 9 · low_confidence_hidden: 31"
+
+
+def test_text_summary_formats_list_values_readably_not_as_python_repr():
+    """B1 regression: a list-valued field (`effects_reachable`) used to
+    render as Python's list repr (`['DB_WRITE', 'PROCESS']`, quotes and
+    brackets included) because it fell through to plain `str()`. It should
+    read as a comma-separated list, and an empty list should read as
+    'none', not a blank field after the colon."""
+    report = Report(
+        summary={"symbols": 2, "effects_reachable": ["DB_WRITE", "PROCESS"]},
+        groups=[],
+        truncated=False,
+    )
+    first = render_text(report).splitlines()[0]
+    assert first == "symbols: 2 · effects_reachable: DB_WRITE, PROCESS"
+    assert "[" not in first and "'" not in first
+
+    empty_report = Report(summary={"effects_reachable": []}, groups=[], truncated=False)
+    assert render_text(empty_report).splitlines()[0] == "effects_reachable: none"

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,6 +1,6 @@
 from codegraph.cli import main
 from codegraph.indexer import GitTreeSource, Indexer
-from codegraph.resolve import module_for_path
+from codegraph.resolve import module_for_path, split_by_ambiguity_limit
 from codegraph.store import Store
 
 
@@ -308,3 +308,155 @@ def test_status_reports_the_unresolved_count(repo, write, capsys):
     write("m.py", "import requests\n\n\ndef fetch():\n    requests.get('u')\n", commit="m")
     assert main(["status", "--path", str(repo), "--rev", "HEAD"]) == 0
     assert "unresolved: 1" in capsys.readouterr().out
+
+
+# -- the ambiguity cap -------------------------------------------------
+#
+# The last-resort step matches a call's final dotted segment against every live
+# definition in the revision. Measured on django (2,930 files) that produced 971
+# candidates for a single call site and 2.09M LOW edges -- 96.6% of the graph --
+# because the candidate list grows with the repo. See issue #6.
+
+
+def unresolved_rows(store, rev="HEAD"):
+    return [
+        dict(row)
+        for row in store.connection.execute(
+            "SELECT path, line, raw_name, ref_kind, reason, candidates FROM unresolved"
+            " WHERE rev=? ORDER BY path, line",
+            (rev,),
+        )
+    ]
+
+
+def many_savers(count):
+    """`count` classes that each define `save`, plus one caller that can only be
+    matched against all of them by name."""
+    classes = "\n\n".join(
+        f"class C{i}:\n    def save(self):\n        return {i}" for i in range(count)
+    )
+    return f"{classes}\n\n\ndef persist(item):\n    return item.save()\n"
+
+
+def test_ambiguity_under_the_limit_is_still_fully_enumerated(repo, write):
+    write("m.py", many_savers(3), commit="m")
+    write("codegraph.toml", "ambiguity_limit = 25\n", commit="cfg")
+    store, indexer = build(repo)
+    stats = indexer.reconcile("HEAD")
+    assert stats.ambiguous == 0
+    assert {dst for src, dst, _ in edges(store) if src == "m.py::persist"} == {
+        f"m.py::C{i}.save" for i in range(3)
+    }
+    store.close()
+
+
+def test_ambiguity_over_the_limit_is_recorded_once_instead_of_enumerated(repo, write):
+    write("m.py", many_savers(6), commit="m")
+    write("codegraph.toml", "ambiguity_limit = 4\n", commit="cfg")
+    store, indexer = build(repo)
+    stats = indexer.reconcile("HEAD")
+
+    # Not enumerated...
+    assert not [dst for src, dst, _ in edges(store) if src == "m.py::persist"]
+    # ...but not dropped either: the claim survives, with its size.
+    ambiguous = [row for row in unresolved_rows(store) if row["reason"] == "ambiguous"]
+    assert len(ambiguous) == 1
+    assert ambiguous[0]["raw_name"] == "item.save"
+    assert ambiguous[0]["ref_kind"] == "call"
+    assert ambiguous[0]["candidates"] == 6
+    assert stats.ambiguous == 1
+    store.close()
+
+
+def test_ambiguous_is_counted_separately_from_unknown(repo, write):
+    """They are opposite failures -- blind vs. dazzled -- and collapsing them
+    into one number makes the health signal unreadable."""
+    write("m.py", many_savers(6) + "\n\ndef gone():\n    no_such_name_anywhere()\n", commit="m")
+    write("codegraph.toml", "ambiguity_limit = 4\n", commit="cfg")
+    store, indexer = build(repo)
+    stats = indexer.reconcile("HEAD")
+    assert stats.ambiguous == 1
+    assert stats.unresolved >= 1
+    reasons = {row["reason"] for row in unresolved_rows(store)}
+    assert reasons == {"ambiguous", "unknown"}
+    store.close()
+
+
+def test_a_crowded_name_does_not_weaken_a_call_that_resolves_confidently(repo, write):
+    """`AstResolver` stops at the first step that matches, so a module-local
+    call never reaches the last-resort step at all -- the cap must not change
+    that just because the name is crowded elsewhere in the repo."""
+    write("crowd.py", many_savers(6), commit="crowd")
+    write(
+        "m.py",
+        "def save():\n    return 0\n\n\ndef caller():\n    return save()\n",
+        commit="m",
+    )
+    write("codegraph.toml", "ambiguity_limit = 2\n", commit="cfg")
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    # module-local, so HIGH -- it never reaches the last-resort step at all
+    assert ("m.py::caller", "m.py::save", "HIGH") in edges(store)
+    store.close()
+
+
+def test_ambiguous_base_class_is_capped_without_disturbing_the_mro(repo, write):
+    """Bases fan out exactly like calls (on django they were the larger half of
+    the blowup), but only HIGH links feed the MRO walk and the cap only ever
+    collapses LOW ones -- so inheritance resolution is unchanged."""
+    write("crowd.py", "\n\n".join(f"class Base{i}:\n    pass" for i in range(6)), commit="crowd")
+    write("dup.py", "\n\n".join(f"class C{i}:\n    class Base:\n        pass" for i in range(6)),
+          commit="dup")
+    write(
+        "child.py",
+        "from crowd import Base0\n\n\nclass Child(Base0):\n    pass\n",
+        commit="child",
+    )
+    write("codegraph.toml", "ambiguity_limit = 3\n", commit="cfg")
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    inherits = {
+        (row["src"], row["dst"], row["confidence"])
+        for row in store.connection.execute(
+            "SELECT src, dst, confidence FROM edges WHERE rev='HEAD' AND kind='INHERITS'"
+        )
+    }
+    # The import makes this one certain, so the cap cannot touch it.
+    assert ("child.py::Child", "crowd.py::Base0", "HIGH") in inherits
+    store.close()
+
+
+def test_ambiguity_limit_zero_disables_the_cap(repo, write):
+    write("m.py", many_savers(6), commit="m")
+    write("codegraph.toml", "ambiguity_limit = 0\n", commit="cfg")
+    store, indexer = build(repo)
+    stats = indexer.reconcile("HEAD")
+    assert stats.ambiguous == 0
+    assert len([dst for src, dst, _ in edges(store) if src == "m.py::persist"]) == 6
+    store.close()
+
+
+def test_split_by_ambiguity_limit_keeps_strong_candidates_alongside_a_collapsed_tail():
+    """`AstResolver` returns the first matching step's hits, so today a result is
+    either confident or entirely LOW and this mix cannot arise from it. The
+    `Resolver` protocol is a documented swap-in seam, though, and a smarter
+    engine can return both -- the cap must collapse only the part it cannot
+    distinguish, never the part it can."""
+    hits = [("a.py::x", "HIGH"), ("b.py::y", "MEDIUM")] + [
+        (f"c.py::z{i}", "LOW") for i in range(6)
+    ]
+    kept, collapsed = split_by_ambiguity_limit(hits, 4)
+    assert kept == [("a.py::x", "HIGH"), ("b.py::y", "MEDIUM")]
+    assert collapsed == 6
+
+
+def test_split_by_ambiguity_limit_counts_only_the_weak_candidates():
+    """A long list of candidates the resolver could actually tell apart is not
+    ambiguity, and must not be collapsed however long it is."""
+    hits = [(f"a.py::x{i}", "HIGH") for i in range(50)]
+    assert split_by_ambiguity_limit(hits, 4) == (hits, 0)
+
+
+def test_split_by_ambiguity_limit_leaves_a_list_at_exactly_the_limit_alone():
+    hits = [(f"a.py::x{i}", "LOW") for i in range(4)]
+    assert split_by_ambiguity_limit(hits, 4) == (hits, 0)

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -277,6 +277,33 @@ def test_resolve_command_exits_one_when_nothing_matches(repo, capsys):
     assert main(["resolve", "nope", "--path", str(repo), "--rev", "HEAD"]) == 1
 
 
+def test_resolve_is_case_consistent_not_disjoint_across_query_case(repo, write, capsys):
+    """B5 regression: steps 1-2 of `find_symbol` compared with binary `=`
+    while step 3's `LIKE` was already case-insensitive. A query differing
+    only in case from the real name could fall through the (missed) exact
+    steps and land on step 3's dot-anchored suffix pattern instead --
+    which can never match a top-level, dot-free qualname at all -- so
+    `resolve charge` (1 match, the top-level function, via the exact-match
+    step) and `resolve CHARGE` (2 disjoint matches, two unrelated nested
+    methods, via the suffix step) used to return completely different
+    result sets and flip exit code 0 -> 2."""
+    write(
+        "pay.py",
+        (
+            "def charge():\n    pass\n\n\n"
+            "class PaymentService:\n    def charge(self):\n        pass\n\n\n"
+            "class Refund:\n    def charge(self):\n        pass\n"
+        ),
+        commit="pay",
+    )
+    assert main(["resolve", "charge", "--path", str(repo), "--rev", "HEAD"]) == 0
+    lower = capsys.readouterr().out.strip()
+    assert main(["resolve", "CHARGE", "--path", str(repo), "--rev", "HEAD"]) == 0
+    upper = capsys.readouterr().out.strip()
+    assert lower == "pay.py::charge"
+    assert upper == lower
+
+
 def test_status_reports_the_unresolved_count(repo, write, capsys):
     write("m.py", "import requests\n\n\ndef fetch():\n    requests.get('u')\n", commit="m")
     assert main(["status", "--path", str(repo), "--rev", "HEAD"]) == 0

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -146,6 +146,65 @@ def test_external_call_is_unresolved_not_an_edge(repo, write):
     store.close()
 
 
+def test_super_call_resolves_weakly_by_name_not_dropped(repo, write):
+    """Regression for F2: `super().helper()`'s receiver (`super()`) isn't a
+    flattenable Name/Attribute chain, so `visit_Call` used to drop the ref
+    entirely -- no edge, no `unresolved` row. `helper` is unique in this
+    repo (unlike the overriding method's own name), so the existing
+    repo-wide by-last-segment step should now weakly resolve it at MEDIUM,
+    exactly as `test_unique_method_name_is_medium_confidence` does for
+    `thing.unique_op()`."""
+    write(
+        "base.py",
+        "class Base:\n    def helper(self):\n        pass\n",
+        commit="base",
+    )
+    write(
+        "child.py",
+        "from base import Base\n\n\n"
+        "class Child(Base):\n    def go(self):\n        super().helper()\n",
+        commit="child",
+    )
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    assert ("child.py::Child.go", "base.py::Base.helper", "MEDIUM") in edges(store)
+    store.close()
+
+
+def test_call_on_non_flattenable_receiver_with_no_match_is_unresolved_not_dropped(repo, write):
+    """`PaymentService().charge(x)` has no `charge` defined anywhere in the
+    repo, so it cannot resolve -- but it must still show up in `unresolved`
+    rather than vanishing without a trace."""
+    write(
+        "m.py",
+        "class PaymentService:\n    pass\n\n\n"
+        "def run():\n    PaymentService().charge(1)\n",
+        commit="m",
+    )
+    store, indexer = build(repo)
+    stats = indexer.reconcile("HEAD")
+    assert stats.unresolved >= 1
+    rows = store.connection.execute("SELECT raw_name FROM unresolved WHERE rev='HEAD'").fetchall()
+    assert "<attr>.charge" in {row["raw_name"] for row in rows}
+    store.close()
+
+
+def test_dynamic_call_with_no_attribute_is_unresolved_not_dropped(repo, write):
+    """`handlers[i]()` -- the callable isn't even an attribute access, so
+    there is no name to key on at all; it still must be counted."""
+    write(
+        "m.py",
+        "def dispatch(handlers, i):\n    handlers[i]()\n",
+        commit="m",
+    )
+    store, indexer = build(repo)
+    stats = indexer.reconcile("HEAD")
+    assert stats.unresolved >= 1
+    rows = store.connection.execute("SELECT raw_name FROM unresolved WHERE rev='HEAD'").fetchall()
+    assert "<dynamic>" in {row["raw_name"] for row in rows}
+    store.close()
+
+
 def test_editing_a_module_updates_edges_in_its_importers(repo, write):
     write("dep.py", "def target():\n    pass\n", commit="dep")
     write("user.py", "from dep import target\n\n\ndef go():\n    target()\n", commit="user")


### PR DESCRIPTION
Closes #6.

`AstResolver`'s last resort matches a call's final dotted segment against every
live definition in the revision and emits one LOW edge per candidate. On a small
repo that is a useful over-approximation. Measured on django (2,930 files) it is
not:

```
by confidence:                    call sites:    114,371
  LOW      2,093,012              call edges:  1,533,691
  MEDIUM      39,886              mean fan-out:     13.4
  HIGH        33,933

worst call site: 971 candidates  django/db/models/expressions.py:1251
```

96.6% of the graph was LOW noise, and the edge table grew with the **square** of
the repo — 120 edges/file on flask, 740 on django. "This call could be any of 971
methods named `resolve_expression`" is the question restated, not an answer to
it, and any `impact` query touching one of those nodes inherited the whole repo.

### The fix

Above `ambiguity_limit` (default 25; `0` disables) a reference is recorded **once**
in `unresolved` as ambiguous — with the name and the count it declined to
enumerate — instead of as N edges.

This does not violate the spec's over-approximation bias. The bias says a
candidate is never dropped *to improve precision*, and nothing here is dropped:
the N edges and the single record make exactly the same claim, stored in O(1)
rather than O(n). What is declined is enumerating it.

Only LOW candidates are ever collapsed. A HIGH or MEDIUM hit means the resolver
actually distinguished something, so it is always materialized — including
alongside a collapsed tail. Bases are capped too (on django they were the larger
half of the blowup) and the MRO is unaffected, since only HIGH links feed it.

`unresolved` gains `ref_kind` / `reason` / `candidates`, because "found nothing"
and "found too much" are opposite failures — blind vs. dazzled — and collapsing
them into one number makes the health signal unreadable. Schema 2 → 3.

### Measured after

| | edges | mean fan-out | resolve | 1-file reconcile |
|---|---|---|---|---|
| django before | 2,166,831 | 13.4 | 69.2s | 87.3s |
| django after | **428,151** | **3.9** | **7.7s** | **22.2s** |
| flask before | 9,976 | — | 0.11s | 0.28s |
| flask after | 9,032 | — | 0.11s | 0.36s |

flask barely moves, which is the point: the cap does nothing at small scale and
5x at large.

### Why nothing caught it

Every test repo in the suite is a handful of files, and the one slow test runs
against flask, where the fan-out is still only 13x. `tests/test_invariants.py`
now builds a repo big enough to see it and asserts the growth **rate** rather
than a size. Verified non-vacuous: with the cap disabled that test reports
`1640 -> 25760 edges for 4x the files (15.7x growth)` — essentially perfect
quadratic — and a single call site producing 60 edges.

231 passed, ruff clean.
