### PR TITLE
feat: `codegraph init`, so any agent can find the tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,26 +27,61 @@ That also makes `codegraph diff` possible — the semantic delta of a branch:
 which symbols and edges changed, and which side effects newly became
 reachable.
 
-Built agent-first: a CLI, installable as a Claude Code plugin
-(`/plugin marketplace add swalla02/codegraph`), driven through `SKILL.md`
-rather than an MCP server (see "Why no MCP server" below), with a schema a
-visual navigator can project from later.
+Built agent-first: a CLI, driven through `AGENTS.md` (`codegraph init` writes
+the section, for any of the 25+ agents that read it) and through `SKILL.md`
+for Claude Code (`/plugin marketplace add swalla02/codegraph`), rather than an
+MCP server (see "Why no MCP server" below), with a schema a visual navigator
+can project from later.
 
 **Status:** implemented and in use. See
 [the design spec](docs/superpowers/specs/2026-08-29-codegraph-design.md) for
 the full rationale behind every decision below.
 
-## Install
+## Quickstart
 
-Requires Python 3.12+.
+Two commands, from a fresh machine to an agent that knows the tool exists:
 
 ```sh
-pip install /path/to/codegraph   # or: uv pip install /path/to/codegraph
+uv tool install --python 3.12 git+https://github.com/swalla02/codegraph
+cd /path/to/your/repo && codegraph init
 ```
 
