### PR TITLE
Name the commands the CLI actually has

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ code to import it.
 
 It answers two questions grep structurally cannot:
 
-- **`impact_of(symbol)`** — what transitively depends on this, ranked, with the
-  blast radius summarized rather than dumped.
-- **`effects_of(symbol)`** — does anything downstream write the database, hit
-  the network, touch the filesystem, or mutate global state — each claim backed
-  by a witness path to the exact `file:line` that causes it.
+- **`codegraph impact <symbol>`** — what transitively depends on this, ranked,
+  with the blast radius summarized rather than dumped.
+- **`codegraph effects <symbol>`** — does anything downstream write the
+  database, hit the network, touch the filesystem, or mutate global state —
+  each claim backed by a witness path to the exact `file:line` that causes it.
 
 Composed, they give the answer you actually want before a change: not "47 things
 call this," which is anxiety rather than information, but *"47 things call this,

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -32,3 +32,47 @@ def test_skill_documents_every_shipped_command():
     text = (ROOT / "skills" / "codegraph" / "SKILL.md").read_text()
     for command in ["codegraph resolve", "codegraph impact", "codegraph effects", "codegraph diff"]:
         assert command in text
+
+
+def test_every_command_the_readme_names_actually_exists():
+    """Pins the README's command names to the CLI's actual subcommands.
+
+    Prompted by the README opening on `impact_of(symbol)` and
+    `effects_of(symbol)` -- the API sketch from before the CLI existed, left
+    behind when it landed. Note this test would NOT have caught those two: they
+    were written without the `codegraph ` prefix, so nothing marked them as
+    commands at all. What it does catch is the ongoing case -- a command renamed
+    or removed while the README keeps advertising it, which is the way this
+    drifts once the names are written properly.
+    """
+    import re
+    from pathlib import Path
+
+    readme = (Path(__file__).resolve().parent.parent / "README.md").read_text()
+    named = set(re.findall(r"codegraph ([a-z][a-z-]+)", readme))
+    assert named, "no commands found in the README -- has the format changed?"
+
+    help_text = _cli_help()
+    real = set(_subcommands(help_text))
+    assert named <= real, f"README names commands that do not exist: {sorted(named - real)}"
+
+
+def _cli_help():
+    import contextlib
+    import io
+
+    from codegraph.cli import main
+
+    # `main` builds its parser internally; --help is the supported way to see it.
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer), contextlib.suppress(SystemExit):
+        main(["--help"])
+    return buffer.getvalue()
+
+
+def _subcommands(help_text):
+    import re
+
+    # argparse lists subcommands in a {a,b,c} block.
+    match = re.search(r"\{([a-z,\-]+)\}", help_text)
+    return match.group(1).split(",") if match else []


### PR DESCRIPTION
Supersedes and closes #4, which was opened before the implementation landed and would now
revert newer content.

The README opened on:

```
- **`impact_of(symbol)`** — what transitively depends on this...
- **`effects_of(symbol)`** — does anything downstream write the database...
```

Neither was ever a command. They're the API sketch from before the CLI existed, left
behind when it landed. Documentation that names a command that doesn't exist is worse
than no documentation — an agent reading it runs something that isn't there.

Now `codegraph impact <symbol>` and `codegraph effects <symbol>`.

Checked all eight commands the README names against `--help`: `diff`, `effects`, `gc`,
`impact`, `index`, `install-hooks`, `resolve`, `status`. All present.

A test now pins every `codegraph <cmd>` in the README to the parser's real subcommands.
**It would not have caught these two** — they carried no prefix marking them as commands
at all — and the docstring says so rather than implying otherwise. What it catches is the
ongoing case: a command renamed or removed while the README keeps advertising it.
Verified non-vacuous.

The "Why no MCP server" section stays. It documents an explicit non-goal, not a claim
that a server exists.

261 passed, ruff clean.
