### PR TITLE
self.X resolves to overrides too, and diff stops diffing guesses

### DIFF
--- a/src/codegraph/query/diff.py
+++ b/src/codegraph/query/diff.py
@@ -75,8 +75,32 @@ def _nodes(store: Store, rev: str) -> dict[str, sqlite3.Row]:
 
 
 def _edges_by_src(store: Store, rev: str) -> dict[str, set[tuple[str, str]]]:
+    """Outgoing edges per symbol, EXCLUDING the low-confidence fan-out.
+
+    A symbol whose body hash is unchanged is still reported as `changed` when
+    its callees changed -- `foo()` now reaching a different `foo` is a real
+    change in behaviour even though not one character of this function moved.
+    That is worth catching, but only for edges the resolver was actually
+    confident about.
+
+    A LOW edge is not a statement about this symbol. It is a guess about the
+    whole repository: the bare-name fallback matches a call's last segment
+    against every definition there is, so the LOW set of an untouched function
+    moves whenever anyone anywhere adds or deletes a same-named symbol.
+    Comparing those guesses across two revisions manufactures change out of
+    edits that never came near the file.
+
+    Measured on `psf/requests` before this filter: one new `AttrProxy.__init__`
+    in a test file added a candidate to every `super().__init__()` call site in
+    the repository, and `diff` reported `HTTPAdapter.__init__`,
+    `BaseAdapter.__init__`, `LookupDict.__init__`, `JSONDecodeError.__init__`
+    and others as `changed` -- in files whose git blob SHA was byte-identical
+    across the range. 7 of 20 `changed` rows, 35% of the list. See issue #13.
+    """
     edges: dict[str, set[tuple[str, str]]] = {}
-    for row in store.connection.execute("SELECT src, dst, kind FROM edges WHERE rev=?", (rev,)):
+    for row in store.connection.execute(
+        "SELECT src, dst, kind FROM edges WHERE rev=? AND confidence != 'LOW'", (rev,)
+    ):
         edges.setdefault(row["src"], set()).add((row["dst"], row["kind"]))
     return edges
 

--- a/src/codegraph/resolve.py
+++ b/src/codegraph/resolve.py
@@ -113,6 +113,10 @@ class ResolveContext:
     bases: dict[str, list[str]]  # class node id -> base class node ids
     enclosing_class: dict[str, str] = field(default_factory=dict)  # node id -> class node id
     subclasses: dict[str, list[str]] = field(default_factory=dict)  # inverse of `bases`
+    #: Memo for `_descendants`, shared across every file of the revision. The
+    #: hierarchy is fixed once inheritance has been resolved, but the walk runs
+    #: per `self.X` reference -- on django that cost 3.5s of a 11.2s resolve.
+    descendant_cache: dict[str, list[str]] = field(default_factory=dict)
 
 
 class Resolver(Protocol):
@@ -242,7 +246,11 @@ class AstResolver:
     @classmethod
     def _descendants(cls, start: str, ctx: ResolveContext) -> list[str]:
         """Every known subclass of `start`, transitively (excluding `start`)."""
-        return cls._walk(start, ctx.subclasses)[1:]
+        cached = ctx.descendant_cache.get(start)
+        if cached is None:
+            cached = cls._walk(start, ctx.subclasses)[1:]
+            ctx.descendant_cache[start] = cached
+        return cached
 
     # -- steps 4 and 5: a repo-wide match on the last segment -------------
     def _by_last_segment(self, ref: ParsedRef, ctx: ResolveContext) -> list[tuple[str, str]]:
@@ -363,6 +371,7 @@ class _SymbolTable:
         path: str,
         bases: dict[str, list[str]],
         subclasses: dict[str, list[str]] | None = None,
+        descendant_cache: dict[str, list[str]] | None = None,
     ) -> ResolveContext:
         return ResolveContext(
             rev=rev,
@@ -375,6 +384,7 @@ class _SymbolTable:
             bases=bases,
             enclosing_class=self.enclosing_class,
             subclasses=subclasses if subclasses is not None else {},
+            descendant_cache=descendant_cache if descendant_cache is not None else {},
         )
 
 
