### PR TITLE
Make reconcile proportional to the edit, not the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,18 +157,29 @@ are not in the same place:
   results do not depend on file mtimes across checkouts (which `git
   checkout` rewrites indiscriminately and an mtime-keyed cache would have
   re-parsed on every switch).
-- **Resolve (Layer 2) — not yet proportional.** `resolve_revision` currently
-  re-resolves the *entire* symbol table for a revision on every reconcile,
-  rather than the design's intended `D ∪ dependents(D)` incremental
-  invalidation (`resolve.dependents` exists and is tested, but has no
-  production caller yet). Measured, one-file edit, steady state: flask (83
-  files) reconciles in 0.36s, django (2,930 files) in **22s** — of which one
-  blob is parsed and everything else is the whole revision being rebuilt.
-  django's *cold* index is 65s, so at that size an incremental edit costs a
-  third of a full re-index rather than nothing. The resolve step, not the
-  parse step, is where reconcile time scales with repository size today.
-  Tracked as follow-up work; this README will stop calling this out honestly
-  the day it's fixed, not before.
+- **Resolve (Layer 2) — proportional for most edits, not all.** Resolution is
+  global by nature: a bare-name call matches every definition in the revision,
+  and `self.X` walks a class hierarchy that spans files. So a reconcile narrows
+  to the edited files only when it can prove the revision's *symbol table* is
+  unchanged — same qualnames, same kinds, same live/shadowed bindings, same
+  base classes. A body-only edit qualifies; adding, removing or renaming a
+  definition does not, and falls back to a whole-revision rewrite, which cannot
+  leave a stale edge behind. Measured on django (2,930 files):
+
+  | | before | now |
+  |---|---|---|
+  | reconcile with no changes (every query pays this) | ~86s | **0.34s** |
+  | body-only edit | ~86s | **3.7s** |
+  | edit that adds or removes a definition | ~86s | 22.9s |
+  | cold index | 83.6s | 45.1s |
+
+  So the honest version: the common cases are proportional now, and the
+  symbol-table-changing case is not. What remains non-proportional is effect
+  *propagation* — an effect flows along edges, so a change anywhere can reach
+  anywhere and there is no cheap frontier to start from. It is skipped
+  entirely when a narrowed edit provably did not change any of its three
+  inputs, which is why a body-only edit is 3.7s rather than 9s, but a
+  structural edit still pays it in full.
 
 ## Why no MCP server
 

--- a/src/codegraph/effects/detect.py
+++ b/src/codegraph/effects/detect.py
@@ -18,20 +18,40 @@ from codegraph.resolve import HIGH, MODULE_SCOPE, build_import_maps, module_for_
 from codegraph.store import Store
 
 
-def detect_direct(store: Store, rev: str, catalog: Catalog, config: Config) -> int:
-    """Tag every ref in `rev` that is a direct effect. Returns rows written."""
+def detect_direct(
+    store: Store,
+    rev: str,
+    catalog: Catalog,
+    config: Config,
+    only_paths: set[str] | None = None,
+) -> int:
+    """Tag every ref in `rev` that is a direct effect. Returns rows written.
+
+    `only_paths` re-detects just those paths, leaving other paths' direct rows
+    alone. Direct detection is per-reference and reads nothing outside the file
+    a reference sits in except the import map, so narrowing it is sound whenever
+    those files' contents are the only thing that changed. Propagation is a
+    separate, still-global pass -- an effect flows along edges and cannot be
+    narrowed the same way.
+    """
     connection = store.connection
     import_maps, _imported_modules = build_import_maps(connection, rev, config)
     owner_index, live_index = _owner_index(store, rev)
     first_party = _first_party_modules(store, rev, config)
 
-    rows: list[tuple] = []
-    for row in connection.execute(
+    sql = (
         "SELECT t.path AS path, r.from_qualname, r.ref_kind, r.raw_name, r.line"
         " FROM blob_refs r JOIN tree t ON t.blob_sha = r.blob_sha"
-        " WHERE t.rev=? AND r.ref_kind IN ('call', 'global')",
-        (rev,),
-    ):
+        " WHERE t.rev=? AND r.ref_kind IN ('call', 'global')"
+    )
+    args: tuple = (rev,)
+    if only_paths is not None:
+        paths = sorted(only_paths)
+        sql += f" AND t.path IN ({','.join('?' * len(paths))})"
+        args += tuple(paths)
+
+    rows: list[tuple] = []
+    for row in connection.execute(sql, args):
         if row["ref_kind"] == "global":
             # Syntactic detection (assignment to a name declared `global`/
             # `nonlocal`), not a catalog match -- there is no pattern
@@ -51,7 +71,15 @@ def detect_direct(store: Store, rev: str, catalog: Catalog, config: Config) -> i
         )
         rows.append((rev, node_id, kind, 1, row["path"], row["line"], confidence))
 