-This installs the `codegraph` console script (`pyproject.toml`'s
-`[project.scripts]` entry point). Not yet published to PyPI — install from a
-checkout or a git URL until it is.
+**`--python 3.12` is not optional.** This tool needs Python 3.12+, and on a machine
+whose default interpreter is 3.11 — still the distro default nearly everywhere —
+the install fails outright rather than degrading. Passing the version explicitly
+makes `uv` fetch a suitable interpreter instead of failing on yours.
+
+`uv tool install` puts the `codegraph` console script (`pyproject.toml`'s
+`[project.scripts]` entry point) on `PATH` in its own isolated environment. Not
+yet published to PyPI, hence the git URL. From a local checkout, `uv pip install
+-e .` works the same way.
+
+### `codegraph init`
+
+`codegraph init` makes a repository's coding agents aware of codegraph, and is
+safe to re-run — it is idempotent, additive, and never overwrites content it
+did not write. It:
+
+- writes a short codegraph-owned section into `AGENTS.md` (creating the file if
+  needed), delimited by `<!-- codegraph:begin -->` / `<!-- codegraph:end -->`
+  so a later run updates that block in place instead of duplicating it. The
+  section is deliberately ~15 lines: it loads into *every* session of every
+  agent that reads `AGENTS.md`, so it names the commands and the trigger and
+  defers the rest to `codegraph guide`;
+- adds the documented `@AGENTS.md` import to `CLAUDE.md` **if that file already
+  exists**. It never creates one — for Claude Code the plugin below is strictly
+  better, because a skill loads on demand rather than into every session;
+- writes a fully commented-out `codegraph.toml` stub if there isn't one, and
+  never touches one there is.
+
+It does not install git hooks. That stays behind `install-hooks`, which you ask
+for by name.
+
+`AGENTS.md` is the cross-agent convention — Codex, Cursor, Gemini CLI, Copilot's
+coding agent, Aider, goose, opencode, Zed, Windsurf, Amp, Warp, Junie, Jules,
+Devin, RooCode, Kilo Code, Factory and others read it. Claude Code reads
+`CLAUDE.md` instead, which is what the `@AGENTS.md` import bridges
+([docs](https://code.claude.com/docs/en/memory)).
 
 ### As a Claude Code plugin
 
@@ -77,6 +112,8 @@ slower on a cold cache.
 | `codegraph impact <symbol> [--hops N] [--limit N] [--all] [--json]` | Report the ranked dependents of a symbol — everything a change to it could break. |
 | `codegraph diff [<base>..<head>] [--json]` | Report what changed between two revisions by content hash, never by line number: symbols added/removed/changed, plus any side effect newly reachable. Defaults to `merge-base(default branch, HEAD)..WORKTREE` — "what has this branch changed so far." |
 | `codegraph gc [--keep REV]` | Prune the Layer 1 parse cache down to what `HEAD`, the worktree, and any `--keep`-named revisions still reference. Never touches the graph itself, so it can only make a future answer slower to rebuild, never wrong. |
+| `codegraph init` | Make this repository's coding agents aware of codegraph: an `AGENTS.md` section, the `@AGENTS.md` bridge into an existing `CLAUDE.md`, and a commented `codegraph.toml` stub. Idempotent; never overwrites content it did not write; never touches `.git/`. |
+| `codegraph guide` | Print the agent-facing workflow to stdout — the same text the plugin ships as `SKILL.md`, so the short `AGENTS.md` section can defer to it rather than inline it. |
 | `codegraph install-hooks` | Install `post-commit`/`post-checkout`/`post-merge` git hooks that warm the cache in the background. Purely an optimization — every query reconciles the working tree itself regardless (see below), so results are identical whether or not a hook ever fires. |
 
 `resolve`, `impact`, and `effects` share one exit-code convention for
@@ -132,6 +169,11 @@ It lives at the repository root, not inside `.codegraph/`, because it is
 hand-written configuration meant to be committed and shared, whereas
 `.codegraph/` self-ignores and holds only derived cache: config is tracked,
 everything derived is disposable.
+
+`codegraph init` drops a fully commented-out version of this file, documenting
+every setting above with its default, if there isn't one already. It is inert
+until you uncomment something, and an existing `codegraph.toml` is never
+rewritten.
 
 ## Lazy refresh on query
 

--- a/src/codegraph/cli.py
+++ b/src/codegraph/cli.py
@@ -7,7 +7,9 @@ import sys
 from pathlib import Path
 
 from codegraph import __version__, gitio
+from codegraph.guide import guide_text
 from codegraph.indexer import FsTreeSource, GitTreeSource, Indexer
+from codegraph.init import SKIPPED, plan_init
 from codegraph.maintenance import gc, plan_hooks
 from codegraph.query.diff import MissingRevisionError, diff_report
 from codegraph.query.effects import effects_report
@@ -251,6 +253,47 @@ def _cmd_install_hooks(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_init(args: argparse.Namespace) -> int:
+    """Make this repository's coding agents aware of codegraph: an AGENTS.md
+    section, the CLAUDE.md bridge if there is a CLAUDE.md, and an inert
+    codegraph.toml stub. Idempotent and additive -- see `codegraph.init`.
+
+    Notably absent: git hooks. Those stay behind `install-hooks`, which the
+    user has to ask for by name.
+    """
+    root = Path(args.path).resolve()
+    if not root.is_dir():
+        print(f"not a directory: {root}", file=sys.stderr)
+        return 1
+    if not gitio.is_repo(root):
+        # Not fatal: codegraph indexes a plain directory too (see
+        # `open_workspace`'s FsTreeSource fallback), and the files written
+        # here are ordinary repo-root markdown that make just as much sense
+        # without git. Worth saying out loud, though -- `--path` pointing
+        # one directory off is a much likelier explanation than a
+        # deliberately un-versioned project.
+        print(f"note: {root} is not a git repository", file=sys.stderr)
+
+    failed = False
+    for result in plan_init(root):
+        line = f"{result.action:<9} {result.path.relative_to(root)}"
+        if result.reason:
+            line += f" -- {result.reason}"
+        if result.action == SKIPPED:
+            print(line, file=sys.stderr)
+            failed = True
+        else:
+            print(line)
+    return 1 if failed else 0
+
+
+def _cmd_guide(args: argparse.Namespace) -> int:
+    """Print the agent-facing workflow. The AGENTS.md block `init` writes
+    stays short by pointing here instead of inlining this."""
+    print(guide_text(), end="")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="codegraph")
     parser.add_argument("--version", action="version", version=__version__)
@@ -334,6 +377,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Additional revision to retain besides HEAD and the worktree (repeatable)",
     )
     gc_parser.set_defaults(handler=_cmd_gc)
+
+    init_parser = subparsers.add_parser(
+        "init", help="Make this repository's coding agents aware of codegraph"
+    )
+    init_parser.add_argument("--path", default=".", help="Repository root (default: cwd)")
+    init_parser.set_defaults(handler=_cmd_init)
+
+    guide_parser = subparsers.add_parser("guide", help="Print the agent-facing workflow")
+    guide_parser.set_defaults(handler=_cmd_guide)
 
     hooks_parser = subparsers.add_parser(
         "install-hooks", help="Install git hooks that warm the cache in the background"

--- a/src/codegraph/guide.md
+++ b/src/codegraph/guide.md
@@ -1,8 +1,3 @@
----
-name: codegraph
-description: Use when about to modify a Python function or class, or when asked "what breaks if I change this", "what does this affect", "is this safe to change", or "what did this branch change" — answers with a ranked, git-native call graph instead of a grep.
----
-
 # codegraph
 
 `codegraph` is a sidecar index over a Python codebase (content-addressed by

--- a/src/codegraph/guide.py
+++ b/src/codegraph/guide.py
@@ -1,0 +1,73 @@
+"""The agent-facing workflow text, and the one place it is authored.
+
+Three consumers want the same words: `codegraph guide` (stdout, for any
+agent), `skills/codegraph/SKILL.md` (the Claude Code plugin), and the
+`AGENTS.md` block `codegraph init` writes -- which stays short precisely by
+pointing at the first of those instead of restating it.
+
+The text is authored in `guide.md`, *inside the package*, because that is
+the only copy an installed `codegraph` has: the wheel ships
+`src/codegraph/` and nothing else (see `pyproject.toml`), so a `guide` that
+read `skills/codegraph/SKILL.md` from the repo would work from a checkout
+and fail everywhere it actually matters. `SKILL.md` is therefore the
+derived copy -- `guide.md` plus the skill frontmatter -- regenerated with
+`python -m codegraph.guide` and pinned byte-for-byte by
+`test_packaging.py::test_skill_md_is_the_generated_form_of_the_packaged_guide`,
+so the two cannot drift silently in either direction.
+
+Shipping a `.md` as package data is the same pattern as
+`effects/builtin.toml`: hatchling includes every file under the packaged
+directory, so no manifest entry is needed for it.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_GUIDE_PATH = Path(__file__).with_name("guide.md")
+
+#: Skill-runtime metadata, which is about *when to load* the text rather
+#: than part of the text -- so it lives here, with the generator, and not
+#: in `guide.md`, which `codegraph guide` prints verbatim. The
+#: `description` stays on one long line because a skill frontmatter value
+#: is scalar: wrapping it would change what it means, not just how it looks.
+_SKILL_FRONTMATTER = """---
+name: codegraph
+description: Use when about to modify a Python function or class, or when asked "what breaks if I change this", "what does this affect", "is this safe to change", or "what did this branch change" — answers with a ranked, git-native call graph instead of a grep.
+---
+"""
+
+
+def guide_text() -> str:
+    """The agent-facing workflow, as printed by `codegraph guide`."""
+    return _GUIDE_PATH.read_text(encoding="utf-8")
+
+
+def skill_text() -> str:
+    """The full expected contents of `skills/codegraph/SKILL.md`."""
+    return f"{_SKILL_FRONTMATTER}\n{guide_text()}"
+
+
+def _regenerate_skill_file() -> int:
+    """Dev chore: rewrite `skills/codegraph/SKILL.md` from `guide.md`.
+
+    Deliberately not a `codegraph` subcommand -- it is maintenance of this
+    repository's own files, not something a user of the tool ever runs, and
+    the path it writes only exists in a checkout.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    skill_path = repo_root / "skills" / "codegraph" / "SKILL.md"
+    if not skill_path.parent.is_dir():
+        print(
+            f"no skill directory at {skill_path.parent} (not a codegraph checkout?)",
+            file=sys.stderr,
+        )
+        return 1
+    skill_path.write_text(skill_text(), encoding="utf-8")
+    print(skill_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_regenerate_skill_file())

--- a/src/codegraph/init.py
+++ b/src/codegraph/init.py
@@ -1,0 +1,313 @@
+"""`codegraph init`: make a repository's coding agents aware of codegraph.
+
+A teammate who installs the binary still has an agent that has never heard
+of it, and an agent that has never heard of it greps for callers -- the
+exact anti-pattern this tool exists to displace. `init` closes that gap
+with three files and no daemon, no registry, and no MCP server (a non-goal;
+see the README).
+
+Why `AGENTS.md` is the target: it is the one discovery channel that is not
+per-vendor. 25+ agent tools read it -- Codex, Cursor, Gemini CLI, Copilot's
+coding agent, Devin, Windsurf, Zed, Aider, goose, opencode, Jules, Junie,
+Amp, Warp, VS Code, RooCode, Kilo Code, Factory -- across 60k+ repositories.
+
+Why `CLAUDE.md` is only ever *edited*, never created: Claude Code reads
+`CLAUDE.md`, not `AGENTS.md`, and the documented bridge is an `@AGENTS.md`
+import line inside it (https://code.claude.com/docs/en/memory). But that is
+the wrong shape for Claude Code specifically -- `CLAUDE.md` loads into
+*every* session, whereas this repo's plugin skill loads only when relevant.
+So if a `CLAUDE.md` already exists we wire it up (the user has already
+accepted that cost for their own content), and if it does not we say what
+to install instead rather than manufacturing a file nobody asked for.
+
+What `init` deliberately does NOT do: touch `.git/hooks/`. Warming hooks
+stay behind the explicit `install-hooks` command. A command named `init` is
+the one a person runs before they trust the tool, and writing into git's own
+directory as an unannounced side effect of "set up some markdown" is how a
+tool loses that trust.
+
+Everything here is idempotent and additive. The codegraph section of
+`AGENTS.md` is delimited by markers and updated in place; a `codegraph.toml`
+that already exists is never rewritten; prose above, below and around any of
+it is copied through byte-for-byte. See `markers.py` for the marker
+discipline, which `install_hooks` worked out first.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from codegraph.config import CONFIG_NAME
+from codegraph.markers import MalformedMarkerError, replace_marker_blocks
+
+AGENTS_NAME = "AGENTS.md"
+CLAUDE_NAME = "CLAUDE.md"
+
+BEGIN_MARKER = "<!-- codegraph:begin -->"
+END_MARKER = "<!-- codegraph:end -->"
+
+#: Claude Code's import syntax for pulling another file into memory.
+CLAUDE_IMPORT_LINE = "@AGENTS.md"
+
+CREATED = "created"
+UPDATED = "updated"
+UNCHANGED = "unchanged"
+SKIPPED = "skipped"
+
+_INSTALL_COMMAND = "uv tool install --python 3.12 git+https://github.com/swalla02/codegraph"
+
+# Short on purpose. This block loads into *every* session of every agent
+# that reads AGENTS.md, so it is priced per turn, not per repo: it has to
+# earn its context by naming the three commands and the trigger, then hand
+# off to `codegraph guide` (one cheap tool call, on demand) for exit codes,
+# output format and the rest. An inlined full workflow here would be the
+# same mistake as an always-loaded MCP tool definition.
+AGENTS_BLOCK = f"""{BEGIN_MARKER}
+## codegraph
+
+Before editing a Python function or class -- and whenever asked "what breaks if
+I change this", "what does this affect", or "what did this branch change" --
+query the call graph instead of grepping for callers:
+
+- `codegraph impact <symbol>` -- ranked dependents; what a change could break.
+- `codegraph effects <symbol>` -- side effects reachable downstream, each with
+  a witness path to the exact `file:line` that causes it.
+- `codegraph diff` -- what this branch changed, by content hash.
+
+Grep misses dynamic dispatch and never tells you when you have found the last
+caller. Run `codegraph guide` for the full workflow, exit codes, and how to
+read the output. If the command is missing, install it:
+`{_INSTALL_COMMAND}`
+{END_MARKER}
+"""
+
+_AGENTS_PREAMBLE = """# AGENTS.md
+
+Conventions for coding agents working in this repository.
+"""
+
+# Every line is commented out, so the file is inert the moment it lands and
+# stays inert until someone means it. The values shown are the defaults
+# already in force, which makes this a readable record of current behavior
+# rather than a config that silently changes behavior by existing.
+_CONFIG_STUB = '''# codegraph configuration -- https://github.com/swalla02/codegraph
+#
+# Nothing here is active: every setting is commented out, and the values shown
+# are the defaults codegraph already applies. Uncomment what you want to change.
+
+
+# How a file path becomes a Python module name for import resolution. The
+# longest matching root is stripped from the front of the path, so with "src"
+# in the list, src/pay/service.py resolves as the module `pay.service`. If
+# `codegraph status` reports a lot of unresolved references, a missing source
+# root is the first thing to check.
+# source_roots = ["", "src"]
+
+
+# How many equally-weak candidates one call site may name before codegraph
+# records it once as ambiguous instead of as that many low-confidence edges.
+# A call like `item.save()` that names nothing importable, nothing
+# module-local, and nothing reachable through `self` falls back to matching
+# `save` against every definition in the repository. On django that was 971
+# candidates for a single call site, and 96.6% of the whole graph was that kind
+# of guess -- the edge table grew with the square of the repository. Nothing is
+# discarded at the cap: the one ambiguous record makes the same claim the N
+# edges did. Raise it to get the full cross product back; 0 disables the cap.
+# ambiguity_limit = 25
+
+
+# Effect overrides, merged over the built-in catalog. The built-ins only know
+# public library calls (stdlib, requests/httpx, SQLAlchemy, psycopg, boto3,
+# ...), but most real side effects sit behind a house abstraction instead, and
+# for a call into a module THIS repository defines the built-ins are skipped
+# entirely -- only the overrides below apply.
+#
+# `match` is a dotted-name glob, matched against the call target after the
+# calling file's imports are expanded: with `from app import db` in scope, a
+# call to `db.save()` is matched as `app.db.save`. `kind` is one of DB_READ,
+# DB_WRITE, NETWORK, FS_READ, FS_WRITE, PROCESS, ENV_READ, GLOBAL_MUTATE,
+# NONDETERMINISM. Where two rules match, the one with the longer literal
+# prefix wins, so a specific override always beats a general built-in.
+
+# Every call into the house database module.
+# [[effect]]
+# match = "app.db.*"
+# kind = "DB_WRITE"
+
+# Any `<something>.enqueue(...)`, whatever the receiver turns out to be. A
+# wildcard head matches broadly and is scored LOW confidence for exactly that
+# reason; a fully literal pattern is scored HIGH.
+# [[effect]]
+# match = "*.enqueue"
+# kind = "NETWORK"
+'''
+
+
+@dataclass(frozen=True)
+class FileResult:
+    """One file's outcome, with `reason` carrying the detail a user needs
+    to act: why a file was left alone, or why it could not be touched."""
+
+    path: Path
+    action: str
+    reason: str | None = None
+
+
+def _read_text(path: Path) -> str:
+    """Read `path` without newline translation, so a CRLF file is seen as
+    the CRLF file it is rather than silently rewritten to LF on the way
+    back out. `Path.read_text` only grew a `newline=` parameter in 3.13,
+    and this package supports 3.12."""
+    return path.read_bytes().decode("utf-8")
+
+
+def _write_text(path: Path, text: str) -> None:
+    """Write `text` verbatim -- `newline=""` disables the translation that
+    would otherwise turn every `\\n` into `\\r\\n` on Windows and undo the
+    line endings `_block_for` was careful to match."""
+    path.write_text(text, encoding="utf-8", newline="")
+
+
+def _block_for(text: str) -> str:
+    """`AGENTS_BLOCK` rendered with the line ending the file already uses.
+
+    A file with any CRLF line is treated as a CRLF file, so the block we
+    own matches its surroundings and, crucially, is byte-identical on a
+    re-run. Only the block is converted: a mixed-ending file stays exactly
+    as mixed as we found it, because nothing outside our own lines is
+    rewritten.
+    """
+    return AGENTS_BLOCK.replace("\n", "\r\n") if "\r\n" in text else AGENTS_BLOCK
+
+
+def _separator(body: str, newline: str) -> str:
+    """The newlines needed between existing content and an appended block:
+    enough for one blank line, and none if there is already one.
+
+    Written as "top up what is there" rather than "trim and re-add" so that
+    a second run is byte-identical (the blank line it would add is already
+    present, so it adds nothing) *without* normalizing away trailing
+    whitespace the user chose to leave in their own file.
+    """
+    if not body or body.endswith(newline * 2):
+        return ""
+    return newline if body.endswith(newline) else newline * 2
+
+
+def _plan_agents_md(root: Path) -> FileResult:
+    """Create `AGENTS.md`, or splice/refresh only codegraph's own block in
+    an existing one."""
+    path = root / AGENTS_NAME
+    if not path.exists():
+        _write_text(path, f"{_AGENTS_PREAMBLE}\n{AGENTS_BLOCK}")
+        return FileResult(path, CREATED)
+
+    try:
+        existing = _read_text(path)
+    except UnicodeDecodeError:
+        return FileResult(
+            path,
+            SKIPPED,
+            f"{AGENTS_NAME} is not valid UTF-8; refusing to rewrite it (edit it by hand "
+            f"and add a codegraph section, or fix its encoding and re-run)",
+        )
+
+    block = _block_for(existing)
+    try:
+        replaced = replace_marker_blocks(existing, BEGIN_MARKER, END_MARKER, block)
+    except MalformedMarkerError:
+        return FileResult(
+            path,
+            SKIPPED,
+            f"{AGENTS_NAME} has a malformed codegraph marker (a `{BEGIN_MARKER}` with no "
+            f"matching `{END_MARKER}`, or vice versa); repair or remove it by hand and "
+            f"re-run -- the file was left untouched",
+        )
+
+    if replaced is None:
+        newline = "\r\n" if "\r\n" in existing else "\n"
+        replaced = existing + _separator(existing, newline) + block
+
+    if replaced == existing:
+        return FileResult(path, UNCHANGED, "codegraph section already current")
+    _write_text(path, replaced)
+    return FileResult(path, UPDATED)
+
+
+def _plan_claude_md(root: Path) -> FileResult:
+    """Add the `@AGENTS.md` import to an existing `CLAUDE.md`. Never
+    creates one -- see the module docstring."""
+    path = root / CLAUDE_NAME
+    if not path.exists():
+        return FileResult(
+            path,
+            UNCHANGED,
+            "no CLAUDE.md here, and none created on purpose: for Claude Code, install "
+            "the plugin instead (`/plugin marketplace add swalla02/codegraph`) -- its "
+            "skill loads on demand rather than into every session",
+        )
+
+    try:
+        existing = _read_text(path)
+    except UnicodeDecodeError:
+        return FileResult(
+            path,
+            SKIPPED,
+            f"{CLAUDE_NAME} is not valid UTF-8; refusing to rewrite it (add a "
+            f"`{CLAUDE_IMPORT_LINE}` line by hand)",
+        )
+
+    # A plain substring test, not a line-anchored one: over-detecting means
+    # we decline to add an import the user already has some other way (in a
+    # sentence, inside a list, behind a comment), which costs them one
+    # manual line. Under-detecting would append a second import of the same
+    # file on every run, which is the failure that actually compounds.
+    if CLAUDE_IMPORT_LINE in existing:
+        return FileResult(path, UNCHANGED, f"already imports {AGENTS_NAME}")
+
+    newline = "\r\n" if "\r\n" in existing else "\n"
+    _write_text(path, existing + _separator(existing, newline) + CLAUDE_IMPORT_LINE + newline)
+    return FileResult(path, UPDATED, f"added the `{CLAUDE_IMPORT_LINE}` import")
+
+
+def _plan_config(root: Path) -> FileResult:
+    """Write the commented `codegraph.toml` stub, only if there is none.
+
+    An existing config is hand-written, committed, and shared (see the
+    README) -- it is the one file here whose content this command could
+    not possibly improve on, so it is never rewritten, not even to add
+    comments around what is already there.
+    """
+    path = root / CONFIG_NAME
+    if path.exists():
+        return FileResult(path, UNCHANGED, "already present; never overwritten")
+    _write_text(path, _CONFIG_STUB)
+    return FileResult(path, CREATED)
+
+
+def plan_init(root: Path) -> list[FileResult]:
+    """Run every step, one `FileResult` each, in the order printed.
+
+    One step's unexpected failure (a read-only directory, a permission
+    error, anything not already handled inside the step) is isolated to
+    that step and reported as a skip: an `init` that half-runs and stops
+    leaves a repo in a state nobody can reason about, whereas one that
+    writes what it can and names what it could not is recoverable by
+    re-running after the fix. Same discipline as `plan_hooks`.
+    """
+    results: list[FileResult] = []
+    for step, name in (
+        (_plan_agents_md, AGENTS_NAME),
+        (_plan_claude_md, CLAUDE_NAME),
+        (_plan_config, CONFIG_NAME),
+    ):
+        try:
+            results.append(step(root))
+        except OSError as exc:
+            results.append(
+                FileResult(root / name, SKIPPED, f"could not write {name} ({exc.strerror or exc})")
+            )
+        except Exception as exc:  # noqa: BLE001 -- per-file isolation net, see docstring
+            results.append(FileResult(root / name, SKIPPED, f"unexpected error ({exc})"))
+    return results

--- a/src/codegraph/maintenance.py
+++ b/src/codegraph/maintenance.py
@@ -22,6 +22,7 @@ import stat
 from dataclasses import dataclass
 from pathlib import Path
 
+from codegraph.markers import MalformedMarkerError, strip_marker_blocks
 from codegraph.store import Store
 
 _CHUNK = 400  # stays well under SQLite's default 999-variable limit per statement
@@ -49,15 +50,6 @@ _HOOK_BLOCK = f"""{_BEGIN_MARKER}
 # the allowlist of interpreters `_HOOK_BLOCK`'s POSIX-shell syntax is safe
 # to land inside; anything else is left completely untouched.
 _SHELL_INTERPRETERS = {"sh", "bash", "dash", "ash", "ksh", "zsh"}
-
-
-class _MalformedMarker(Exception):
-    """A codegraph marker line was found without its matching partner --
-    a lone BEGIN with no END, a lone END with no BEGIN, or two BEGINs
-    with no END between them. This is damage from a previous run gone
-    wrong, or a hand-edited file, and guessing how much surrounding
-    content to delete risks eating real statements. The caller must
-    refuse to touch the file, not repair around it."""
 
 
 def _chunks(items: list[str], size: int) -> list[list[str]]:
@@ -154,59 +146,6 @@ def _is_shell_shebang(shebang_line: str) -> bool:
     return _shebang_interpreter(shebang_line) in _SHELL_INTERPRETERS
 
 
-def _is_marker_line(line: str, marker: str) -> bool:
-    """True only if `line` (ignoring surrounding whitespace) is *exactly*
-    the marker, not merely a line that happens to contain it somewhere --
-    a hook whose own comment or quoted string mentions this marker text
-    must never be mistaken for a real block boundary."""
-    return line.strip() == marker
-
-
-def _strip_existing_blocks(text: str) -> str:
-    """Remove every complete codegraph block (a BEGIN marker line, its
-    contents, and the following END marker line -- matched as whole lines
-    only, never a substring inside a longer line). Loops until every
-    marker pair is gone, so a file carrying more than one block (an old
-    one left at the end plus a newer one spliced at the top, say) converges
-    to zero, not one-fewer.
-
-    Raises `_MalformedMarker` if the marker lines found don't pair up
-    cleanly -- a BEGIN with no following END, an END with no preceding
-    BEGIN, or two BEGINs with no END between them. The caller must treat
-    that as damage to leave alone, not a shape to repair by guessing.
-    """
-    lines = text.splitlines(keepends=True)
-    marker_positions = [
-        (index, "begin")
-        for index, line in enumerate(lines)
-        if _is_marker_line(line, _BEGIN_MARKER)
-    ] + [
-        (index, "end") for index, line in enumerate(lines) if _is_marker_line(line, _END_MARKER)
-    ]
-    marker_positions.sort()
-
-    blocks: list[tuple[int, int]] = []
-    pending_begin: int | None = None
-    for index, kind in marker_positions:
-        if kind == "begin":
-            if pending_begin is not None:
-                raise _MalformedMarker
-            pending_begin = index
-        else:
-            if pending_begin is None:
-                raise _MalformedMarker
-            blocks.append((pending_begin, index))
-            pending_begin = None
-    if pending_begin is not None:
-        raise _MalformedMarker
-
-    if not blocks:
-        return text
-
-    removed = {index for start, end in blocks for index in range(start, end + 1)}
-    return "".join(line for index, line in enumerate(lines) if index not in removed)
-
-
 def _insert_after_shebang(existing: str) -> str:
     """Splice `_HOOK_BLOCK` in as the first statement of the script, right
     after its shebang line so it always runs -- before any pre-existing
@@ -271,8 +210,8 @@ def _plan_one_hook(name: str, path: Path) -> HookResult:
         )
 
     try:
-        stripped = _strip_existing_blocks(existing)
-    except _MalformedMarker:
+        stripped = strip_marker_blocks(existing, _BEGIN_MARKER, _END_MARKER)
+    except MalformedMarkerError:
         return HookResult(
             name=name,
             path=path,

--- a/src/codegraph/markers.py
+++ b/src/codegraph/markers.py
@@ -1,0 +1,135 @@
+"""Marker-delimited blocks that codegraph owns inside files it does not.
+
+Two commands splice a codegraph-managed block into a file whose *rest* is
+the user's: `install-hooks` into `.git/hooks/*`, and `init` into
+`AGENTS.md`. Both need the same three properties, and `install-hooks`
+learned all three the hard way, so they live here once rather than being
+re-derived per caller:
+
+- **Whole-line anchoring.** A marker is recognized only when it is the
+  entire line (modulo surrounding whitespace). Substring matching deletes
+  everything between two lines that merely *mention* the marker text --
+  a hook echoing a reminder string, or an `AGENTS.md` documenting this very
+  convention.
+- **Converge on exactly one block.** Every complete block is accounted for,
+  however many there are, so a re-run lands on one -- never one-fewer, never
+  one-more -- and a stale block left by an older version of the writer is
+  replaced rather than left to rot beside a live one.
+- **Refusal over repair.** Markers that don't pair up cleanly are damage
+  from a previous mishap or a hand-edit. Guessing how much surrounding
+  content the missing partner would have covered risks eating the user's
+  own text, so the caller is told to leave the file alone instead.
+"""
+
+from __future__ import annotations
+
+
+class MalformedMarkerError(Exception):
+    """A codegraph marker line was found without its matching partner --
+    a lone BEGIN with no END, a lone END with no BEGIN, or two BEGINs
+    with no END between them. This is damage from a previous run gone
+    wrong, or a hand-edited file, and guessing how much surrounding
+    content to delete risks eating real statements. The caller must
+    refuse to touch the file, not repair around it."""
+
+
+def is_marker_line(line: str, marker: str) -> bool:
+    """True only if `line` (ignoring surrounding whitespace) is *exactly*
+    the marker, not merely a line that happens to contain it somewhere --
+    a file whose own comment or quoted string mentions this marker text
+    must never be mistaken for a real block boundary."""
+    return line.strip() == marker
+
+
+def _find_marker_blocks(
+    lines: list[str], begin_marker: str, end_marker: str
+) -> list[tuple[int, int]]:
+    """Line-index spans (begin line, end line, both inclusive) of every
+    complete marker block, in file order.
+
+    Raises `MalformedMarkerError` if the marker lines found don't pair up
+    cleanly -- a BEGIN with no following END, an END with no preceding
+    BEGIN, or two BEGINs with no END between them. The caller must treat
+    that as damage to leave alone, not a shape to repair by guessing.
+    """
+    marker_positions = [
+        (index, "begin")
+        for index, line in enumerate(lines)
+        if is_marker_line(line, begin_marker)
+    ] + [
+        (index, "end") for index, line in enumerate(lines) if is_marker_line(line, end_marker)
+    ]
+    marker_positions.sort()
+
+    blocks: list[tuple[int, int]] = []
+    pending_begin: int | None = None
+    for index, kind in marker_positions:
+        if kind == "begin":
+            if pending_begin is not None:
+                raise MalformedMarkerError
+            pending_begin = index
+        else:
+            if pending_begin is None:
+                raise MalformedMarkerError
+            blocks.append((pending_begin, index))
+            pending_begin = None
+    if pending_begin is not None:
+        raise MalformedMarkerError
+    return blocks
+
+
+def strip_marker_blocks(text: str, begin_marker: str, end_marker: str) -> str:
+    """Remove every complete marker block (a BEGIN marker line, its
+    contents, and the following END marker line -- matched as whole lines
+    only, never a substring inside a longer line). Removes *all* of them,
+    so a file carrying more than one block (an old one left at the end plus
+    a newer one spliced at the top, say) converges to zero, not one-fewer.
+
+    Raises `MalformedMarkerError`; see `_find_marker_blocks`.
+    """
+    lines = text.splitlines(keepends=True)
+    blocks = _find_marker_blocks(lines, begin_marker, end_marker)
+    if not blocks:
+        return text
+    removed = {index for start, end in blocks for index in range(start, end + 1)}
+    return "".join(line for index, line in enumerate(lines) if index not in removed)
+
+
+def replace_marker_blocks(
+    text: str, begin_marker: str, end_marker: str, block: str
+) -> str | None:
+    """Swap `block` in for the marker block already in `text`, *where it
+    already sits*, and return the result -- or `None` if `text` carries no
+    block at all, leaving the caller to decide where a first one goes.
+
+    Updating in place rather than strip-then-append is the difference
+    between a file the user can arrange and one the tool keeps
+    rearranging: a block a reader deliberately moved below their own
+    preamble stays there across re-runs. If there is more than one block
+    (an older writer's, plus this one's), the first keeps its position and
+    the rest are removed -- converging on exactly one, the same property
+    `install_hooks` needs from `strip_marker_blocks`.
+
+    `block` must already end in a newline; everything outside the block's
+    own line span is copied through byte-for-byte.
+
+    Raises `MalformedMarkerError`; see `_find_marker_blocks`.
+    """
+    lines = text.splitlines(keepends=True)
+    blocks = _find_marker_blocks(lines, begin_marker, end_marker)
+    if not blocks:
+        return None
+
+    keep_start, keep_end = blocks[0]
+    dropped = {index for start, end in blocks[1:] for index in range(start, end + 1)}
+    out: list[str] = []
+    for index, line in enumerate(lines):
+        if index in dropped:
+            continue
+        if index == keep_start:
+            out.append(block)
+            continue
+        if keep_start < index <= keep_end:
+            continue
+        out.append(line)
+    return "".join(out)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -249,13 +249,19 @@ def test_init_on_a_missing_path_fails_with_one_line(tmp_path, capsys):
 def test_init_on_a_read_only_directory_reports_instead_of_crashing(repo, capsys):
     """A repo checked out read-only (a CI cache, a mounted volume) must
     produce a named, one-line failure per file and a nonzero exit -- not a
-    PermissionError traceback, and not a half-written AGENTS.md."""
+    PermissionError traceback, and not a half-written AGENTS.md.
+
+    Both files are named, not just the first: a failure is isolated to the
+    file it happened on, so the user learns everything that needs fixing in
+    one run rather than one error per re-run.
+    """
     repo.chmod(0o555)
     try:
         assert main(["init", "--path", str(repo)]) == 1
         err = capsys.readouterr().err
-        assert "AGENTS.md" in err
         assert "Traceback" not in err
+        skipped = [line for line in err.splitlines() if line.startswith("skipped")]
+        assert [line.split()[1] for line in skipped] == ["AGENTS.md", CONFIG_NAME]
         assert not (repo / "AGENTS.md").exists()
     finally:
         repo.chmod(0o755)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,308 @@
+import hashlib
+import os
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from codegraph.cli import main
+from codegraph.config import CONFIG_NAME, Config
+from codegraph.effects.catalog import EFFECT_KINDS
+from codegraph.guide import guide_text
+from codegraph.init import AGENTS_BLOCK, BEGIN_MARKER, END_MARKER
+
+
+def fingerprint(root: Path) -> dict[str, str]:
+    """Content hash of every file under `root`, for byte-identity checks."""
+    return {
+        str(path.relative_to(root)): hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def test_init_creates_agents_md_and_a_config_stub(repo, capsys):
+    """The whole point of the command: a repo that said nothing about
+    codegraph now tells any AGENTS.md-reading agent about it, and carries a
+    config file to edit when the built-in effect catalog isn't enough."""
+    assert main(["init", "--path", str(repo)]) == 0
+
+    agents = (repo / "AGENTS.md").read_text()
+    assert BEGIN_MARKER in agents and END_MARKER in agents
+    assert "codegraph impact" in agents
+    assert "codegraph guide" in agents
+    assert (repo / CONFIG_NAME).exists()
+
+    out = capsys.readouterr().out
+    assert "created" in out
+    assert "AGENTS.md" in out
+    assert CONFIG_NAME in out
+
+
+def test_running_init_twice_leaves_the_repo_byte_identical(repo):
+    """Idempotency is the property that makes this safe to put in a setup
+    script or a README: a second run must not append a second block, flip a
+    line ending, or touch a single byte anywhere in the repository."""
+    main(["init", "--path", str(repo)])
+    before = fingerprint(repo)
+    assert main(["init", "--path", str(repo)]) == 0
+    assert fingerprint(repo) == before
+    assert (repo / "AGENTS.md").read_text().count(BEGIN_MARKER) == 1
+
+
+def test_init_appends_to_an_existing_agents_md_without_touching_its_prose(repo):
+    """An AGENTS.md that exists but has no codegraph block gets one
+    appended -- and every byte the user wrote survives verbatim, which is
+    the difference between a tool you run on a real repo and one you don't."""
+    prose = "# AGENTS.md\n\nRun `make test` before pushing.\nUse tabs, we're like that.\n"
+    (repo / "AGENTS.md").write_text(prose)
+
+    assert main(["init", "--path", str(repo)]) == 0
+
+    content = (repo / "AGENTS.md").read_text()
+    assert content.startswith(prose)
+    assert content.count(BEGIN_MARKER) == 1
+    assert "codegraph impact" in content
+
+
+def test_init_updates_its_block_in_place_and_keeps_prose_on_both_sides(repo):
+    """A block sitting between two pieces of user prose must be refreshed
+    *where it is*, not deleted and re-appended at the end of the file. A
+    reader who moved the section under their own preamble should not find it
+    relocated on the next run, and the prose that followed it must still
+    follow it."""
+    stale = (
+        "# AGENTS.md\n\nTop prose.\n\n"
+        f"{BEGIN_MARKER}\n## codegraph\n\nSomething an older version wrote.\n{END_MARKER}\n"
+        "\nBottom prose that must stay at the bottom.\n"
+    )
+    (repo / "AGENTS.md").write_text(stale)
+
+    assert main(["init", "--path", str(repo)]) == 0
+
+    content = (repo / "AGENTS.md").read_text()
+    assert "Something an older version wrote." not in content
+    assert content.startswith("# AGENTS.md\n\nTop prose.\n\n")
+    assert content.endswith("\nBottom prose that must stay at the bottom.\n")
+    assert content.index("codegraph impact") < content.index("Bottom prose")
+    assert content.count(BEGIN_MARKER) == 1
+
+
+def test_init_ignores_marker_text_embedded_in_a_longer_line(repo):
+    """Marker matching is anchored to a whole line, never a substring --
+    the exact lesson `install_hooks` learned. An AGENTS.md that *documents*
+    this convention (mentioning the markers inline) must not have everything
+    between those two sentences eaten."""
+    prose = (
+        "# AGENTS.md\n\n"
+        f"codegraph owns the section between `{BEGIN_MARKER}` and\n"
+        "IMPORTANT PROJECT RULE THAT MUST SURVIVE\n"
+        f"`{END_MARKER}`; edit outside it freely.\n"
+    )
+    (repo / "AGENTS.md").write_text(prose)
+
+    assert main(["init", "--path", str(repo)]) == 0
+
+    content = (repo / "AGENTS.md").read_text()
+    assert "IMPORTANT PROJECT RULE THAT MUST SURVIVE" in content
+    assert content.startswith(prose)
+
+
+def test_init_refuses_an_agents_md_with_a_half_deleted_block(repo, capsys):
+    """A begin marker with no matching end is damage -- a hand-edit, or an
+    interrupted write. Guessing how much of the surrounding file the missing
+    partner would have covered risks deleting the user's own text, so the
+    file is left byte-identical and the failure is loud."""
+    broken = f"# AGENTS.md\n\n{BEGIN_MARKER}\n## codegraph\n\nhalf a block\n"
+    (repo / "AGENTS.md").write_text(broken)
+
+    assert main(["init", "--path", str(repo)]) == 1
+
+    assert (repo / "AGENTS.md").read_text() == broken
+    err = capsys.readouterr().err
+    assert "malformed" in err.lower()
+    assert "Traceback" not in err
+
+
+def test_init_leaves_a_non_utf8_agents_md_untouched(repo, capsys):
+    """A file codegraph cannot decode is a file it cannot safely rewrite.
+    Refuse with one line, leave every byte alone -- never a traceback, and
+    never a partial write that loses whatever the bytes meant."""
+    original = b"# AGENTS.md\n\nlatin-1 caf\xe9\n"
+    (repo / "AGENTS.md").write_bytes(original)
+
+    assert main(["init", "--path", str(repo)]) == 1
+
+    assert (repo / "AGENTS.md").read_bytes() == original
+    err = capsys.readouterr().err
+    assert "UTF-8" in err
+    assert "Traceback" not in err
+
+
+def test_init_keeps_crlf_line_endings_and_stays_idempotent(repo):
+    """A repo edited on Windows has CRLF files, and a tool that silently
+    rewrites every line ending shows up as a whole-file diff. The block we
+    add adopts the file's own endings, so nothing outside it changes and the
+    second run is still byte-identical."""
+    (repo / "AGENTS.md").write_bytes(b"# AGENTS.md\r\n\r\nWindows prose.\r\n")
+
+    assert main(["init", "--path", str(repo)]) == 0
+
+    raw = (repo / "AGENTS.md").read_bytes()
+    assert raw.count(b"\n") == raw.count(b"\r\n"), "a bare LF was introduced into a CRLF file"
+    assert raw.startswith(b"# AGENTS.md\r\n\r\nWindows prose.\r\n")
+
+    assert main(["init", "--path", str(repo)]) == 0
+    assert (repo / "AGENTS.md").read_bytes() == raw
+
+
+def test_init_never_overwrites_an_existing_codegraph_toml(repo, capsys):
+    """codegraph.toml is hand-written, committed configuration -- the one
+    file here whose contents this command could only make worse."""
+    original = "ambiguity_limit = 100\n\n[[effect]]\nmatch = \"app.db.*\"\nkind = \"DB_WRITE\"\n"
+    (repo / CONFIG_NAME).write_text(original)
+
+    assert main(["init", "--path", str(repo)]) == 0
+
+    assert (repo / CONFIG_NAME).read_text() == original
+    assert Config.load(repo).ambiguity_limit == 100
+
+    reported = next(line for line in capsys.readouterr().out.splitlines() if CONFIG_NAME in line)
+    assert reported.startswith("unchanged")
+
+
+def test_init_never_creates_a_claude_md_and_says_why(repo, capsys):
+    """Claude Code already has a better channel than AGENTS.md -- the
+    plugin's skill, which loads on demand instead of into every session.
+    Manufacturing a CLAUDE.md nobody asked for would make every Claude
+    session permanently more expensive to buy nothing."""
+    assert main(["init", "--path", str(repo)]) == 0
+
+    assert not (repo / "CLAUDE.md").exists()
+    out = capsys.readouterr().out
+    assert "CLAUDE.md" in out
+    assert "plugin" in out
+
+
+def test_init_bridges_an_existing_claude_md_with_the_agents_import(repo):
+    """Claude Code reads CLAUDE.md, not AGENTS.md. If the user has already
+    accepted a CLAUDE.md's per-session cost, the documented `@AGENTS.md`
+    import is what makes the block we just wrote visible there too."""
+    (repo / "CLAUDE.md").write_text("# CLAUDE.md\n\nProject notes.\n")
+
+    assert main(["init", "--path", str(repo)]) == 0
+
+    content = (repo / "CLAUDE.md").read_text()
+    assert content.startswith("# CLAUDE.md\n\nProject notes.\n")
+    assert "@AGENTS.md" in content
+
+
+def test_init_does_not_duplicate_an_existing_agents_import(repo):
+    """A second `@AGENTS.md` line is the failure that compounds: it would
+    grow by one every run. Detection is deliberately generous (any mention
+    counts) because declining to add an import the user already has costs
+    them one manual line, while duplicating costs them a file that grows
+    forever."""
+    original = "# CLAUDE.md\n\n@AGENTS.md\n\nProject notes.\n"
+    (repo / "CLAUDE.md").write_text(original)
+
+    assert main(["init", "--path", str(repo)]) == 0
+    assert (repo / "CLAUDE.md").read_text() == original
+
+    assert main(["init", "--path", str(repo)]) == 0
+    assert (repo / "CLAUDE.md").read_text() == original
+
+
+def test_init_never_writes_into_the_git_directory(repo):
+    """`init` must not install hooks as a side effect. Writing into `.git/`
+    from a command named "init" is a surprise the user did not consent to;
+    that stays behind `install-hooks`, which they have to ask for by name."""
+    before = fingerprint(repo / ".git")
+
+    assert main(["init", "--path", str(repo)]) == 0
+
+    assert fingerprint(repo / ".git") == before
+    hooks = repo / ".git" / "hooks"
+    assert not any("codegraph" in path.read_text(errors="replace") for path in hooks.glob("*"))
+
+
+def test_init_outside_a_git_repo_still_writes_the_files(tmp_path, capsys):
+    """codegraph indexes a plain directory too (the FsTreeSource fallback),
+    and AGENTS.md is ordinary markdown -- so a missing `.git` is worth a
+    note (a mistyped `--path` is the likelier cause) but not a refusal."""
+    assert main(["init", "--path", str(tmp_path)]) == 0
+
+    assert (tmp_path / "AGENTS.md").exists()
+    captured = capsys.readouterr()
+    assert "not a git repository" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_init_on_a_missing_path_fails_with_one_line(tmp_path, capsys):
+    assert main(["init", "--path", str(tmp_path / "nope")]) == 1
+    err = capsys.readouterr().err
+    assert "not a directory" in err
+    assert len(err.strip().splitlines()) == 1
+
+
+@pytest.mark.skipif(os.getuid() == 0, reason="root ignores directory write permissions")
+def test_init_on_a_read_only_directory_reports_instead_of_crashing(repo, capsys):
+    """A repo checked out read-only (a CI cache, a mounted volume) must
+    produce a named, one-line failure per file and a nonzero exit -- not a
+    PermissionError traceback, and not a half-written AGENTS.md."""
+    repo.chmod(0o555)
+    try:
+        assert main(["init", "--path", str(repo)]) == 1
+        err = capsys.readouterr().err
+        assert "AGENTS.md" in err
+        assert "Traceback" not in err
+        assert not (repo / "AGENTS.md").exists()
+    finally:
+        repo.chmod(0o755)
+
+
+def test_the_agents_block_stays_short_enough_to_load_every_session(repo):
+    """This block is priced per turn, not per repo -- every session of every
+    AGENTS.md-reading agent pays for it. It earns that by naming the
+    commands and the trigger and then deferring to `codegraph guide`; if it
+    ever grows into a full workflow, that trade is gone."""
+    lines = AGENTS_BLOCK.splitlines()
+    assert len(lines) <= 20, f"AGENTS.md block has grown to {len(lines)} lines"
+    assert max(len(line) for line in lines) <= 80
+    assert "codegraph guide" in AGENTS_BLOCK
+
+
+def test_the_config_stub_is_inert_until_edited(repo):
+    """Every line of the stub is commented out, so dropping it into a repo
+    changes no behavior at all: it parses as an empty table, and the config
+    it loads is identical to the one loaded with no file present."""
+    assert main(["init", "--path", str(repo)]) == 0
+
+    text = (repo / CONFIG_NAME).read_text()
+    assert tomllib.loads(text) == {}
+    assert Config.load(repo) == Config()
+
+
+def test_the_config_stub_documents_every_setting_and_effect_kind(repo):
+    """The stub is the only configuration reference most people will read.
+    A kind missing from it is a kind nobody discovers, so this fails if the
+    catalog grows one and the stub is not updated."""
+    assert main(["init", "--path", str(repo)]) == 0
+
+    text = (repo / CONFIG_NAME).read_text()
+    for setting in ("source_roots", "ambiguity_limit", "[[effect]]"):
+        assert setting in text
+    for kind in EFFECT_KINDS:
+        assert kind in text, f"effect kind {kind} is undocumented in {CONFIG_NAME}"
+
+
+def test_guide_prints_the_workflow_to_stdout(capsys):
+    """The AGENTS.md block buys its brevity by pointing here, so `guide`
+    has to actually carry the detail it defers -- the resolve/impact/effects
+    workflow and the shared exit-code convention."""
+    assert main(["guide"]) == 0
+
+    out = capsys.readouterr().out
+    assert out == guide_text()
+    for expected in ("codegraph resolve", "codegraph impact", "codegraph effects", "exit-code"):
+        assert expected in out

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -50,17 +50,32 @@ def test_running_init_twice_leaves_the_repo_byte_identical(repo):
     assert (repo / "AGENTS.md").read_text().count(BEGIN_MARKER) == 1
 
 
-def test_init_appends_to_an_existing_agents_md_without_touching_its_prose(repo):
+@pytest.mark.parametrize(
+    ("prose", "gap"),
+    [
+        pytest.param("# AGENTS.md\n\nRun `make test`.\n", "\n", id="ends-with-newline"),
+        pytest.param("# AGENTS.md\n\nNo trailing newline.", "\n\n", id="no-trailing-newline"),
+        pytest.param("# AGENTS.md\n\nBlank-terminated.\n\n", "", id="ends-blank-line"),
+        pytest.param("# AGENTS.md\n\nExtra room.\n\n\n", "", id="ends-several-blank-lines"),
+    ],
+)
+def test_init_appends_to_an_existing_agents_md_without_touching_its_prose(repo, prose, gap):
     """An AGENTS.md that exists but has no codegraph block gets one
-    appended -- and every byte the user wrote survives verbatim, which is
-    the difference between a tool you run on a real repo and one you don't."""
-    prose = "# AGENTS.md\n\nRun `make test` before pushing.\nUse tabs, we're like that.\n"
+    appended, every byte the user wrote surviving verbatim, with just enough
+    newlines added to leave one blank line before the block.
+
+    Topping up rather than trimming-and-re-adding is what makes this
+    stable: "always add a blank line" would pad a file that already ended
+    in one, and grow the gap by one every time the block is removed and
+    re-added; "normalize the tail first" would quietly eat blank lines the
+    user left in their own file.
+    """
     (repo / "AGENTS.md").write_text(prose)
 
     assert main(["init", "--path", str(repo)]) == 0
 
     content = (repo / "AGENTS.md").read_text()
-    assert content.startswith(prose)
+    assert content == prose + gap + AGENTS_BLOCK
     assert content.count(BEGIN_MARKER) == 1
     assert "codegraph impact" in content
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -76,3 +76,22 @@ def _subcommands(help_text):
     # argparse lists subcommands in a {a,b,c} block.
     match = re.search(r"\{([a-z,\-]+)\}", help_text)
     return match.group(1).split(",") if match else []
+
+
+def test_skill_md_is_the_generated_form_of_the_packaged_guide():
+    """`codegraph guide` and the plugin's SKILL.md must say the same thing,
+    forever.
+
+    They are one file: `src/codegraph/guide.md` is authored, and SKILL.md is
+    that plus the skill frontmatter. It has to be the package copy that is
+    canonical, because an installed codegraph ships `src/codegraph/` and
+    nothing else -- a `guide` reading SKILL.md out of the repo would work
+    from a checkout and fail on every real install.
+
+    If this fails, you edited SKILL.md directly. Edit
+    `src/codegraph/guide.md` instead and regenerate with
+    `uv run python -m codegraph.guide`.
+    """
+    from codegraph.guide import skill_text
+
+    assert (ROOT / "skills" / "codegraph" / "SKILL.md").read_text() == skill_text()


### PR DESCRIPTION
Closes #21.

## The gap

A teammate who installs the binary still has an agent that has never heard of
codegraph, and an agent that has never heard of it greps for callers — the
exact anti-pattern this tool exists to displace. The only discovery channel
today is the Claude Code plugin. Every other harness gets nothing.

## What lands

`codegraph init [--path .]` writes three files and no more:

- **`AGENTS.md`** — a short codegraph section, created or updated in place,
  delimited by `<!-- codegraph:begin -->` / `<!-- codegraph:end -->`.
  `AGENTS.md` is the one discovery channel that is not per-vendor: 25+ tools
  read it (Codex, Cursor, Gemini CLI, Copilot's coding agent, Aider, goose,
  opencode, Zed, Windsurf, Amp, Warp, Junie, Jules, Devin, RooCode, Kilo Code,
  Factory, …) across 60k+ repositories.
- **`CLAUDE.md`** — the documented `@AGENTS.md` import, **only if that file
  already exists**. Claude Code reads `CLAUDE.md`, not `AGENTS.md`
  ([docs](https://code.claude.com/docs/en/memory)), but it is better served by
  the plugin's skill, which loads on demand rather than into every session. So
  `init` says that in its output instead of manufacturing a memory file nobody
  asked for.
- **`codegraph.toml`** — a fully commented-out stub documenting `source_roots`,
  `ambiguity_limit` and `[[effect]]` with their real defaults, written only when
  there is none. An existing config is hand-written, committed and shared; it is
  the one file here this command could only make worse.

It does **not** touch `.git/hooks/`. Warming hooks stay behind `install-hooks`.
`init` is the command someone runs before they trust the tool, and writing into
git's own directory as an unannounced side effect of "set up some markdown" is
how a tool loses that trust.

Plus `codegraph guide`, which prints the agent-facing workflow to stdout.

## The two design calls worth arguing about

**The `AGENTS.md` block is ~15 lines on purpose.** It is priced per turn, not
per repo — it loads into every session of every agent that reads the file. So
it names the three commands and the trigger, then defers to `codegraph guide`:
one cheap call, on demand. Inlining the full workflow there would be the same
mistake as an always-loaded MCP tool definition, which this project already
declined to make. A test fails if the block grows past 20 lines.

**`guide` and `SKILL.md` are one file, not two that agree.** The text is
authored at `src/codegraph/guide.md`; `SKILL.md` is that plus the skill
frontmatter, regenerated by `python -m codegraph.guide` and pinned
byte-for-byte by a test. The package copy has to be the canonical one: the
wheel ships `src/codegraph/` and nothing else, so a `guide` that read
`SKILL.md` out of the repo would work from a checkout and fail on every real
install. Same pattern as `effects/builtin.toml`.

## Marker handling is `install_hooks`' code, not a second copy of it

`_strip_existing_blocks`, `_is_marker_line` and `_MalformedMarker` move out of
`maintenance.py` into a shared `markers.py`, with the lessons intact:

- whole-line anchoring, so an `AGENTS.md` that *documents* this convention
  keeps every line between the two mentions;
- convergence on exactly one block, however many were there;
- refusing to guess a repair for markers that do not pair up.

It gains `replace_marker_blocks`, which refreshes a block **where it already
sits** rather than stripping and re-appending — a section a reader moved below
their own preamble stays there, with their prose still after it.

## Failure modes, all tested

Non-UTF-8 `AGENTS.md`, a half-deleted block, a read-only directory, a `--path`
that is not a directory, CRLF line endings, a directory with no `.git` (a note,
not a refusal — codegraph indexes plain directories too). Each is a named
one-line failure with the file left byte-identical, isolated per file the way
`plan_hooks` isolates per hook: an `init` that half-runs and stops leaves a repo
nobody can reason about.

## Proof it works on a repo that is not this one

On a clone of `psf/requests`:

```
$ codegraph init
created   AGENTS.md
unchanged CLAUDE.md -- no CLAUDE.md here, and none created on purpose: for Claude Code, install the plugin instead (`/plugin marketplace add swalla02/codegraph`) -- its skill loads on demand rather than into every session
created   codegraph.toml

$ codegraph init   # second run
unchanged AGENTS.md -- codegraph section already current
unchanged CLAUDE.md -- no CLAUDE.md here, and none created on purpose: ...
unchanged codegraph.toml -- already present; never overwritten
```

Every file in the working tree hashed identical across the two runs, and
`.git/hooks/` still holds nothing but git's own samples.

## README

Now leads with `uv tool install --python 3.12 git+https://github.com/swalla02/codegraph`
then `codegraph init`. The old lead was a local-checkout `pip install`, which on
a machine whose default interpreter is 3.11 — still the distro default nearly
everywhere — fails outright, something the docs never mentioned.

## Gates

`uv run ruff check .` clean · `uv run pytest -q` 285 passed · `uv run pytest -q -m slow` 3 passed.

Every new test was verified non-vacuous by breaking the implementation and
watching it fail: 20 mutations, 20 failures, 0 tests that shrugged.
