### PR TITLE
Python builtins are not repo symbols

### DIFF
--- a/src/codegraph/resolve.py
+++ b/src/codegraph/resolve.py
@@ -16,6 +16,7 @@ improve precision, only recorded at a lower confidence.
 
 from __future__ import annotations
 
+import builtins
 import sqlite3
 from dataclasses import dataclass, field
 from typing import Protocol
@@ -49,6 +50,31 @@ def weaker(a: str, b: str) -> str:
 
 
 PROVENANCE = "static"
+
+#: Python builtins, as the names they are actually called by.
+#:
+#: These matter because the last-resort step matches a call's final dotted
+#: segment against every definition in the repository, and plenty of builtins
+#: share a name with a plausible method: `set`, `list`, `next`, `id`, `type`,
+#: `format`, `hash`, `filter`, `map`, `open`, `sum`, `iter`, `compile`, `vars`.
+#: On `psf/requests` that turned `badargs = set(kwargs) - set(result)` inside
+#: `create_cookie` into an edge to `RequestsCookieJar.set`, which then carried
+#: an effect into a witness path presented as clickable evidence. See #17.
+BUILTIN_NAMES: frozenset[str] = frozenset(dir(builtins))
+
+
+def is_builtin_call(ref: ParsedRef) -> bool:
+    """Is this reference a call to a Python builtin rather than a repo symbol?
+
+    Only a BARE name can be: `x.set(...)` is a method call on something, and
+    must keep falling through to the name match. A bare name is safe to claim
+    here because the steps before this one have already ruled out every way a
+    repo symbol could legitimately shadow the builtin -- a module-local
+    `def set(...)` is caught at step 2 and an imported one at step 1, both at
+    HIGH. So a bare builtin name arriving at the last-resort step is the
+    builtin.
+    """
+    return not ref.dotted and ref.raw_name in BUILTIN_NAMES
 
 #: `src` for a reference made at module scope, which owns no node of its own.
 MODULE_SCOPE = "<module>"
@@ -254,6 +280,8 @@ class AstResolver:
 
     # -- steps 4 and 5: a repo-wide match on the last segment -------------
     def _by_last_segment(self, ref: ParsedRef, ctx: ResolveContext) -> list[tuple[str, str]]:
+        if is_builtin_call(ref):
+            return []
         candidates = ctx.name_index.get(ref.raw_name.rpartition(".")[2], ())
         if len(candidates) == 1:
             return [(candidates[0], MEDIUM)]