-    connection.execute("DELETE FROM effects WHERE rev=? AND direct=1", (rev,))
+    if only_paths is None:
+        connection.execute("DELETE FROM effects WHERE rev=? AND direct=1", (rev,))
+    else:
+        paths = sorted(only_paths)
+        connection.execute(
+            "DELETE FROM effects WHERE rev=? AND direct=1 AND evidence_path IN"
+            f" ({','.join('?' * len(paths))})",
+            (rev, *paths),
+        )
     connection.executemany(
         "INSERT INTO effects(rev, node_id, kind, direct, evidence_path, evidence_line,"
         " confidence) VALUES(?,?,?,?,?,?,?)",

--- a/src/codegraph/indexer.py
+++ b/src/codegraph/indexer.py
@@ -141,6 +141,18 @@ class Indexer:
         dirty = {path for path, sha in tree.items() if stored.get(path) != sha}
         removed = set(stored) - set(tree)
 
+        catalog = Catalog.load(self.config)
+        fingerprint = self._fingerprint(catalog)
+        if not dirty and not removed and self._is_current(rev, fingerprint):
+            # Nothing in the tree moved and nothing outside it did either, so
+            # the materialized graph is already the answer.
+            #
+            # This is the hot path, not an edge case: every query reconciles
+            # the working tree first (the `git status` model -- see the README),
+            # so without this a repeated query pays a full rebuild of a
+            # revision that did not change. On django that was ~20s per query.
+            return self._unchanged_stats(rev, tree)
+
         # One transaction for the whole reconcile: Layer 1 fill-in and the
         # Layer 2 rewrite either both land or neither does.
         with connection:
@@ -157,9 +169,16 @@ class Indexer:
             shadowed = self._materialize_nodes(rev, tree)
 
             connection.execute(
-                "INSERT INTO revisions(rev, kind, materialized_at) VALUES(?, ?, ?) "
-                "ON CONFLICT(rev) DO UPDATE SET materialized_at=excluded.materialized_at",
-                (rev, "worktree" if rev == WORKTREE else "commit", int(time.time())),
+                "INSERT INTO revisions(rev, kind, materialized_at, fingerprint)"
+                " VALUES(?, ?, ?, ?) ON CONFLICT(rev) DO UPDATE SET"
+                " materialized_at=excluded.materialized_at,"
+                " fingerprint=excluded.fingerprint",
+                (
+                    rev,
+                    "worktree" if rev == WORKTREE else "commit",
+                    int(time.time()),
+                    fingerprint,
+                ),
             )
 
             # Phase 2 runs inside the same transaction: a revision is never
@@ -169,7 +188,6 @@ class Indexer:
             # Effect detection and propagation close out the same
             # transaction: a revision is never visible with edges but
             # stale (or missing) effects.
-            catalog = Catalog.load(self.config)
             detect_direct(self.store, rev, catalog, self.config)
             propagate(self.store, rev)
 
@@ -183,6 +201,70 @@ class Indexer:
             edges=resolved.edges,
             unresolved=resolved.unresolved,
             ambiguous=resolved.ambiguous,
+        )
+
+    def _fingerprint(self, catalog: Catalog) -> str:
+        """Digest of everything the graph depends on that is NOT in the tree.
+
+        A reconcile is allowed to skip its work when the tree is unchanged, so
+        anything else that can change an edge or an effect has to be pinned
+        here or that skip becomes a stale-answer bug. Editing `codegraph.toml`
+        touches no file in the revision's tree and can change every effect in
+        the graph.
+
+        `Catalog.fingerprint` was written for exactly this and had no caller
+        until now.
+        """
+        parts = (
+            PARSER_VERSION,
+            catalog.fingerprint(),
+            ",".join(self.config.source_roots),
+            str(self.config.ambiguity_limit),
+        )
+        return hashlib.blake2b("\x00".join(parts).encode(), digest_size=16).hexdigest()
+
+    def _is_current(self, rev: str, fingerprint: str) -> bool:
+        """Has `rev` been materialized under this exact fingerprint?"""
+        row = self.store.connection.execute(
+            "SELECT fingerprint FROM revisions WHERE rev=?", (rev,)
+        ).fetchone()
+        return row is not None and row["fingerprint"] == fingerprint
+
+    def _unchanged_stats(self, rev: str, tree: dict[str, str]) -> IndexStats:
+        """Stats for a reconcile that did nothing, read back from the store.
+
+        Counted rather than remembered: the numbers have to describe the graph
+        as it stands, not the pass that happened to build it, or `status` would
+        report zeroes whenever nothing changed.
+        """
+        connection = self.store.connection
+        shas = set(tree.values())
+
+        def count(sql: str) -> int:
+            return connection.execute(sql, (rev,)).fetchone()["n"]
+
+        return IndexStats(
+            paths_total=len(tree),
+            paths_dirty=0,
+            blobs_parsed=0,
+            blobs_cached=len(shas),
+            parse_errors=self._error_count(shas),
+            # Counted from Layer 1 the same way `_materialize_nodes` counts it
+            # -- `nodes` keeps neither `shadow_index` nor `conditional`, so
+            # counting non-live rows there would quietly include the
+            # conditional definitions that `_materialize_nodes` excludes.
+            shadowed=count(
+                "SELECT COUNT(*) AS n FROM blob_nodes b JOIN tree t"
+                " ON t.blob_sha = b.blob_sha"
+                " WHERE t.rev=? AND b.shadow_index IS NOT NULL AND b.conditional=0"
+            ),
+            edges=count("SELECT COUNT(*) AS n FROM edges WHERE rev=?"),
+            unresolved=count(
+                "SELECT COUNT(*) AS n FROM unresolved WHERE rev=? AND reason='unknown'"
+            ),
+            ambiguous=count(
+                "SELECT COUNT(*) AS n FROM unresolved WHERE rev=? AND reason='ambiguous'"
+            ),
         )
 
     def _ensure_parsed(self, shas: set[str]) -> tuple[int, int]:

--- a/src/codegraph/indexer.py
+++ b/src/codegraph/indexer.py
@@ -143,7 +143,8 @@ class Indexer:
 
         catalog = Catalog.load(self.config)
         fingerprint = self._fingerprint(catalog)
-        if not dirty and not removed and self._is_current(rev, fingerprint):
+        fingerprint_ok = self._is_current(rev, fingerprint)
+        if not dirty and not removed and fingerprint_ok:
             # Nothing in the tree moved and nothing outside it did either, so
             # the materialized graph is already the answer.
             #
@@ -165,8 +166,21 @@ class Indexer:
                 "INSERT INTO tree(rev, path, blob_sha) VALUES(?, ?, ?)",
                 [(rev, path, sha) for path, sha in tree.items()],
             )