@@ -536,9 +546,13 @@ def resolve_revision(
         for base in base_ids:
             subclasses.setdefault(base, []).append(subclass)
 
+    # One cache object shared by every file's context, so the descendant walk
+    # runs once per class for the whole revision rather than once per reference.
+    descendant_cache: dict[str, list[str]] = {}
+
     call_refs = _refs_by_path(store, rev, "call")
     for path in table.paths:
-        ctx = table.context(rev, path, bases, subclasses)
+        ctx = table.context(rev, path, bases, subclasses, descendant_cache)
         for ref in call_refs.get(path, ()):
             src = _source_id(ref, table, path)
             hits = resolver.resolve_call(ref, ctx)

--- a/src/codegraph/resolve.py
+++ b/src/codegraph/resolve.py
@@ -112,6 +112,7 @@ class ResolveContext:
     import_map: dict[str, str]  # local alias -> dotted target
     bases: dict[str, list[str]]  # class node id -> base class node ids
     enclosing_class: dict[str, str] = field(default_factory=dict)  # node id -> class node id
+    subclasses: dict[str, list[str]] = field(default_factory=dict)  # inverse of `bases`
 
 
 class Resolver(Protocol):
@@ -165,8 +166,31 @@ class AstResolver:
         node_id = ctx.qualname_index.get((ctx.path, ref.raw_name))
         return [(node_id, HIGH)] if node_id else []
 
-    # -- step 3: self.X through the class and its bases -------------------
+    # -- step 3: self.X through the class, its bases, and its overrides ----
     def _through_self(self, ref: ParsedRef, ctx: ResolveContext) -> list[tuple[str, str]]:
+        """`self.X` resolves to the method the enclosing class inherits, PLUS
+        every override of it in a subclass.
+
+        Walking only up the MRO and stopping at the first hit is wrong, and
+        wrong in the direction that hurts most. `self` is an instance of the
+        enclosing class *or of any subclass of it*, so an override is a real
+        runtime candidate, and dropping it is the over-approximation bias
+        pointing backwards.
+
+        The damage is worst when the base declaration is an abstract stub. In
+        `requests`, `SessionRedirectMixin.send` has a `...` body and
+        `Session(SessionRedirectMixin)` supplies the real one; first-match-wins
+        bound `self.send()` inside `resolve_redirects` to the stub at HIGH
+        confidence, so `impact Session.send` -- the single most important edge
+        in the library, the one that drives every redirect hop -- reported
+        nothing. See issue #14.
+
+        The inherited match keeps HIGH: it is the declaration this class
+        actually resolves to by name. Overrides are MEDIUM, because which one
+        runs depends on the instance, and that is genuinely less certain than
+        a name lookup -- not LOW, which is the tier for a repo-wide guess with
+        no hierarchy behind it.
+        """
         head, _, attribute = ref.raw_name.partition(".")
         if head != "self" or not attribute or "." in attribute:
             return []
@@ -174,25 +198,51 @@ class AstResolver:
         start = ctx.enclosing_class.get(owner) if owner else None
         if start is None:
             return []
+
+        hits: list[tuple[str, str]] = []
         for class_id in self._mro(start, ctx):
-            class_path, _, class_qualname = class_id.partition("::")
-            node_id = ctx.qualname_index.get((class_path, f"{class_qualname}.{attribute}"))
+            node_id = self._method_on(class_id, attribute, ctx)
             if node_id:
-                return [(node_id, HIGH)]
-        return []
+                hits.append((node_id, HIGH))
+                break
+        if not hits:
+            return []
+
+        seen = {hits[0][0]}
+        for class_id in self._descendants(start, ctx):
+            node_id = self._method_on(class_id, attribute, ctx)
+            if node_id and node_id not in seen:
+                seen.add(node_id)
+                hits.append((node_id, MEDIUM))
+        return hits
 
     @staticmethod
-    def _mro(start: str, ctx: ResolveContext) -> list[str]:
-        """Breadth-first walk of the class and its known bases, cycle-safe."""
+    def _method_on(class_id: str, attribute: str, ctx: ResolveContext) -> str | None:
+        class_path, _, class_qualname = class_id.partition("::")
+        return ctx.qualname_index.get((class_path, f"{class_qualname}.{attribute}"))
+
+    @staticmethod
+    def _walk(start: str, adjacency: dict[str, list[str]]) -> list[str]:
+        """Breadth-first walk from `start` over `adjacency`, cycle-safe."""
         order, seen, queue = [], {start}, [start]
         while queue:
             current = queue.pop(0)
             order.append(current)
-            for base in ctx.bases.get(current, ()):
-                if base not in seen:
-                    seen.add(base)
-                    queue.append(base)
+            for nxt in adjacency.get(current, ()):
+                if nxt not in seen:
+                    seen.add(nxt)
+                    queue.append(nxt)
         return order
+
+    @classmethod
+    def _mro(cls, start: str, ctx: ResolveContext) -> list[str]:
+        """The class and its known bases, nearest first."""
+        return cls._walk(start, ctx.bases)
+
+    @classmethod
+    def _descendants(cls, start: str, ctx: ResolveContext) -> list[str]:
+        """Every known subclass of `start`, transitively (excluding `start`)."""
+        return cls._walk(start, ctx.subclasses)[1:]
 
     # -- steps 4 and 5: a repo-wide match on the last segment -------------
     def _by_last_segment(self, ref: ParsedRef, ctx: ResolveContext) -> list[tuple[str, str]]:
@@ -307,7 +357,13 @@ class _SymbolTable:
 
         self.import_maps, self.imported_modules = build_import_maps(connection, rev, config)
 
-    def context(self, rev: str, path: str, bases: dict[str, list[str]]) -> ResolveContext:
+    def context(
+        self,
+        rev: str,
+        path: str,
+        bases: dict[str, list[str]],
+        subclasses: dict[str, list[str]] | None = None,
+    ) -> ResolveContext:
         return ResolveContext(
             rev=rev,
             path=path,
@@ -318,6 +374,7 @@ class _SymbolTable:
             import_map=self.import_maps[path],
             bases=bases,
             enclosing_class=self.enclosing_class,
+            subclasses=subclasses if subclasses is not None else {},
         )
 
 
@@ -472,9 +529,16 @@ def resolve_revision(
                     (rev, path, ref.line, ref.raw_name, "base", "ambiguous", ambiguous_count)
                 )
 
+    # The hierarchy is complete now, so it can be inverted once: `self.X`
+    # needs to see downwards (overrides in subclasses) as well as upwards.
+    subclasses: dict[str, list[str]] = {}
+    for subclass, base_ids in bases.items():
+        for base in base_ids:
+            subclasses.setdefault(base, []).append(subclass)
+
     call_refs = _refs_by_path(store, rev, "call")
     for path in table.paths:
-        ctx = table.context(rev, path, bases)
+        ctx = table.context(rev, path, bases, subclasses)
         for ref in call_refs.get(path, ()):
             src = _source_id(ref, table, path)
             hits = resolver.resolve_call(ref, ctx)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -143,3 +143,70 @@ def test_module_level_effect_addition_is_changed_and_new_effect(repo, write):
     assert "m.py::<module>" in rows(report, "changed")
     assert "NETWORK" in str(report.summary)
     store.close()
+
+
+# -- the LOW fan-out must not read as a change ------------------------------
+#
+# `changed` also fires when a symbol's outgoing edges move, so that `foo()` now
+# reaching a different `foo` counts even when the body is untouched. LOW edges
+# broke that: they are a guess about the whole repo, so an untouched function's
+# LOW set moves whenever anyone adds a same-named symbol anywhere. On
+# `psf/requests` one new `AttrProxy.__init__` in a test marked every
+# `super().__init__()` caller changed -- 7 of 20 rows, in files whose git blob
+# was byte-identical across the range. See #13.
+
+
+def test_an_unrelated_same_named_symbol_does_not_mark_a_file_changed(repo, write):
+    write(
+        "stable.py",
+        "class Thing:\n"
+        "    def __init__(self):\n"
+        "        super().__init__()\n"
+        "        self.x = 1\n",
+        commit="stable",
+    )
+    write("other.py", "class One:\n    def __init__(self):\n        pass\n", commit="other")
+    store, indexer = build(repo)
+    base = git(repo, "rev-parse", "HEAD").strip()
+
+    # A brand-new class in a DIFFERENT file. `stable.py` is not touched.
+    write(
+        "other.py",
+        "class One:\n"
+        "    def __init__(self):\n"
+        "        pass\n"
+        "\n\n"
+        "class Two:\n"
+        "    def __init__(self):\n"
+        "        pass\n",
+        commit="add Two",
+    )
+    assert git(repo, "rev-parse", f"{base}:stable.py") == git(repo, "rev-parse", "HEAD:stable.py")
+
+    report = diff_report(store, indexer, base, "HEAD")
+    changed = rows(report, "changed")
+    assert not [node_id for node_id in changed if node_id.startswith("stable.py")], (
+        f"stable.py is byte-identical across the range but was reported changed: {changed}"
+    )
+    assert "other.py::Two.__init__" in rows(report, "added")
+    store.close()
+
+
+def test_a_confident_callee_disappearing_still_reads_as_changed(repo, write):
+    """Non-vacuity guard for the filter above: the edge-set comparison must
+    still fire for edges the resolver was confident about, or it has just been
+    switched off. `caller`'s body is identical in both revisions -- only what
+    `helper()` resolves to changed."""
+    write(
+        "m.py",
+        "def helper():\n    return 1\n\n\ndef caller():\n    return helper()\n",
+        commit="m",
+    )
+    store, indexer = build(repo)
+    base = git(repo, "rev-parse", "HEAD").strip()
+    write("m.py", "def caller():\n    return helper()\n", commit="drop helper")
+
+    report = diff_report(store, indexer, base, "HEAD")
+    assert "m.py::caller" in rows(report, "changed")
+    assert "m.py::helper" in rows(report, "removed")
+    store.close()

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,5 +1,6 @@
 from codegraph.cli import main
 from codegraph.indexer import GitTreeSource, Indexer
+from codegraph.query.impact import impact_report
 from codegraph.resolve import module_for_path, split_by_ambiguity_limit
 from codegraph.store import Store
 
@@ -460,3 +461,147 @@ def test_split_by_ambiguity_limit_counts_only_the_weak_candidates():
 def test_split_by_ambiguity_limit_leaves_a_list_at_exactly_the_limit_alone():
     hits = [(f"a.py::x{i}", "LOW") for i in range(4)]
     assert split_by_ambiguity_limit(hits, 4) == (hits, 0)
+
+
+# -- self.X finds overrides, not just the inherited declaration -------------
+#
+# Walking only UP the MRO and stopping at the first hit drops every subclass
+# override, and `self` is an instance of the enclosing class or any subclass of
+# it. Worst case measured on `psf/requests`: `SessionRedirectMixin.send` is a
+# `...` stub that `Session` overrides, so `self.send()` inside
+# `resolve_redirects` bound to the stub at HIGH and `impact Session.send` found
+# nothing -- the edge that drives every redirect hop. See #14.
+
+
+def test_self_call_finds_the_subclass_override_as_well_as_the_base(repo, write):
+    write(
+        "shapes.py",
+        "class Shape:\n"
+        "    def area(self):\n"
+        "        return 0\n"
+        "\n"
+        "    def describe(self):\n"
+        "        return self.area()\n"
+        "\n\n"
+        "class Square(Shape):\n"
+        "    def area(self):\n"
+        "        return 4\n",
+        commit="shapes",
+    )
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    found = {(dst, conf) for src, dst, conf in edges(store) if src == "shapes.py::Shape.describe"}
+    assert ("shapes.py::Shape.area", "HIGH") in found
+    assert ("shapes.py::Square.area", "MEDIUM") in found
+    store.close()
+
+
+def test_a_stub_base_does_not_hide_the_real_implementation(repo, write):
+    """The requests shape, minimised: the base declares the method with an
+    empty body and a subclass supplies the real one. First-match-wins bound
+    `self.send()` to the stub and stopped, making the real implementation
+    unreachable from `impact`."""
+    write(
+        "svc.py",
+        "class Mixin:\n"
+        "    def send(self):\n"
+        "        ...\n"
+        "\n"
+        "    def retry(self):\n"
+        "        return self.send()\n"
+        "\n\n"
+        "class Real(Mixin):\n"
+        "    def send(self):\n"
+        "        return 'sent'\n",
+        commit="svc",
+    )
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    targets = {dst for src, dst, _ in edges(store) if src == "svc.py::Mixin.retry"}
+    assert "svc.py::Real.send" in targets, (
+        "the real implementation must be reachable, not just the stub"
+    )
+
+    report = impact_report(store, "HEAD", "svc.py::Real.send")
+    assert "svc.py::Mixin.retry" in {row.id for group in report.groups for row in group.rows}
+    store.close()
+
+
+def test_an_override_further_down_a_chain_is_still_found(repo, write):
+    write(
+        "chain.py",
+        "class A:\n"
+        "    def run(self):\n"
+        "        return 0\n"
+        "\n"
+        "    def go(self):\n"
+        "        return self.run()\n"
+        "\n\n"
+        "class B(A):\n"
+        "    pass\n"
+        "\n\n"
+        "class C(B):\n"
+        "    def run(self):\n"
+        "        return 1\n",
+        commit="chain",
+    )
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    targets = {dst for src, dst, _ in edges(store) if src == "chain.py::A.go"}
+    assert targets == {"chain.py::A.run", "chain.py::C.run"}
+    store.close()
+
+
+def test_an_unrelated_class_with_the_same_method_name_is_not_pulled_in(repo, write):
+    """The override walk follows the class hierarchy, not the name. A class
+    that merely shares a method name must not become a HIGH/MEDIUM candidate --
+    that is the LOW fallback's job, at LOW."""
+    write(
+        "sep.py",
+        "class Base:\n"
+        "    def act(self):\n"
+        "        return 0\n"
+        "\n"
+        "    def trigger(self):\n"
+        "        return self.act()\n"
+        "\n\n"
+        "class Child(Base):\n"
+        "    def act(self):\n"
+        "        return 1\n"
+        "\n\n"
+        "class Stranger:\n"
+        "    def act(self):\n"
+        "        return 2\n",
+        commit="sep",
+    )
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    targets = {dst for src, dst, _ in edges(store) if src == "sep.py::Base.trigger"}
+    assert targets == {"sep.py::Base.act", "sep.py::Child.act"}
+    assert "sep.py::Stranger.act" not in targets
+    store.close()
+
+
+def test_an_inheritance_cycle_does_not_hang_the_override_walk(repo, write):
+    """`class A(B)` / `class B(A)` is not valid Python at runtime, but it is
+    parseable, and the resolver reads text -- the downward walk has to be as
+    cycle-safe as the MRO walk above it."""
+    write(
+        "cyc.py",
+        "class A(B):\n"
+        "    def run(self):\n"
+        "        return 0\n"
+        "\n"
+        "    def go(self):\n"
+        "        return self.run()\n"
+        "\n\n"
+        "class B(A):\n"
+        "    def run(self):\n"
+        "        return 1\n",
+        commit="cyc",
+    )
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")  # must terminate
+    targets = {dst for src, dst, _ in edges(store) if src == "cyc.py::A.go"}
+    assert "cyc.py::A.run" in targets
+    store.close()


### PR DESCRIPTION
Closes #14 and #13 — both found by an adversarial trial of the tool against `psf/requests`.

## #14 — `self.X` dropped every subclass override

`_through_self` walked up the MRO and returned the first hit. But `self` is an
instance of the enclosing class **or any subclass of it**, so an override is a real
runtime candidate — dropping it is the over-approximation bias pointing backwards.

Worst when the base declaration is a stub:

```python
class SessionRedirectMixin:
    def send(self): ...              # <- bound here, at HIGH
    def resolve_redirects(self):
        resp = self.send(...)

class Session(SessionRedirectMixin):
    def send(self): ...              # <- the real one, unreachable
```

`impact Session.send` reported nothing for the edge that drives every redirect hop in
requests. It now reports `resolve_redirects` at hop 1.

The inherited match keeps **HIGH** — it is the declaration this class resolves to by
name. Overrides are **MEDIUM**, because which one runs depends on the instance, and
that is genuinely less certain than a name lookup but far more than a repo-wide guess.
The downward walk follows the class hierarchy, not the name, so an unrelated class that
merely shares a method name stays the LOW fallback's problem.

Accuracy harness: **recall 0.90 → 1.00**, precision unchanged at 1.00. The 0.10 was the
`Square.area` case the fixture already documented as a known miss. flask gains 18 edges,
so this is not a new fan-out.

## #13 — `diff` was diffing guesses

`diff` marks a symbol changed when its outgoing edge set moves, so `foo()` now reaching
a different `foo` counts even with the body untouched. Worth catching — but it compared
LOW edges too, and a LOW edge is a guess about the whole repository, not a statement
about the symbol.

One new `AttrProxy.__init__` in a requests test added a candidate to **every**
`super().__init__()` call site in the repo:

```
$ git rev-parse 3816cfa:src/requests/adapters.py 84d10f0:src/requests/adapters.py
40fe8a6d5a6168ba7303b91477af925db0aa3914
40fe8a6d5a6168ba7303b91477af925db0aa3914     # byte-identical
```

...yet `HTTPAdapter.__init__`, `BaseAdapter.__init__`, `LookupDict.__init__`,
`JSONDecodeError.__init__` and others were all reported `changed`. 7 of 20 rows.

Restricting the comparison to HIGH/MEDIUM takes that range from **20 changed rows to
13**, every one in a file `git diff --name-only` agrees changed.

## Tests

Both regression tests verified non-vacuous against the unfixed code — the diff one
reports `stable.py::Thing.__init__` changed for a file it never touched, and the
accuracy floor falls back to 0.90.

The diff filter carries its own non-vacuity guard: a confident callee disappearing must
*still* read as changed, or the check has merely been switched off rather than fixed.
Override tests cover the stub case, a two-level chain, an unrelated same-named class
that must NOT be pulled in, and an inheritance cycle (invalid at runtime, parseable, and
the resolver reads text — so the downward walk has to be as cycle-safe as the MRO walk).

238 passed, slow suite green, ruff clean.
