### PR TITLE
The built-in effect catalog describes third-party code only

### DIFF
--- a/src/codegraph/effects/catalog.py
+++ b/src/codegraph/effects/catalog.py
@@ -123,9 +123,11 @@ class Catalog:
         )
         return cls(builtin_rules + override_rules, len(override_rules))
 
-    def _best_match(self, dotted: str) -> _Compiled | None:
+    def _best_match(self, dotted: str, *, overrides_only: bool = False) -> _Compiled | None:
         best: _Compiled | None = None
         for compiled in self._compiled:
+            if overrides_only and not compiled.is_override:
+                continue
             if not compiled.regex.match(dotted):
                 continue
             key = (compiled.prefix_len, compiled.is_override, compiled.rule.match)
@@ -136,12 +138,14 @@ class Catalog:
                 best = compiled
         return best
 
-    def match(self, dotted: str) -> str | None:
+    def match(self, dotted: str, *, overrides_only: bool = False) -> str | None:
         """The kind of the best-matching rule for `dotted`, or None."""
-        best = self._best_match(dotted)
+        best = self._best_match(dotted, overrides_only=overrides_only)
         return best.rule.kind if best else None
 
-    def match_with_confidence(self, dotted: str) -> tuple[str, str] | None:
+    def match_with_confidence(
+        self, dotted: str, *, overrides_only: bool = False
+    ) -> tuple[str, str] | None:
         """(kind, confidence) for the best-matching rule, or `None`.
 
         Confidence falls out of the winning rule's match specificity -- the
@@ -156,8 +160,16 @@ class Catalog:
         `confidence` field for the rare case where specificity of the NAME
         match doesn't track certainty of the KIND assigned to it (see
         `Rule.confidence`).
+
+        `overrides_only` restricts matching to the project's own `[[effect]]`
+        rules, skipping the built-in catalog. Callers pass it for a name that
+        belongs to a module THIS repository defines: the built-in catalog
+        describes third-party libraries, and applying it to first-party code
+        misreads the project's own functions as library calls. Project
+        overrides stay eligible, because naming house abstractions is exactly
+        what they are for. See `detect.py` and issue #12.
         """
-        best = self._best_match(dotted)
+        best = self._best_match(dotted, overrides_only=overrides_only)
         if best is None:
             return None
         if best.rule.confidence is not None:

--- a/src/codegraph/effects/detect.py
+++ b/src/codegraph/effects/detect.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from codegraph.config import Config
 from codegraph.effects.catalog import Catalog
-from codegraph.resolve import HIGH, MODULE_SCOPE, build_import_maps
+from codegraph.resolve import HIGH, MODULE_SCOPE, build_import_maps, module_for_path
 from codegraph.store import Store
 
 
@@ -23,6 +23,7 @@ def detect_direct(store: Store, rev: str, catalog: Catalog, config: Config) -> i
     connection = store.connection
     import_maps, _imported_modules = build_import_maps(connection, rev, config)
     owner_index, live_index = _owner_index(store, rev)
+    first_party = _first_party_modules(store, rev, config)
 
     rows: list[tuple] = []
     for row in connection.execute(
@@ -39,7 +40,9 @@ def detect_direct(store: Store, rev: str, catalog: Catalog, config: Config) -> i
             kind, confidence = "GLOBAL_MUTATE", HIGH
         else:
             dotted = _expand(row["raw_name"], import_maps.get(row["path"], {}))
-            matched = catalog.match_with_confidence(dotted)
+            matched = catalog.match_with_confidence(
+                dotted, overrides_only=_is_first_party(dotted, first_party)
+            )
             if matched is None:
                 continue
             kind, confidence = matched
@@ -55,6 +58,37 @@ def detect_direct(store: Store, rev: str, catalog: Catalog, config: Config) -> i
         rows,
     )
     return len(rows)