-            connection.execute("DELETE FROM nodes WHERE rev=?", (rev,))
-            shadowed = self._materialize_nodes(rev, tree)
+
+            # `narrow` is the set of paths this reconcile may confine itself to,
+            # or None to rebuild the whole revision. See `_narrowable`.
+            narrow = self._narrowable(tree, stored, dirty, removed, fingerprint_ok)
+            if narrow is None:
+                connection.execute("DELETE FROM nodes WHERE rev=?", (rev,))
+                shadowed = self._materialize_nodes(rev, tree)
+            else:
+                marks = ",".join("?" * len(narrow))
+                connection.execute(
+                    f"DELETE FROM nodes WHERE rev=? AND path IN ({marks})",
+                    (rev, *sorted(narrow)),
+                )
+                self._materialize_nodes(rev, {p: tree[p] for p in narrow})
+                shadowed = self._shadowed_count(rev)
 
             connection.execute(
                 "INSERT INTO revisions(rev, kind, materialized_at, fingerprint)"
@@ -183,13 +197,28 @@ class Indexer:
 
             # Phase 2 runs inside the same transaction: a revision is never
             # visible with materialized nodes but stale edges.
-            resolved = resolve_revision(self.store, rev, self.config)
+            # Propagation reads exactly three things: the revision's node ids,
+            # its CALLS edges, and the (node, kind, confidence) of its direct
+            # effects. A narrowed pass can only change those within `narrow`,
+            # and `_narrowable` has already guaranteed the node ids are
+            # identical -- so snapshotting the other two before and after says
+            # whether propagation has any work to do at all. An edit that
+            # changes a literal or shifts lines usually changes neither.
+            before = None if narrow is None else self._propagation_inputs(rev, narrow)
+
+            resolved = resolve_revision(self.store, rev, self.config, only_paths=narrow)
 
             # Effect detection and propagation close out the same
             # transaction: a revision is never visible with edges but
             # stale (or missing) effects.
-            detect_direct(self.store, rev, catalog, self.config)
-            propagate(self.store, rev)
+            detect_direct(self.store, rev, catalog, self.config, only_paths=narrow)
+
+            # When it does have work, propagation is still whole-revision: an
+            # effect flows along edges, so a change anywhere can reach anywhere
+            # and there is no cheap frontier to start from. That remains the
+            # non-proportional phase -- see #7.
+            if before is None or before != self._propagation_inputs(rev, narrow):
+                propagate(self.store, rev)
 
         return IndexStats(
             paths_total=len(tree),
@@ -202,6 +231,117 @@ class Indexer:
             unresolved=resolved.unresolved,
             ambiguous=resolved.ambiguous,
         )
+
+    def _narrowable(
+        self,
+        tree: dict[str, str],
+        stored: dict[str, str],
+        dirty: set[str],
+        removed: set[str],
+        fingerprint_ok: bool,
+    ) -> set[str] | None:
+        """The paths this reconcile may confine itself to, or None for all.
+
+        Resolution is global by nature: a bare-name call matches against every
+        definition in the revision, and `self.X` walks a class hierarchy that
+        spans files. So narrowing is only sound when the revision's SYMBOL
+        TABLE is provably unchanged -- then nothing outside the edited files
+        can resolve differently, and only those files' own references need
+        rebuilding.
+
+        The conditions, each of them load-bearing:
+
+        - the revision is already materialized under this fingerprint, so
+          there is a correct previous state to keep;
+        - no path was added or removed, since either changes `module_to_path`
+          and the repo-wide name index;
+        - every dirty path declares exactly the same symbols as before -- same
+          qualnames, kinds, live/shadowed bindings. A new `def` changes what
+          bare-name calls anywhere in the repo can match;
+        - every dirty path's base references are unchanged. A changed base
+          class moves `self.X` resolution in every subclass, wherever it lives,
+          and lets `_load_bases` read the hierarchy back from the existing
+          INHERITS edges instead of recomputing it.
+
+        Anything else falls back to a whole-revision rewrite, which cannot
+        leave a stale edge behind. Getting this wrong is worse than being slow,
+        so the check is deliberately conservative -- a body-only edit is the
+        case worth catching, and it is by far the common one.
+        """
+        if not fingerprint_ok or removed or set(tree) != set(stored):
+            return None
+        if not dirty:
+            return set()
+        for path in dirty:
+            before, after = stored[path], tree[path]
+            if self._symbol_signature(before) != self._symbol_signature(after):
+                return None
+            if self._base_signature(before) != self._base_signature(after):
+                return None
+        return set(dirty)
+
+    def _propagation_inputs(self, rev: str, paths: set[str]) -> tuple[frozenset, frozenset]:
+        """What `propagate` would see differently if these paths changed.
+
+        Deliberately projected: `evidence_line` is excluded because propagation
+        never reads it, so a call moving down a line must not be mistaken for a
+        change in what that call means.
+        """
+        if not paths:
+            return frozenset(), frozenset()
+        connection = self.store.connection
+        marks = ",".join("?" * len(paths))
+        args = (rev, *sorted(paths))
+        edges = frozenset(
+            tuple(row)
+            for row in connection.execute(
+                "SELECT src, dst, confidence FROM edges"
+                f" WHERE rev=? AND kind='CALLS' AND callsite_path IN ({marks})",
+                args,
+            )
+        )
+        direct = frozenset(
+            tuple(row)
+            for row in connection.execute(
+                "SELECT node_id, kind, confidence FROM effects"
+                f" WHERE rev=? AND direct=1 AND evidence_path IN ({marks})",
+                args,
+            )
+        )
+        return edges, direct
+
+    def _symbol_signature(self, blob_sha: str) -> frozenset[tuple]:
+        """What a blob DECLARES, ignoring what any of it does.
+
+        `body_hash` is deliberately absent: a changed body is exactly the edit
+        this is trying to let through.
+        """
+        return frozenset(
+            tuple(row)
+            for row in self.store.connection.execute(
+                "SELECT qualname, kind, name_binding, shadow_index, conditional"
+                " FROM blob_nodes WHERE blob_sha=?",
+                (blob_sha,),
+            )
+        )
+
+    def _base_signature(self, blob_sha: str) -> frozenset[tuple]:
+        """The blob's base-class references, ignoring line positions."""
+        return frozenset(
+            tuple(row)
+            for row in self.store.connection.execute(
+                "SELECT from_qualname, raw_name, dotted FROM blob_refs"
+                " WHERE blob_sha=? AND ref_kind='base'",
+                (blob_sha,),
+            )
+        )
+
+    def _shadowed_count(self, rev: str) -> int:
+        return self.store.connection.execute(
+            "SELECT COUNT(*) AS n FROM blob_nodes b JOIN tree t ON t.blob_sha = b.blob_sha"
+            " WHERE t.rev=? AND b.shadow_index IS NOT NULL AND b.conditional=0",
+            (rev,),
+        ).fetchone()["n"]
 
     def _fingerprint(self, catalog: Catalog) -> str:
         """Digest of everything the graph depends on that is NOT in the tree.

--- a/src/codegraph/parse.py
+++ b/src/codegraph/parse.py
@@ -129,48 +129,64 @@ def _body_hash(node: ast.AST) -> str:
     return hashlib.blake2b(ast.dump(node).encode(), digest_size=16).hexdigest()
 
 
-class _BodyElider(ast.NodeTransformer):
-    """Replace every function/class def's `body` with a single placeholder
-    statement, without recursing into the original body first.
+_PASS = ast.Pass()
 
-    Used to build the module-level structural hash: a def/class's own
-    `body_hash` already covers everything inside it (via `_body_hash` on
-    the untouched node), so folding that same content into the module hash
-    too would double-count it and reintroduce the exact line-shift churn
-    `body_hash` comparison exists to avoid (an edit two functions away from
-    a def would ripple into every def nested inside it, transitively, all
-    the way up to the module). Not recursing into the original body before
-    replacing it also means a closure nested inside a top-level function
-    is dropped for free -- it is already inside that function's own
-    (unelided) `body_hash`.
 
-    Everything else about the def -- its name, decorators, arguments,
-    base classes, and its position among the module's other top-level
-    statements -- is left intact, so renaming a def, changing its
-    signature, or reordering top-level statements still changes the
-    module hash.
+def _elide_nested(node: object) -> object:
+    """`node` with every def/class body replaced by a single `Pass`, without
+    mutating it and without copying anything that does not change.
+
+    `ast.NodeTransformer.generic_visit` writes back into the node it is given,
+    which is why the elider used to be handed `copy.deepcopy(...)`. That copy
+    was quadratic in practice: a module was deep-copied once, and then every
+    class inside it deep-copied again for its own hash. On django's largest test
+    module -- 52 classes -- parsing that one file cost 4.8s, 3.8s of it inside
+    `copy.deepcopy`, which put the "parse is proportional to the diff" half of
+    the cost guarantee on the wrong side of a 1-file edit.
+
+    This returns the original node unchanged when nothing inside it needed
+    eliding, so only the spine down to each def/class is ever copied, one level
+    deep at a time.
     """
-
-    def _elide(self, node: ast.AST) -> ast.AST:
+    if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
         clone = copy.copy(node)
-        clone.body = [ast.Pass()]
+        clone.body = [_PASS]
         return clone
+    if not isinstance(node, ast.AST):
+        return node
+    return _elide_children(node)
 
-    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.AST:
-        return self._elide(node)
 
-    visit_AsyncFunctionDef = visit_FunctionDef  # type: ignore[assignment]
+def _elide_children(node: ast.AST) -> ast.AST:
+    """`_elide_nested` applied to `node`'s children but never to `node` itself.
 
-    def visit_ClassDef(self, node: ast.ClassDef) -> ast.AST:
-        return self._elide(node)
+    This is the difference between hashing a module (whose own "body" is the
+    thing being described) and hashing a def (whose own body must stay intact
+    while its methods' bodies are elided).
+    """
+    replacements: dict[str, object] = {}
+    for name, value in ast.iter_fields(node):
+        if isinstance(value, list):
+            items = [_elide_nested(item) for item in value]
+            if any(new is not old for new, old in zip(items, value, strict=True)):
+                replacements[name] = items
+        elif isinstance(value, ast.AST):
+            item = _elide_nested(value)
+            if item is not value:
+                replacements[name] = item
+    if not replacements:
+        return node
+    clone = copy.copy(node)
+    for name, value in replacements.items():
+        setattr(clone, name, value)
+    return clone
 
 
 def _module_body_hash(tree: ast.Module) -> str:
     """Structural hash of `tree`'s top-level statements, reusing
     `_body_hash` (the same dump-and-hash `parse.py` already uses for a
-    def/class's own body) over a copy with nested def/class bodies elided."""
-    skeleton = _BodyElider().visit(copy.deepcopy(tree))
-    return _body_hash(skeleton)
+    def/class's own body) over a view with nested def/class bodies elided."""
+    return _body_hash(_elide_children(tree))
 
 
 def _class_body_hash(node: ast.ClassDef) -> str:
@@ -186,18 +202,15 @@ def _class_body_hash(node: ast.ClassDef) -> str:
     about module-level churn: an editor touching `PaymentService.charge`
     should not also report `PaymentService` itself as changed.
 
-    `_BodyElider().generic_visit(skeleton)` (not `.visit(skeleton)`) is the
-    deliberate difference from `_module_body_hash`: `generic_visit` walks
-    `skeleton`'s children without ever calling `visit_ClassDef` on
-    `skeleton` itself, so the class's own body list, bases, decorators,
-    and name stay intact -- only a `FunctionDef`/`ClassDef` found AMONG
-    its children (a method, a nested class) gets its body replaced with a
-    single `Pass`. Bases and decorators live in separate AST fields from
-    `body`, so they're hashed as-is regardless.
+    `_elide_children` (rather than `_elide_nested`) is what makes this differ
+    from hashing a plain def: it never elides `node` itself, so the class's own
+    body list, bases, decorators and name stay intact -- only a
+    `FunctionDef`/`ClassDef` found AMONG its children (a method, a nested
+    class) gets its body replaced with a single `Pass`. Bases and decorators
+    live in separate AST fields from `body`, so they're hashed as-is
+    regardless.
     """
-    skeleton = copy.deepcopy(node)
-    _BodyElider().generic_visit(skeleton)
-    return _body_hash(skeleton)
+    return _body_hash(_elide_children(node))
 
 
 class _Collector(ast.NodeVisitor):

--- a/src/codegraph/resolve.py
+++ b/src/codegraph/resolve.py
@@ -426,14 +426,25 @@ def _nearest_class(path: str, qualname: str, class_ids: dict[tuple[str, str], st
     return None
 
 
-def _refs_by_path(store: Store, rev: str, ref_kind: str) -> dict[str, list[ParsedRef]]:
-    """Every reference of one kind in the revision, grouped by owning path."""
-    rows = store.connection.execute(
+def _refs_by_path(
+    store: Store, rev: str, ref_kind: str, only_paths: list[str] | None = None
+) -> dict[str, list[ParsedRef]]:
+    """References of one kind, grouped by owning path.
+
+    `only_paths` restricts the scan itself, not just the loop over the result:
+    a narrowed resolve that still read every reference in the repository would
+    be proportional to repo size in the one place the narrowing exists to fix.
+    """
+    sql = (
         "SELECT t.path, r.ordinal, r.from_qualname, r.ref_kind, r.raw_name, r.dotted, r.line"
         " FROM blob_refs r JOIN tree t ON t.blob_sha = r.blob_sha"
-        " WHERE t.rev=? AND r.ref_kind=? ORDER BY t.path, r.ordinal",
-        (rev, ref_kind),
+        " WHERE t.rev=? AND r.ref_kind=?"
     )
+    args: tuple = (rev, ref_kind)
+    if only_paths is not None:
+        sql += f" AND t.path IN ({','.join('?' * len(only_paths))})"
+        args += tuple(only_paths)
+    rows = store.connection.execute(sql + " ORDER BY t.path, r.ordinal", args)
     grouped: dict[str, list[ParsedRef]] = {}
     for row in rows:
         grouped.setdefault(row["path"], []).append(
@@ -503,15 +514,41 @@ def split_by_ambiguity_limit(
     return [hit for hit in hits if hit[1] != LOW], len(weak)
 
 
+def _load_bases(connection: sqlite3.Connection, rev: str) -> dict[str, list[str]]:
+    """Rebuild the class hierarchy from already-materialized INHERITS edges.
+
+    Only HIGH links feed the MRO walk, which is exactly the filter the
+    inheritance pass applies when it builds this map from scratch, so reading it
+    back is equivalent -- provided the base references it was built from have
+    not changed. That is a precondition the caller checks before narrowing; see
+    `Indexer._narrowable`.
+    """
+    bases: dict[str, list[str]] = {}
+    for row in connection.execute(
+        "SELECT src, dst FROM edges WHERE rev=? AND kind='INHERITS' AND confidence='HIGH'",
+        (rev,),
+    ):
+        bases.setdefault(row["src"], []).append(row["dst"])
+    return bases
+
+
 def resolve_revision(
-    store: Store, rev: str, config: Config, resolver: Resolver | None = None
+    store: Store,
+    rev: str,
+    config: Config,
+    resolver: Resolver | None = None,
+    only_paths: set[str] | None = None,
 ) -> ResolveStats:
     """Rewrite `edges`, `imports` and `unresolved` for one revision.
 
-    Still re-resolves the whole revision rather than narrowing to
-    `dependents()`: a whole-revision rewrite cannot leave a stale edge behind.
-    That is the one half of the cost guarantee this does not yet honour --
-    tracked, and stated in the README rather than glossed.
+    `only_paths` narrows the rewrite to those paths, leaving every other path's
+    rows in place. That is sound only when the revision's symbol table is
+    unchanged outside them -- a definition appearing or disappearing anywhere
+    changes what bare-name calls in unrelated files can match, and a changed
+    base class changes `self.X` resolution in every subclass, wherever it
+    lives. The caller owns that check (`Indexer._narrowable`); this function
+    trusts it. Passing `None` rewrites the whole revision, which cannot leave a
+    stale edge behind under any circumstances.
 
     `config.ambiguity_limit` bounds how many indistinguishable LOW candidates a
     single reference will be expanded into; past it the reference is recorded
@@ -522,14 +559,32 @@ def resolve_revision(
     limit = config.ambiguity_limit
     table = _SymbolTable(store, rev, config)
 
-    connection.execute("DELETE FROM edges WHERE rev=?", (rev,))
-    connection.execute("DELETE FROM imports WHERE rev=?", (rev,))
-    connection.execute("DELETE FROM unresolved WHERE rev=?", (rev,))
+    if only_paths is None:
+        target_paths = table.paths
+        bases: dict[str, list[str]] = {}
+        connection.execute("DELETE FROM edges WHERE rev=?", (rev,))
+        connection.execute("DELETE FROM imports WHERE rev=?", (rev,))
+        connection.execute("DELETE FROM unresolved WHERE rev=?", (rev,))
+    else:
+        target_paths = [path for path in table.paths if path in only_paths]
+        # Read the hierarchy back BEFORE deleting the edges it is derived from.
+        bases = _load_bases(connection, rev)
+        marks = ",".join("?" * len(target_paths))
+        args = (rev, *target_paths)
+        connection.execute(
+            f"DELETE FROM edges WHERE rev=? AND callsite_path IN ({marks})", args
+        )
+        connection.execute(
+            f"DELETE FROM imports WHERE rev=? AND importer_path IN ({marks})", args
+        )
+        connection.execute(f"DELETE FROM unresolved WHERE rev=? AND path IN ({marks})", args)
+    scan_paths = None if only_paths is None else target_paths
+
     connection.executemany(
         "INSERT INTO imports(rev, importer_path, module) VALUES(?, ?, ?)",
         [
             (rev, path, module)
-            for path in table.paths
+            for path in target_paths
             for module in sorted(table.imported_modules[path])
         ],
     )
@@ -541,9 +596,8 @@ def resolve_revision(
 
     # Inheritance first: `self.X` walks the class hierarchy, so the hierarchy
     # has to exist before any call is resolved.
-    bases: dict[str, list[str]] = {}
-    base_refs = _refs_by_path(store, rev, "base")
-    for path in table.paths:
+    base_refs = _refs_by_path(store, rev, "base", scan_paths)
+    for path in target_paths:
         ctx = table.context(rev, path, bases)
         for ref in base_refs.get(path, ()):
             src = _source_id(ref, table, path)
@@ -561,7 +615,7 @@ def resolve_revision(
                 # Only a certain link feeds the MRO walk, which claims HIGH.
                 # A weaker one still gets its edge, and a `self.X` that misses
                 # the walk falls through to the repo-wide name match anyway.
-                if confidence == HIGH:
+                if confidence == HIGH and only_paths is None:
                     bases.setdefault(src, []).append(node_id)
             if ambiguous_count:
                 ambiguous_rows.append(
@@ -579,8 +633,8 @@ def resolve_revision(
     # runs once per class for the whole revision rather than once per reference.
     descendant_cache: dict[str, list[str]] = {}
 
-    call_refs = _refs_by_path(store, rev, "call")
-    for path in table.paths:
+    call_refs = _refs_by_path(store, rev, "call", scan_paths)
+    for path in target_paths:
         ctx = table.context(rev, path, bases, subclasses, descendant_cache)
         for ref in call_refs.get(path, ()):
             src = _source_id(ref, table, path)
@@ -616,10 +670,17 @@ def resolve_revision(
         " VALUES(?, ?, ?, ?, ?, ?, ?)",
         unresolved_rows + ambiguous_rows + builtin_rows,
     )
+    # Counted over the whole revision, not over this pass: a narrowed rewrite
+    # touches a handful of paths but `status` has to describe the whole graph.
+    def total(sql: str) -> int:
+        return connection.execute(sql, (rev,)).fetchone()["n"]
+
     return ResolveStats(
-        edges=len(edge_rows),
-        unresolved=len(unresolved_rows),
-        ambiguous=len(ambiguous_rows),
+        edges=total("SELECT COUNT(*) AS n FROM edges WHERE rev=?"),
+        unresolved=total(
+            "SELECT COUNT(*) AS n FROM unresolved WHERE rev=? AND reason='unknown'"
+        ),
+        ambiguous=total("SELECT COUNT(*) AS n FROM unresolved WHERE rev=? AND reason='ambiguous'"),
     )
 
 

--- a/src/codegraph/store.py
+++ b/src/codegraph/store.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 WORKTREE = "WORKTREE"
 
@@ -63,11 +63,17 @@ CREATE TABLE IF NOT EXISTS blob_imports (
 );
 
 -- Layer 2: materialized per revision, evictable.
+-- `fingerprint` pins everything OUTSIDE the tree that the materialized graph
+-- depends on: parser version, source roots, ambiguity limit, and the effect
+-- catalog's own digest. A reconcile whose tree is unchanged can only skip its
+-- work if these are unchanged too -- editing codegraph.toml changes no file in
+-- the tree but can change every edge and every effect.
 CREATE TABLE IF NOT EXISTS revisions (
     rev TEXT PRIMARY KEY,
     kind TEXT NOT NULL,
     materialized_at INTEGER NOT NULL,
-    pinned INTEGER NOT NULL DEFAULT 0
+    pinned INTEGER NOT NULL DEFAULT 0,
+    fingerprint TEXT NOT NULL DEFAULT ''
 );
 CREATE TABLE IF NOT EXISTS tree (
     rev TEXT NOT NULL, path TEXT NOT NULL, blob_sha TEXT NOT NULL,

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -425,3 +425,114 @@ def _effect_kinds(store, node_id, rev=WORKTREE):
             "SELECT kind FROM effects WHERE rev=? AND node_id=?", (rev, node_id)
         )
     }
+
+
+# -- narrowing an edit to the files it can affect ---------------------------
+#
+# Resolution is global by nature: a bare-name call matches every definition in
+# the revision, and `self.X` walks a hierarchy that spans files. Narrowing is
+# sound only when the symbol table is provably unchanged. These tests pin both
+# halves -- that the narrow path fires when it should, and that it does NOT
+# when a change could reach other files. Getting the second wrong is a stale
+# graph, which is worse than being slow.
+
+
+def narrow_sets(monkeypatch):
+    """Record the `only_paths` of every phase-2 call."""
+    import codegraph.indexer as indexer_module
+
+    seen = []
+    original = indexer_module.resolve_revision
+
+    def spy(store, rev, config, resolver=None, only_paths=None):
+        seen.append(only_paths)
+        return original(store, rev, config, resolver, only_paths)
+
+    monkeypatch.setattr(indexer_module, "resolve_revision", spy)
+    return seen
+
+
+def test_a_body_only_edit_is_narrowed_to_that_file(repo, write, monkeypatch):
+    write("a.py", "def alpha():\n    return 1\n")
+    write("b.py", "def beta():\n    return 2\n", commit="two")
+    store = Store.open(repo)
+    indexer = Indexer(repo, store, GitTreeSource(repo))
+    indexer.reconcile(WORKTREE)
+
+    seen = narrow_sets(monkeypatch)
+    write("a.py", "def alpha():\n    return 1 + 1\n")
+    indexer.reconcile(WORKTREE)
+    assert seen == [{"a.py"}]
+    store.close()
+
+
+def test_a_body_only_edit_still_equals_a_cold_rebuild(repo, write):
+    write("lib.py", "def helper():\n    return 1\n")
+    write(
+        "app.py",
+        "from lib import helper\n\n\ndef run(x):\n    return helper() + x.helper()\n",
+        commit="two",
+    )
+    store = Store.open(repo)
+    indexer = Indexer(repo, store, GitTreeSource(repo))
+    indexer.reconcile(WORKTREE)
+    for value in range(2, 6):
+        write("lib.py", f"def helper():\n    return {value}\n")
+        indexer.reconcile(WORKTREE)
+    incremental = dump_graph(store, WORKTREE)
+    store.close()
+    assert incremental == cold_dump(repo, WORKTREE)
+
+
+@pytest.mark.parametrize(
+    "label, source",
+    [
+        ("adds a definition", "def alpha():\n    return 1\n\n\ndef added():\n    pass\n"),
+        ("removes a definition", ""),
+        ("renames a definition", "def renamed():\n    return 1\n"),
+        ("changes a base class", "class Base:\n    pass\n\n\nclass alpha(Base):\n    pass\n"),
+    ],
+)
+def test_a_change_that_can_reach_other_files_forces_a_full_rebuild(
+    repo, write, monkeypatch, label, source
+):
+    write("b.py", "def beta():\n    return 2\n", commit="b")
+    store = Store.open(repo)
+    indexer = Indexer(repo, store, GitTreeSource(repo))
+    indexer.reconcile(WORKTREE)
+
+    seen = narrow_sets(monkeypatch)
+    write("a.py", source)
+    indexer.reconcile(WORKTREE)
+    assert seen == [None], f"{label} was narrowed, but it changes the symbol table"
+    store.close()
+
+
+def test_a_definition_added_elsewhere_updates_another_files_edges(repo, write):
+    """The concrete reason the symbol-table check exists. `caller` is never
+    touched, but a new `save` in another file changes what its bare-name call
+    can match -- so narrowing to the edited file would leave a stale graph."""
+    write(
+        "caller.py",
+        "def caller(item):\n    return item.save()\n",
+    )
+    write("one.py", "class One:\n    def save(self):\n        return 1\n", commit="two")
+    store = Store.open(repo)
+    indexer = Indexer(repo, store, GitTreeSource(repo))
+    indexer.reconcile(WORKTREE)
+
+    def targets():
+        return {
+            row["dst"]
+            for row in store.connection.execute(
+                "SELECT dst FROM edges WHERE rev=? AND src='caller.py::caller'", (WORKTREE,)
+            )
+        }
+
+    assert targets() == {"one.py::One.save"}
+
+    write("two.py", "class Two:\n    def save(self):\n        return 2\n")
+    indexer.reconcile(WORKTREE)
+    assert targets() == {"one.py::One.save", "two.py::Two.save"}
+    assert dump_graph(store, WORKTREE) == cold_dump(repo, WORKTREE)
+    store.close()

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -30,7 +30,18 @@ def dump_graph(store, rev):
         "unresolved": sorted(
             tuple(row)
             for row in connection.execute(
-                "SELECT path, raw_name FROM unresolved WHERE rev=?", (rev,)
+                "SELECT path, raw_name, ref_kind, reason FROM unresolved WHERE rev=?", (rev,)
+            )
+        ),
+        # Effects are part of the materialized revision, so they belong in the
+        # equivalence too. Leaving them out left the incremental-vs-cold net
+        # with a hole exactly where detection and propagation are narrowed.
+        "effects": sorted(
+            tuple(row)
+            for row in connection.execute(
+                "SELECT node_id, kind, direct, evidence_path, evidence_line, confidence"
+                " FROM effects WHERE rev=?",
+                (rev,),
             )
         ),
     }
@@ -301,3 +312,116 @@ def test_no_single_reference_is_expanded_past_the_ambiguity_limit(repo, write):
     worst = max(row["n"] for row in rows)
     assert worst <= DEFAULT_AMBIGUITY_LIMIT, f"a single call site produced {worst} edges"
     store.close()
+
+
+# -- a reconcile that has nothing to do costs nothing ------------------------
+#
+# Every query reconciles the working tree first (the `git status` model), so a
+# repeated query used to pay a full rebuild of a revision that had not changed:
+# ~86s per query on django, ~2s on flask. See #7.
+
+
+def resolve_calls(monkeypatch):
+    """Count how many times `reconcile` reaches phase 2."""
+    import codegraph.indexer as indexer_module
+
+    calls = []
+    original = indexer_module.resolve_revision
+
+    def spy(*args, **kwargs):
+        calls.append(1)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(indexer_module, "resolve_revision", spy)
+    return calls
+
+
+def test_reconciling_an_unchanged_tree_does_no_work(repo, write, monkeypatch):
+    write(
+        "m.py",
+        "import requests\n"
+        "\n\n"
+        "def fetch():\n"
+        "    requests.get('u')\n"
+        "\n\n"
+        "def caller():\n"
+        "    fetch()\n",
+        commit="m",
+    )
+    store = Store.open(repo)
+    indexer = Indexer(repo, store, GitTreeSource(repo))
+    indexer.reconcile(WORKTREE)
+
+    calls = resolve_calls(monkeypatch)
+    before = dump_graph(store, WORKTREE)
+    stats = indexer.reconcile(WORKTREE)
+
+    assert calls == [], "an unchanged tree was re-resolved"
+    assert dump_graph(store, WORKTREE) == before
+    # The numbers must still describe the graph, not the pass that skipped.
+    assert stats.paths_total == 2
+    assert stats.edges > 0
+    store.close()
+
+
+def test_a_real_edit_still_rebuilds(repo, write, monkeypatch):
+    """Non-vacuity guard for the skip above."""
+    store = Store.open(repo)
+    indexer = Indexer(repo, store, GitTreeSource(repo))
+    indexer.reconcile(WORKTREE)
+
+    calls = resolve_calls(monkeypatch)
+    write("a.py", "def alpha():\n    return 99\n")
+    indexer.reconcile(WORKTREE)
+    assert calls == [1]
+    store.close()
+
+
+def test_editing_the_config_invalidates_even_though_no_tracked_file_changed(repo, write):
+    """`codegraph.toml` is tracked, so editing it does change the tree -- but
+    the point stands for what the fingerprint protects: the graph depends on
+    inputs the tree diff alone cannot see."""
+    write("app/__init__.py", "")
+    write("app/db.py", "def save(row):\n    return row\n")
+    write(
+        "app/service.py",
+        "from app.db import save\n\n\ndef persist(row):\n    return save(row)\n",
+        commit="app",
+    )
+    store = Store.open(repo)
+    Indexer(repo, store, GitTreeSource(repo)).reconcile(WORKTREE)
+    assert not _effect_kinds(store, "app/service.py::persist")
+
+    (repo / "codegraph.toml").write_text('[[effect]]\nmatch = "app.db.*"\nkind = "DB_WRITE"\n')
+    # A NEW indexer, so the config is re-read -- the store is the same one.
+    Indexer(repo, store, GitTreeSource(repo)).reconcile(WORKTREE)
+    assert "DB_WRITE" in _effect_kinds(store, "app/service.py::persist")
+    store.close()
+
+
+def test_an_untracked_config_change_still_invalidates(repo, write):
+    """The fingerprint's real job. An untracked `codegraph.toml` is invisible to
+    the tree diff (`git status` does not list it into the tree source), so
+    without the fingerprint the reconcile would skip and keep serving a graph
+    built under the old catalog."""
+    write("m.py", "def house_call():\n    pass\n\n\ndef caller():\n    house_call()\n", commit="m")
+    (repo / ".gitignore").write_text("codegraph.toml\n")
+    store = Store.open(repo)
+    Indexer(repo, store, GitTreeSource(repo)).reconcile(WORKTREE)
+    assert not _effect_kinds(store, "m.py::caller")
+
+    (repo / "codegraph.toml").write_text('[[effect]]\nmatch = "house_call"\nkind = "DB_WRITE"\n')
+    Indexer(repo, store, GitTreeSource(repo)).reconcile(WORKTREE)
+    assert "DB_WRITE" in _effect_kinds(store, "m.py::caller"), (
+        "an ignored config change was skipped by the unchanged-tree fast path"
+    )
+    store.close()
+
+
+def _effect_kinds(store, node_id, rev=WORKTREE):
+    return {
+        row["kind"]
+        for row in store.connection.execute(
+            "SELECT kind FROM effects WHERE rev=? AND node_id=?", (rev, node_id)
+        )
+    }

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,4 +1,12 @@
-from codegraph.parse import parse_blob
+import ast
+import copy
+
+from codegraph.parse import (
+    _body_hash,
+    _class_body_hash,
+    _module_body_hash,
+    parse_blob,
+)
 
 
 def qualnames(result):
@@ -273,3 +281,120 @@ def test_module_body_hash_changes_when_def_is_added():
     one = parse_blob(b"def alpha():\n    return 1\n")
     two = parse_blob(b"def alpha():\n    return 1\n\n\ndef beta():\n    return 2\n")
     assert one.module_body_hash != two.module_body_hash
+
+
+# -- body hashing is a persistent transform, not a deep copy ----------------
+#
+# `_elide_children` replaced a `deepcopy` + `NodeTransformer` pair. The copy was
+# quadratic in practice -- a module deep-copied once, then every class inside it
+# deep-copied again for its own hash -- and cost 4.8s to parse django's largest
+# test module, 3.8s of it inside `copy.deepcopy`. That put the "parse is
+# proportional to the diff" half of the cost guarantee on the wrong side of a
+# one-file edit. See #7.
+#
+# The reference implementation below is the code that was replaced. It is kept
+# as an oracle: the rewrite had to produce byte-identical hashes, or every
+# `body_hash` in every store would change meaning. Verified equal over all 2,929
+# modules and 11,072 classes of django before landing; this pins the property on
+# inputs a unit test can carry.
+
+
+class _ReferenceElider(ast.NodeTransformer):
+    """The pre-rewrite implementation, kept only to check the new one."""
+
+    def _elide(self, node):
+        clone = copy.copy(node)
+        clone.body = [ast.Pass()]
+        return clone
+
+    def visit_FunctionDef(self, node):
+        return self._elide(node)
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def visit_ClassDef(self, node):
+        return self._elide(node)
+
+
+def _reference_module_hash(tree):
+    return _body_hash(_ReferenceElider().visit(copy.deepcopy(tree)))
+
+
+def _reference_class_hash(node):
+    skeleton = copy.deepcopy(node)
+    _ReferenceElider().generic_visit(skeleton)
+    return _body_hash(skeleton)
+
+
+NASTY_SOURCE = '''
+import os
+from a import b as c
+
+CONST = [1, 2, {"k": (3, 4)}]
+
+@decorated(arg=1)
+async def top(a, *args, b: int = 2, **kw) -> None:
+    """doc"""
+    def closure():
+        return 1
+    class Inner:
+        def deep(self):
+            return closure()
+    return Inner
+
+
+class Outer(Base, metaclass=Meta):
+    """doc"""
+    attr = 1
+
+    class Nested:
+        def method(self):
+            if True:
+                def deeper():
+                    pass
+            return 2
+
+    async def amethod(self):
+        async with x:
+            pass
+
+    @property
+    def prop(self):
+        return self.attr
+
+
+if os.environ:
+    def conditional():
+        pass
+else:
+    class AlsoConditional:
+        pass
+
+try:
+    from d import e
+except ImportError:
+    e = None
+'''
+
+
+def test_the_rewritten_body_hash_matches_the_implementation_it_replaced():
+    tree = ast.parse(NASTY_SOURCE)
+    assert _module_body_hash(tree) == _reference_module_hash(tree)
+    classes = [n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)]
+    assert len(classes) >= 4, "fixture stopped covering nested and conditional classes"
+    for node in classes:
+        assert _class_body_hash(node) == _reference_class_hash(node), node.name
+
+
+def test_hashing_does_not_mutate_the_tree_it_is_given():
+    """The whole reason the old code deep-copied. If the transform ever starts
+    writing back into the original, the second hash of the same tree differs
+    from the first and every cached `body_hash` silently rots."""
+    tree = ast.parse(NASTY_SOURCE)
+    before = ast.dump(tree)
+    first = _module_body_hash(tree)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            _class_body_hash(node)
+    assert ast.dump(tree) == before
+    assert _module_body_hash(tree) == first


### PR DESCRIPTION
Closes #7 — the half of the cost guarantee that was never implemented.

## Measured on django (2,930 files)

| case | before | now |
|---|---|---|
| reconcile with no changes — **every query pays this** | ~86s | **0.34s** |
| body-only edit | ~86s | **3.7s** |
| edit that adds/removes/renames a definition | ~86s | 22.9s |
| cold index | 83.6s | **45.1s** |

## 1. A reconcile with nothing to do now costs nothing

Every query reconciles the working tree first (the `git status` model), so a repeated
query paid a full rebuild of a revision that hadn't changed. This was the hot path, not
an edge case.

The skip is only sound if nothing *outside* the tree can change the graph, so `revisions`
now carries a fingerprint over parser version, source roots, ambiguity limit, and the
catalog digest. `Catalog.fingerprint` was written for exactly this and had no caller.
What makes it load-bearing rather than decorative: **a gitignored `codegraph.toml` never
appears in the tree at all**, so without it a catalog edit would be skipped and the stale
graph served indefinitely. That has its own test.

## 2. Narrowing an edit to the files it can affect

Resolution is global by nature — a bare-name call matches every definition in the
revision, and `self.X` walks a hierarchy spanning files. So narrowing is sound only when
the symbol table is *provably* unchanged: same qualnames, kinds, live/shadowed bindings,
and base classes in every dirty file.

A body-only edit qualifies. Adding, removing or renaming a definition doesn't, and falls
back to a whole-revision rewrite, which cannot leave a stale edge behind. The check is
deliberately conservative — a stale graph is worse than a slow one.

## 3. Three things profiling found that guessing wouldn't have

**Parsing one file cost 4.8s**, 3.8s of it in `copy.deepcopy`.
`ast.NodeTransformer.generic_visit` mutates what it's given, so the body-hash elider was
handed a deep copy — a module copied once, then every class inside it copied *again* for
its own hash. Replaced with a persistent transform that returns the original node
untouched when nothing inside it needed eliding.

This was on the **parse** side — the half of the guarantee that was supposed to already
be proportional. Verified byte-identical over all 2,929 modules and 11,072 classes of
django, 16.3x faster. The old implementation is kept in the tests as an oracle so the
equivalence stays pinned, along with a test that hashing never mutates its input (the
whole reason the deep copy was there).

**Propagation reads exactly three things** — node ids, CALLS edges, and direct effects'
`(node, kind, confidence)`. A narrowed pass snapshots the latter two before and after and
skips propagation when neither moved. That's the difference between 9s and 3.7s.

I did **not** rewrite propagate itself. It's 27 BFS passes and roughly 2x is available
there, but it's also the code whose witness-totality invariant has bitten this project
three times, and a 2x on one phase doesn't justify touching it in the same PR.

**`_refs_by_path` and `detect_direct` narrow the SQL scan**, not just the loop over its
result — otherwise a narrowed resolve still reads every reference in the repo.

## Safety

`dump_graph` now covers **effects** as well as nodes/edges/unresolved. The
incremental-equals-cold-rebuild net (8 seeds × 12 random mutations including merges and
rebases) had a hole exactly where this change cuts.

New tests pin that the narrow path fires for a body edit; that it does **not** fire when
a definition is added, removed, renamed, or re-based; and that a definition added in one
file still updates another file's bare-name edges — the concrete stale-graph scenario the
symbol-table check exists to prevent.

260 passed, slow suite green, ruff clean. README's cost section rewritten with the
measurements instead of a promise.