@@ -509,6 +537,7 @@ def resolve_revision(
     edge_rows: list[tuple] = []
     unresolved_rows: list[tuple] = []
     ambiguous_rows: list[tuple] = []
+    builtin_rows: list[tuple] = []
 
     # Inheritance first: `self.X` walks the class hierarchy, so the hierarchy
     # has to exist before any call is resolved.
@@ -565,6 +594,13 @@ def resolve_revision(
                 ambiguous_rows.append(
                     (rev, path, ref.line, ref.raw_name, "call", "ambiguous", ambiguous_count)
                 )
+            elif is_builtin_call(ref):
+                # Recorded, but not as a gap. A builtin is a reference the
+                # resolver understood and deliberately did not link to a repo
+                # symbol -- counting it as "unresolved" buries the real gaps
+                # under a large constant. Still written, so the choice is
+                # visible rather than silent.
+                builtin_rows.append((rev, path, ref.line, ref.raw_name, "call", "builtin", 0))
             elif not hits:
                 # Never dropped: the ref stays in `blob_refs` for effect
                 # detection, and the gap is counted as a health signal.
@@ -578,7 +614,7 @@ def resolve_revision(
     connection.executemany(
         "INSERT INTO unresolved(rev, path, line, raw_name, ref_kind, reason, candidates)"
         " VALUES(?, ?, ?, ?, ?, ?, ?)",
-        unresolved_rows + ambiguous_rows,
+        unresolved_rows + ambiguous_rows + builtin_rows,
     )
     return ResolveStats(
         edges=len(edge_rows),

--- a/src/codegraph/store.py
+++ b/src/codegraph/store.py
@@ -112,7 +112,9 @@ CREATE TABLE IF NOT EXISTS imports (
 -- were (see config.DEFAULT_AMBIGUITY_LIMIT); `candidates` carries the count the
 -- ambiguous case declined to enumerate, and is 0 for 'unknown'. Separating the
 -- two matters because they are opposite problems: 'unknown' means the resolver
--- is blind to something, 'ambiguous' means it sees too much.
+-- is blind to something, 'ambiguous' means it sees too much. 'builtin' is
+-- neither: a call the resolver understood and deliberately did not link to a
+-- repo symbol, kept out of the gap count so the real gaps stay visible.
 CREATE TABLE IF NOT EXISTS unresolved (
     rev TEXT NOT NULL,
     path TEXT NOT NULL,

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -605,3 +605,89 @@ def test_an_inheritance_cycle_does_not_hang_the_override_walk(repo, write):
     targets = {dst for src, dst, _ in edges(store) if src == "cyc.py::A.go"}
     assert "cyc.py::A.run" in targets
     store.close()
+
+
+# -- builtins are not repo symbols -----------------------------------------
+#
+# The last-resort step matches a call's final segment against every definition
+# in the repo, and plenty of builtins share a name with a plausible method. On
+# `psf/requests`, `badargs = set(kwargs) - set(result)` inside `create_cookie`
+# became an edge to `RequestsCookieJar.set`, which then carried a NONDETERMINISM
+# effect into a witness path presented to the user as evidence. See #17.
+
+
+def repo_with_a_method_named_set(write):
+    write(
+        "jar.py",
+        "class Jar:\n"
+        "    def set(self, k, v):\n"
+        "        self._d[k] = v\n",
+    )
+    write(
+        "make.py",
+        "def build(kwargs, result):\n"
+        "    badargs = set(kwargs) - set(result)\n"
+        "    return badargs\n",
+        commit="jar",
+    )
+
+
+def test_a_bare_builtin_call_is_not_an_edge_to_a_same_named_method(repo, write):
+    repo_with_a_method_named_set(write)
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    assert not [dst for src, dst, _ in edges(store) if src == "make.py::build"], (
+        "the builtin set() was linked to a repo method named set"
+    )
+    store.close()
+
+
+def test_a_builtin_is_recorded_as_such_and_not_counted_as_a_gap(repo, write):
+    repo_with_a_method_named_set(write)
+    store, indexer = build(repo)
+    stats = indexer.reconcile("HEAD")
+    rows = [row for row in unresolved_rows(store) if row["path"] == "make.py"]
+    assert {row["reason"] for row in rows} == {"builtin"}
+    assert {row["raw_name"] for row in rows} == {"set"}
+    # Recorded, but a builtin is not a hole in the graph.
+    assert stats.unresolved == 0
+    store.close()
+
+
+def test_a_dotted_call_ending_in_a_builtin_name_still_falls_through(repo, write):
+    """Only a BARE name can be the builtin. `x.set(...)` is a method call on
+    something and must keep reaching the name match -- otherwise this fix would
+    blind the resolver to every `.set()`, `.list()` and `.format()` in the repo."""
+    write("jar.py", "class Jar:\n    def set(self, k):\n        return k\n")
+    write("use.py", "def store(j, k):\n    return j.set(k)\n", commit="use")
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    assert ("use.py::store", "jar.py::Jar.set", "MEDIUM") in edges(store)
+    store.close()
+
+
+def test_a_module_local_definition_still_shadows_the_builtin(repo, write):
+    """The skip is only safe because the earlier steps run first. A repo that
+    really does define `set` must still resolve to its own."""
+    write(
+        "own.py",
+        "def set(x):\n    return x\n\n\ndef caller():\n    return set(1)\n",
+        commit="own",
+    )
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    assert ("own.py::caller", "own.py::set", "HIGH") in edges(store)
+    store.close()
+
+
+def test_an_imported_definition_still_shadows_the_builtin(repo, write):
+    write("lib.py", "def set(x):\n    return x\n")
+    write(
+        "app.py",
+        "from lib import set\n\n\ndef caller():\n    return set(1)\n",
+        commit="imported",
+    )
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    assert ("app.py::caller", "lib.py::set", "HIGH") in edges(store)
+    store.close()


### PR DESCRIPTION
Closes #17. Found while verifying #12 against `psf/requests`.

The last-resort step matches a call's final dotted segment against every definition in
the repo. Plenty of builtins share a name with a plausible method — `set`, `list`,
`next`, `id`, `type`, `format`, `hash`, `filter`, `map`, `open`, `sum`, `iter`,
`compile`, `vars`.

In `cookies.py::create_cookie`:

```python
badargs = set(kwargs) - set(result)
```

...became an edge to `RequestsCookieJar.set`, purely because that class defines a method
called `set`. The phantom edge then carried a NONDETERMINISM effect into a witness path
the user is told to treat as clickable evidence:

```
... -> create_cookie -> RequestsCookieJar.set -> morsel_to_cookie
```

`create_cookie` calls neither of them. Its only calls are the two `set()` builtins, a
`list()`, and `cookielib.Cookie(**result)`.

**After:** that effect disappears from `Session.send` entirely, and the two witnesses
that remain are both real — `is_ipv4_address` really is `socket.inet_aton(...)`, and
`get_proxy` really is `os.environ.get(...)`.

## Only bare names

`x.set(...)` is a method call and keeps falling through to the name match — otherwise
this would blind the resolver to every `.set()`, `.list()` and `.format()` in a repo.
There is a test pinning that.

Bare is safe because the earlier steps run first and already handle every way a repo
symbol could legitimately shadow a builtin: a module-local `def set(...)` is caught at
step 2 and an imported one at step 1, both at HIGH. Tests pin both paths, so the skip
can't silently swallow a real definition.

## Health signal

Builtins are recorded with `reason='builtin'` rather than counted as unresolved. A
builtin is not a hole in the graph, and counting it as one buried the real holes under a
large constant — on requests, `unresolved` drops **1249 → 826**.

247 passed, ruff clean.