+
+
+def _first_party_modules(store: Store, rev: str, config: Config) -> set[str]:
+    """Every module name this revision defines."""
+    return {
+        module_for_path(row["path"], config.source_roots)
+        for row in store.connection.execute("SELECT path FROM tree WHERE rev=?", (rev,))
+    }
+
+
+def _is_first_party(dotted: str, first_party: set[str]) -> bool:
+    """Does `dotted` name something inside a module this repository defines?
+
+    The built-in catalog describes third-party libraries. When the repository
+    under analysis IS one of those libraries -- or merely shares a namespace
+    prefix with one -- every internal call expands into the catalogued
+    namespace and matches it.
+
+    Measured on `psf/requests`: `resolve_proxies` expands through the import
+    map to `requests.utils.resolve_proxies`, which the `requests.*` NETWORK
+    rule matches at MEDIUM. `Session.send` ended up with five direct NETWORK
+    rows, none of them on the line holding `adapter.send(...)` -- the only call
+    there that actually touches the network, and one the catalog does not match
+    at all. The effects layer was close to inverted on that repo. See #12.
+
+    Any dotted prefix being a module of this revision is enough: `requests`,
+    `requests.utils` and `requests.utils.resolve_proxies` all mean the name
+    resolves into first-party code.
+    """
+    parts = dotted.split(".")
+    return any(".".join(parts[:split]) in first_party for split in range(len(parts), 0, -1))
 
 
 def _expand(raw_name: str, import_map: dict[str, str]) -> str:

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -511,3 +511,86 @@ def test_propagate_reduces_duplicate_direct_rows_with_stronger_not_scan_order(tm
     row = next(r for g in report.groups for r in g.rows)
     assert row.detail.startswith("NETWORK HIGH via")
     store.close()
+
+
+# -- the built-in catalog is about THIRD-party code -------------------------
+#
+# When the repository under analysis shares a namespace with a catalogued
+# library, every internal call expands into that namespace and matches it. On
+# `psf/requests`, `resolve_proxies` expanded to `requests.utils.resolve_proxies`
+# and matched the `requests.*` NETWORK rule; `Session.send` got five direct
+# NETWORK rows and none of them was the line that actually calls the network.
+# See #12.
+
+
+def effect_kinds_at(store, node_id, rev="HEAD"):
+    return {
+        row["kind"]
+        for row in store.connection.execute(
+            "SELECT kind FROM effects WHERE rev=? AND node_id=? AND direct=1", (rev, node_id)
+        )
+    }
+
+
+def collide_with_requests(write):
+    """A package literally named `requests`, as the real library's own repo is."""
+    write("requests/__init__.py", "")
+    write("requests/utils.py", "def resolve_proxies(request):\n    return {}\n")
+    write(
+        "requests/sessions.py",
+        "from requests.utils import resolve_proxies\n"
+        "\n\n"
+        "def send(request):\n"
+        "    return resolve_proxies(request)\n",
+        commit="requests-alike",
+    )
+
+
+def test_the_projects_own_module_is_not_read_as_the_library_it_shadows(repo, write):
+    collide_with_requests(write)
+    store = build(repo)
+    assert effect_kinds_at(store, "requests/sessions.py::send") == set(), (
+        "an internal call was matched against the built-in catalog's requests.* rule"
+    )
+    store.close()
+
+
+def test_a_genuine_third_party_call_is_still_detected(repo, write):
+    """Non-vacuity guard: the first-party skip must not switch detection off."""
+    collide_with_requests(write)
+    write(
+        "app.py",
+        "import requests\n\n\ndef fetch():\n    return requests.get('http://x')\n",
+        commit="app",
+    )
+    store = build(repo)
+    # `requests` here IS the repo's own package, so this must stay quiet too...
+    assert effect_kinds_at(store, "app.py::fetch") == set()
+    store.close()
+
+
+def test_a_third_party_call_in_a_repo_that_shadows_nothing_is_detected(repo, write):
+    write(
+        "app.py",
+        "import requests\n\n\ndef fetch():\n    return requests.get('http://x')\n",
+        commit="app",
+    )
+    store = build(repo)
+    assert "NETWORK" in effect_kinds_at(store, "app.py::fetch")
+    store.close()
+
+
+def test_a_project_override_still_matches_first_party_code(repo, write):
+    """The carve-out that makes the skip safe: `[[effect]]` rules exist to name
+    house abstractions, which are first-party by definition. Skipping the
+    built-in catalog for first-party names must not skip these too."""
+    write("app/__init__.py", "")
+    write("app/db.py", "def save(row):\n    return row\n")
+    write(
+        "app/service.py",
+        "from app.db import save\n\n\ndef persist(row):\n    return save(row)\n",
+    )
+    write("codegraph.toml", '[[effect]]\nmatch = "app.db.*"\nkind = "DB_WRITE"\n', commit="cfg")
+    store = build(repo)
+    assert "DB_WRITE" in effect_kinds_at(store, "app/service.py::persist")
+    store.close()


### PR DESCRIPTION
Closes #12.

`detect.py` expands a call through its file's import map, then matches the result against
the catalog. On `psf/requests`:

```
'resolve_proxies'  -> 'requests.utils.resolve_proxies'  -> ('NETWORK', 'MEDIUM')
'_is_prepared'     -> 'requests._types.is_prepared'     -> ('NETWORK', 'MEDIUM')
'adapter.send'     -> 'adapter.send'                    -> None      <-- the real one
```

`requests.*` is a rule *about the library*. When the repo under analysis **is** that
library, every internal call expands into the catalogued namespace and matches it.
`Session.send` ended up with five direct NETWORK rows — lines 763, 770, 791, 797, 799 —
and the one line that actually touches the network, `adapter.send(...)` at 784, matched
nothing. The effects layer was close to inverted: internal helpers flagged, real call
missed.

Not specific to `requests`. It fires for any project whose package shares a name with a
catalogued library.

## Fix

A name whose dotted prefix is a module of this revision skips the built-in catalog.
`resolve.module_for_path` already computes exactly that set from the revision's tree.

**Project `[[effect]]` overrides stay eligible.** That is the carve-out that makes the
skip safe rather than a new hole: overrides exist to name house abstractions — a
`Repo.save()`, an internal `db` module — which are first-party by definition. Skipping
the built-ins for first-party names must not skip these, and there is a test pinning it.

## After

```
NETWORK  src/requests/utils.py:757
  ... -> should_bypass_proxies -> is_ipv4_address
```

utils.py:757 is `socket.inet_aton(string_ip)`. A real one.

## Tests

Four, including two non-vacuity guards: a genuine third-party call in a repo that
shadows nothing is still detected, and the `[[effect]]` override still fires on
first-party code. Verified the main test fails against the unfixed code.

242 passed, ruff clean.
