### PR TITLE
feat: `codegraph islands` — the graph is disconnected, and that is the answer

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,16 +110,40 @@ slower on a cold cache.
 | `codegraph resolve <name>` | Fuzzy-match a name (trailing name, qualname, or full node id) to node ids. |
 | `codegraph effects <symbol> [--json]` | Report every side-effect kind reachable from a symbol, each with a witness chain down to the causing `file:line`. |
 | `codegraph impact <symbol> [--hops N] [--limit N] [--all] [--json]` | Report the ranked dependents of a symbol — everything a change to it could break. |
+| `codegraph islands [--rev REV] [--limit N] [--json]` | Report the connected components of the revision's `CALLS` edges, read as undirected: how many separate regions the codebase is in, how big each is, and which symbols anchor them. Structure only — an island of one is *not* a dead-code finding (see below). |
 | `codegraph diff [<base>..<head>] [--json]` | Report what changed between two revisions by content hash, never by line number: symbols added/removed/changed, plus any side effect newly reachable. Defaults to `merge-base(default branch, HEAD)..WORKTREE` — "what has this branch changed so far." |
 | `codegraph gc [--keep REV]` | Prune the Layer 1 parse cache down to what `HEAD`, the worktree, and any `--keep`-named revisions still reference. Never touches the graph itself, so it can only make a future answer slower to rebuild, never wrong. |
 | `codegraph init` | Make this repository's coding agents aware of codegraph: an `AGENTS.md` section, the `@AGENTS.md` bridge into an existing `CLAUDE.md`, and a commented `codegraph.toml` stub. Idempotent; never overwrites content it did not write; never touches `.git/`. |
 | `codegraph guide` | Print the agent-facing workflow to stdout — the same text the plugin ships as `SKILL.md`, so the short `AGENTS.md` section can defer to it rather than inline it. |
 | `codegraph install-hooks` | Install `post-commit`/`post-checkout`/`post-merge` git hooks that warm the cache in the background. Purely an optimization — every query reconciles the working tree itself regardless (see below), so results are identical whether or not a hook ever fires. |
 
+### What an island is, and is not
+
+`codegraph islands` treats call edges as undirected and splits the graph
+into connected components. That the call graph is *not* connected is real
+structure, not a defect: a service boundary, a config-gated region, and
+code nothing references all show up as separate islands. On psf/requests
+it reports 807 symbols in 172 islands, the biggest holding 628 of them and
+167 being islands of exactly one.
+
+It deliberately stops there. **An island is not a reachability result, and
+a one-symbol island is not dead code.** Membership comes from the call
+edges the resolver recorded, and a great deal of Python is invoked by
+mechanisms that leave no call site in the source: dunders (`__delitem__`
+runs on every `del d[k]`), decorators, framework dispatch, ABC overrides,
+packaging entry points. `AuthBase.__call__`, `BaseAdapter.__init__` and
+`CaseInsensitiveDict.__delitem__` are each an island of one on requests,
+and not one of them is unused. Read a row as "this region shares no call
+edge with that one" and nothing more; classifying *why* an island exists
+is future work, and it needs edges this graph does not record yet.
+
 `resolve`, `impact`, and `effects` share one exit-code convention for
 resolving `<symbol>` to a node id: `0` = a single unambiguous match, `1` =
 nothing matched, `2` = more than one match (every candidate is printed; pick
 the right one and re-run with the full node id).
+
+`islands` takes no symbol, so that convention does not apply to it: it
+exits `0` for a report and `1` only for a revision it cannot resolve.
 
 All commands accept `--path <dir>` to run against a different repository
 root (default: the current directory).

--- a/skills/codegraph/SKILL.md
+++ b/skills/codegraph/SKILL.md
@@ -56,15 +56,35 @@ Reach for codegraph:
    result sets are truncated with a `truncated` flag rather than dumped in
    full.
 
+`codegraph islands` answers a question the other commands cannot: the
+global shape of the graph. It splits the revision's `CALLS` edges, read as
+**undirected**, into connected components — an *island* is a set of symbols
+that share some call relationship, in either direction and however
+indirect, with each other and with nothing outside it. It takes no symbol,
+so the exit-code convention above does not apply to it: `0` for a report
+(including on a repository with no Python in it), `1` only for a bad
+`--rev`.
+
+**An island is not a reachability result, and a one-symbol island is not
+dead code.** It is computed from the call edges the resolver recorded, and
+plenty of code is invoked by a mechanism that leaves no call site in the
+source at all: dunders (`__delitem__` runs on every `del d[k]`),
+decorators, framework dispatch, ABC overrides, packaging entry points. On
+psf/requests, `AuthBase.__call__`, `BaseAdapter.__init__` and
+`CaseInsensitiveDict.__delitem__` are each an island of one and none of
+them is unused. Read an island as "this region shares no call edge with
+that one", never as "nothing uses this".
+
 `codegraph diff [<base>..<head>]` reports what a branch actually changed —
 symbols added/removed/changed by content hash (never by line number) plus
 any side effect that newly became reachable. With no argument it diffs
 `merge-base(default branch, HEAD)` against the worktree, which is what you
 want when asked "what did this branch change".
 
-All of `resolve`, `impact`, `effects`, and `diff` accept `--path <dir>` to
-run against a different repository root, and `impact`/`effects`/`diff` accept
-`--json` for machine-readable output instead of the default text.
+All of `resolve`, `impact`, `effects`, `islands`, and `diff` accept
+`--path <dir>` to run against a different repository root, and
+`impact`/`effects`/`islands`/`diff` accept `--json` for machine-readable
+output instead of the default text.
 
 ## The anti-pattern this displaces
 
@@ -108,6 +128,24 @@ the full set and how confident it is in each edge.
   — `HIGH`/`MEDIUM`/`LOW` reflects how certain the resolver is that the call
   really targets this symbol (e.g. a dynamic dispatch site is weaker
   evidence than a direct, unambiguous call).
+- `islands`' summary reads `symbols: 807 · islands: 172 · largest: 628 ·
+  singletons: 167 · basis: undirected CALLS edges` (the real figures for
+  psf/requests). `symbols` excludes the synthetic `path::<module>` node
+  each file gets: those carry connectivity — a module-scope call is
+  sometimes the only thing tying a helper to the rest of the graph — but
+  they are not symbols anyone wrote, so they are never members and never
+  rows. `INHERITS` edges deliberately do not join an island, which keeps a
+  symbol's island exactly equal to the set of nodes an unlimited-hop
+  `impact` or `effects` walk could reach.
+- An `islands` row summarizes a whole component rather than listing it:
+  its `id` and `location` are the island's most-called member, and
+  `detail` reads `size N across M files; also <two more members>`. Islands
+  of exactly one are collected into a single `singletons` group — one
+  group of 167 rows on psf/requests, not 167 groups of one — and each such
+  row's `detail` reads `size 1, no resolved call in either direction`,
+  which is a statement about the recorded edges and not about the symbol.
+  `--limit N` (default 20) is a total budget across both groups, islands
+  first, exactly as `impact` budgets dependents ahead of tests.
 - Each `effects` row's `detail` reads `<KIND> <CONFIDENCE> via <chain>` —
   the chain is the call path from the queried symbol down to the concrete
   call site; `location` is that call site's `file:line`, clickable evidence

--- a/src/codegraph/cli.py
+++ b/src/codegraph/cli.py
@@ -14,6 +14,7 @@ from codegraph.maintenance import gc, plan_hooks
 from codegraph.query.diff import MissingRevisionError, diff_report
 from codegraph.query.effects import effects_report
 from codegraph.query.impact import impact_report
+from codegraph.query.islands import islands_report
 from codegraph.render import render_json, render_text
 from codegraph.resolve import find_symbol
 from codegraph.store import WORKTREE, Store
@@ -164,6 +165,31 @@ def _cmd_impact(args: argparse.Namespace) -> int:
             limit=args.limit,
             include_low=args.all,
         )
+        print(render_json(report) if args.json else render_text(report))
+        return 0
+    finally:
+        store.close()
+
+
+def _cmd_islands(args: argparse.Namespace) -> int:
+    """Report the connected components of the revision's call graph.
+
+    Takes no symbol, so the `0`/`1`/`2` exit convention `resolve`,
+    `impact` and `effects` share -- which is entirely about resolving a
+    name to one node id -- has nothing to resolve and cannot apply. This
+    command exits `0` on a report (an empty repository included: "no
+    symbols" is a real answer, not a failure) and `1` only on a bad
+    `--rev`, matching `status`/`index`.
+    """
+    root = Path(args.path).resolve()
+    store, indexer = open_workspace(root)
+    try:
+        try:
+            indexer.reconcile(args.rev)
+        except gitio.GitError:
+            print(f"revision not found: {args.rev}", file=sys.stderr)
+            return 1
+        report = islands_report(store, args.rev, limit=args.limit)
         print(render_json(report) if args.json else render_text(report))
         return 0
     finally:
@@ -351,6 +377,29 @@ def build_parser() -> argparse.ArgumentParser:
     )
     impact_parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
     impact_parser.set_defaults(handler=_cmd_impact)
+
+    islands_parser = subparsers.add_parser(
+        "islands",
+        help="Report the connected components of the call graph",
+        description=(
+            "Split the revision's CALLS edges, read as undirected, into connected"
+            " components. An island is a set of symbols that share some call"
+            " relationship with each other and none with anything outside it. It is"
+            " NOT a reachability result: a one-symbol island is not dead code, only a"
+            " symbol whose calls in or out the resolver did not record -- dunders,"
+            " decorators, framework dispatch and entry points leave no call site."
+        ),
+    )
+    islands_parser.add_argument("--path", default=".", help="Repository root (default: cwd)")
+    islands_parser.add_argument("--rev", default=WORKTREE, help="Revision to query")
+    islands_parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Maximum rows to keep, total across islands and singletons (default: 20)",
+    )
+    islands_parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    islands_parser.set_defaults(handler=_cmd_islands)
 
     diff_parser = subparsers.add_parser(
         "diff", help="Report what changed between two revisions"

--- a/src/codegraph/guide.md
+++ b/src/codegraph/guide.md
@@ -51,15 +51,35 @@ Reach for codegraph:
    result sets are truncated with a `truncated` flag rather than dumped in
    full.
 
+`codegraph islands` answers a question the other commands cannot: the
+global shape of the graph. It splits the revision's `CALLS` edges, read as
+**undirected**, into connected components — an *island* is a set of symbols
+that share some call relationship, in either direction and however
+indirect, with each other and with nothing outside it. It takes no symbol,
+so the exit-code convention above does not apply to it: `0` for a report
+(including on a repository with no Python in it), `1` only for a bad
+`--rev`.
+
+**An island is not a reachability result, and a one-symbol island is not
+dead code.** It is computed from the call edges the resolver recorded, and
+plenty of code is invoked by a mechanism that leaves no call site in the
+source at all: dunders (`__delitem__` runs on every `del d[k]`),
+decorators, framework dispatch, ABC overrides, packaging entry points. On
+psf/requests, `AuthBase.__call__`, `BaseAdapter.__init__` and
+`CaseInsensitiveDict.__delitem__` are each an island of one and none of
+them is unused. Read an island as "this region shares no call edge with
+that one", never as "nothing uses this".
+
 `codegraph diff [<base>..<head>]` reports what a branch actually changed —
 symbols added/removed/changed by content hash (never by line number) plus
 any side effect that newly became reachable. With no argument it diffs
 `merge-base(default branch, HEAD)` against the worktree, which is what you
 want when asked "what did this branch change".
 
-All of `resolve`, `impact`, `effects`, and `diff` accept `--path <dir>` to
-run against a different repository root, and `impact`/`effects`/`diff` accept
-`--json` for machine-readable output instead of the default text.
+All of `resolve`, `impact`, `effects`, `islands`, and `diff` accept
+`--path <dir>` to run against a different repository root, and
+`impact`/`effects`/`islands`/`diff` accept `--json` for machine-readable
+output instead of the default text.
 
 ## The anti-pattern this displaces
 
@@ -103,6 +123,24 @@ the full set and how confident it is in each edge.
   — `HIGH`/`MEDIUM`/`LOW` reflects how certain the resolver is that the call
   really targets this symbol (e.g. a dynamic dispatch site is weaker
   evidence than a direct, unambiguous call).
+- `islands`' summary reads `symbols: 807 · islands: 172 · largest: 628 ·
+  singletons: 167 · basis: undirected CALLS edges` (the real figures for
+  psf/requests). `symbols` excludes the synthetic `path::<module>` node
+  each file gets: those carry connectivity — a module-scope call is
+  sometimes the only thing tying a helper to the rest of the graph — but
+  they are not symbols anyone wrote, so they are never members and never
+  rows. `INHERITS` edges deliberately do not join an island, which keeps a
+  symbol's island exactly equal to the set of nodes an unlimited-hop
+  `impact` or `effects` walk could reach.
+- An `islands` row summarizes a whole component rather than listing it:
+  its `id` and `location` are the island's most-called member, and
+  `detail` reads `size N across M files; also <two more members>`. Islands
+  of exactly one are collected into a single `singletons` group — one
+  group of 167 rows on psf/requests, not 167 groups of one — and each such
+  row's `detail` reads `size 1, no resolved call in either direction`,
+  which is a statement about the recorded edges and not about the symbol.
+  `--limit N` (default 20) is a total budget across both groups, islands
+  first, exactly as `impact` budgets dependents ahead of tests.
 - Each `effects` row's `detail` reads `<KIND> <CONFIDENCE> via <chain>` —
   the chain is the call path from the queried symbol down to the concrete
   call site; `location` is that call site's `file:line`, clickable evidence

--- a/src/codegraph/query/islands.py
+++ b/src/codegraph/query/islands.py
@@ -1,0 +1,215 @@
+"""The `islands` report: the revision's call graph split into connected
+components, treated as undirected.
+
+`impact` and `effects` are node-local -- "who calls X", "what can X reach".
+Neither says anything about the graph's global shape, and that shape is
+real information: the call graph is not connected, and the disconnection
+is structure rather than a defect. A service boundary, a config-gated
+region and genuinely unreferenced code all show up as separate components.
+An **island** is one such component: a set of symbols that share some call
+relationship, however indirect, with each other and none at all with
+anything outside it.
+
+**An island is not a reachability claim, and a one-symbol island is not a
+dead-code finding.** Membership is computed from the call edges the
+resolver actually recorded, and a symbol can be invoked by a mechanism
+that leaves no call site anywhere in the source: a dunder (`__delitem__`
+runs on every `del d[k]`), a decorator, framework dispatch, an ABC
+override, a packaging entry point. On psf/requests
+`src/requests/auth.py::AuthBase.__call__`,
+`src/requests/adapters.py::BaseAdapter.__init__` and
+`src/requests/structures.py::CaseInsensitiveDict.__delitem__` are each an
+island of exactly one, and not one of them is unused. This report says
+where the graph comes apart; *why* a given island exists is issue #27's
+stage 2, and it needs edges this graph does not record yet.
+
+Three deliberate calls here, each of which moves the numbers:
+
+*Undirected.* `A -> B` and `B -> A` put A and B on the same island. That
+is what the word means here -- a region sharing no call relationship of
+any direction with another region. A directed notion (strongly connected
+components) would answer a different and much narrower question: almost
+every acyclic caller/callee pair would become its own component.
+
+*CALLS only -- `INHERITS` edges do not join an island.* An island is
+meant to bound what `impact` and `effects` can ever say about a symbol,
+and both of those walk CALLS and only CALLS. So a symbol's island is
+exactly the set of nodes an unlimited-hop `impact` or `effects` walk could
+ever touch, which is a property a reader can check. Folding INHERITS in
+would break that correspondence: measured on psf/requests it merges 172
+islands down to 156, so 16 boundaries would be reported as crossed by a
+walk that cannot in fact cross them. Subclasses and their bases are of
+course coupled -- `INHERITS` exists so the resolver can do method
+resolution, and the coupling reaches `impact` through the CALLS edges that
+resolution produces, which is where it belongs.
+
+*Synthetic `path::<module>` nodes connect islands but are never members.*
+Their edges are real: a module-scope call (`_init()` at the foot of
+`status_codes.py`) is the only thing tying that file's helper to the rest
+of the graph, and ignoring those 8 edges on psf/requests splits it into
+174 islands instead of 172. But `path::<module>` is not a symbol anyone
+wrote, and counting one per file would invent 32 further islands on
+requests out of files whose top level simply calls nothing. So module
+nodes carry connectivity and are excluded from `symbols`, from island
+sizes, and from the rows.
+
+Counting them as members instead is exactly what #27's headline figures
+do, which is the whole of the difference from them: its largest island of
+631 is this report's 628 plus `setup.py::<module>`,
+`src/requests/help.py::<module>` and
+`src/requests/status_codes.py::<module>`, and its 166 singletons are this
+report's 167 minus `src/requests/compat.py::_resolve_char_detection`,
+whose only caller is its own module scope and which is therefore a pair
+rather than a singleton once the module node counts. The island count,
+172, is identical under both rules.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from codegraph.render import Group, Report, Row, budget
+from codegraph.store import Store
+
+#: How many of an island's members a single row names: the row's `id` is
+#: the first, `detail` names the rest. An island can hold hundreds of
+#: symbols (628 of psf/requests' 807 sit on one), so a row summarizes
+#: rather than dumps -- and the ones worth naming are the hubs, the
+#: members with the most distinct callers inside the graph.
+_HUBS_PER_ROW = 3
+
+
+class _Components:
+    """Union-find over node ids, growing its node set on demand.
+
+    Ids are added as they are seen rather than pre-seeded, so an edge
+    endpoint with no `nodes` row (which `impact.py` also guards against)
+    still joins the two sides it connects instead of being dropped and
+    silently splitting an island in two.
+    """
+
+    def __init__(self) -> None:
+        self._parent: dict[str, str] = {}
+
+    def find(self, node_id: str) -> str:
+        parent = self._parent
+        root = parent.setdefault(node_id, node_id)
+        while root != parent[root]:
+            parent[root] = parent[parent[root]]
+            root = parent[root]
+        return root
+
+    def union(self, left: str, right: str) -> None:
+        left_root, right_root = self.find(left), self.find(right)
+        if left_root != right_root:
+            self._parent[left_root] = right_root
+
+
+def _plural(count: int, noun: str) -> str:
+    return f"{count} {noun}" if count == 1 else f"{count} {noun}s"
+
+
+def islands_report(store: Store, rev: str, limit: int = 20) -> Report:
+    """Connected components of `rev`'s CALLS edges, read as undirected.
+
+    Two queries and one pass over the edges, never a query per node: on a
+    2,930-file repository this walks ~395k edge rows, and a per-node
+    lookup in that loop would be the whole cost of the command.
+    """
+    connection = store.connection
+
+    members: dict[str, tuple[str, int]] = {}
+    for row in connection.execute(
+        "SELECT id, path, kind, line_start FROM nodes WHERE rev=?", (rev,)
+    ):
+        if row["kind"] == "module":
+            continue
+        members[row["id"]] = (row["path"], row["line_start"])
+
+    # Distinct (src, dst) pairs, never raw edge rows: the same call written
+    # twice in a body, or one candidate reached through two import aliases,
+    # writes two rows for one relationship and would inflate the fan-in
+    # that picks each island's hubs (see rank.fan_in for the same care).
+    components = _Components()
+    pairs: set[tuple[str, str]] = set()
+    for row in connection.execute(
+        "SELECT src, dst FROM edges WHERE rev=? AND kind='CALLS'", (rev,)
+    ):
+        pairs.add((row["src"], row["dst"]))
+    for src, dst in pairs:
+        components.union(src, dst)
+    fan_in = Counter(dst for _, dst in pairs)
+
+    grouped: dict[str, list[str]] = {}
+    for node_id in members:
+        grouped.setdefault(components.find(node_id), []).append(node_id)
+
+    island_rows: list[Row] = []
+    singleton_rows: list[Row] = []
+    largest = 0
+    for island in grouped.values():
+        size = len(island)
+        largest = max(largest, size)
+        # Hubs first, then id, so a tie between two never-called members
+        # (every member of a singleton or a mutually-recursive pair) still
+        # produces the same row on every run.
+        island.sort(key=lambda node_id: (-fan_in[node_id], node_id))
+        head, *rest = island
+        path, line_start = members[head]
+
+        if size == 1:
+            # Deliberately phrased as a statement about the recorded edges,
+            # not about the symbol: "nothing calls it" is a claim this
+            # graph cannot make (see the module docstring).
+            detail = "size 1, no resolved call in either direction"
+        else:
+            files = len({members[node_id][0] for node_id in island})
+            detail = f"size {size} across {_plural(files, 'file')}"
+            named = rest[: _HUBS_PER_ROW - 1]
+            if named:
+                detail += f"; also {', '.join(named)}"
+
+        row = Row(
+            id=head,
+            location=f"{path}:{line_start}",
+            detail=detail,
+            score=float(size),
+        )
+        (singleton_rows if size == 1 else island_rows).append(row)
+
+    # `budget` sorts by score (the island size) and is stable, so ordering
+    # the rows here is what decides ties -- and every one of the 167
+    # singletons on psf/requests is a tie. Without this the printed rows
+    # would be in whatever order SQLite handed back the `nodes` rows,
+    # which is stable for one database file and not a contract across a
+    # rebuild; two runs of the same command should print the same report.
+    island_rows.sort(key=lambda row: (-row.score, row.id))
+    singleton_rows.sort(key=lambda row: row.id)
+
+    # `limit` is a TOTAL budget across both groups, the same contract
+    # `impact` uses for dependents and tests: multi-symbol islands are the
+    # structural finding and get first claim, and the long singleton tail
+    # (167 of psf/requests' 172 islands) budgets whatever is left rather
+    # than crowding them out.
+    kept, truncated = budget(island_rows, limit)
+    groups = [Group("islands", kept)] if kept else []
+    if singleton_rows:
+        kept_singletons, singletons_truncated = budget(singleton_rows, limit - len(kept))
+        if kept_singletons:
+            groups.append(Group("singletons", kept_singletons))
+        truncated = truncated or singletons_truncated
+
+    summary = {
+        "symbols": len(members),
+        "islands": len(grouped),
+        "largest": largest,
+        "singletons": len(singleton_rows),
+        # Says what the partition was computed from, so a row is read as
+        # "these share no call edge" and never as "nothing reaches this".
+        "basis": "undirected CALLS edges",
+    }
+
+    return Report(summary=summary, groups=groups, truncated=truncated)
+
+
+__all__ = ["islands_report"]

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -59,6 +59,12 @@ def test_impact_with_bad_rev_reports_cleanly(repo, capsys):
     assert err.strip() == "revision not found: nosuchrev"
 
 
+def test_islands_with_bad_rev_reports_cleanly(repo, capsys):
+    assert main(["islands", "--path", str(repo), "--rev", "nosuchrev"]) == 1
+    err = capsys.readouterr().err
+    assert err.strip() == "revision not found: nosuchrev"
+
+
 def test_install_hooks_outside_git_repo_reports_cleanly(tmp_path, capsys):
     assert main(["install-hooks", "--path", str(tmp_path)]) == 1
     err = capsys.readouterr().err

--- a/tests/test_islands.py
+++ b/tests/test_islands.py
@@ -1,0 +1,275 @@
+import json
+
+from codegraph.cli import main
+from codegraph.indexer import GitTreeSource, Indexer
+from codegraph.query.islands import islands_report
+from codegraph.store import Store
+from tests.conftest import git
+
+
+def build(repo):
+    store = Store.open(repo)
+    Indexer(repo, store, GitTreeSource(repo)).reconcile("HEAD")
+    return store
+
+
+def rows(report, title):
+    return [row for group in report.groups if group.title == title for row in group.rows]
+
+
+def named_ids(row):
+    """The node ids one row names: its `id`, plus any further members its
+    `detail` lists after '; also '."""
+    _, _, tail = row.detail.partition("; also ")
+    return [row.id, *(part for part in tail.split(", ") if part)]
+
+
+def named(report):
+    """Every node id a report mentions -- an island of N members is
+    summarized by one row rather than N rows, so this flattens the rows
+    back out to the ids they name."""
+    return {node_id for group in report.groups for row in group.rows for node_id in named_ids(row)}
+
+
+def test_a_fully_connected_call_graph_is_one_island(repo, write):
+    """The base case the whole report is a generalization of: if every
+    symbol is reachable from every other through call edges, there is
+    exactly one island and it holds all of them."""
+    write(
+        "a.py",
+        "def alpha():\n    beta()\n\n\ndef beta():\n    gamma()\n\n\ndef gamma():\n    pass\n",
+        commit="chain",
+    )
+    store = build(repo)
+    report = islands_report(store, "HEAD")
+    assert report.summary == {
+        "symbols": 3,
+        "islands": 1,
+        "largest": 3,
+        "singletons": 0,
+        "basis": "undirected CALLS edges",
+    }
+    store.close()
+
+
+def test_two_separate_call_clusters_are_two_islands(repo, write):
+    """Two call clusters with no edge between them must stay apart. This is
+    the finding the command exists for -- a partition that merged them
+    would report a codebase as one connected region when it is not."""
+    write(
+        "a.py",
+        "def left_top():\n    left_leaf()\n\n\ndef left_leaf():\n    pass\n\n\n"
+        "def right_top():\n    right_leaf()\n\n\ndef right_leaf():\n    pass\n",
+        commit="two clusters",
+    )
+    store = build(repo)
+    report = islands_report(store, "HEAD")
+    assert report.summary["islands"] == 2
+    assert report.summary["largest"] == 2
+    assert report.summary["singletons"] == 0
+
+    listed = [set(named_ids(row)) for row in rows(report, "islands")]
+    assert {"a.py::left_top", "a.py::left_leaf"} in listed
+    assert {"a.py::right_top", "a.py::right_leaf"} in listed
+    store.close()
+
+
+def test_a_symbol_with_no_call_in_or_out_is_its_own_island(repo, write):
+    """A symbol the resolver linked to nothing in either direction is an
+    island of one, reported in the `singletons` group rather than as a
+    one-row island group of its own."""
+    write(
+        "a.py",
+        "def linked_top():\n    linked_leaf()\n\n\ndef linked_leaf():\n    pass\n\n\n"
+        "def lonely():\n    pass\n",
+        commit="one lonely",
+    )
+    store = build(repo)
+    report = islands_report(store, "HEAD")
+    assert report.summary["islands"] == 2
+    assert report.summary["singletons"] == 1
+    assert [row.id for row in rows(report, "singletons")] == ["a.py::lonely"]
+    store.close()
+
+
+def test_island_membership_does_not_depend_on_call_direction(repo, write):
+    """`A -> B` and `B -> A` must produce the same partition: an island is
+    a region sharing no call relationship of *any* direction, so the
+    traversal reads CALLS edges undirected. A directed walk would report
+    the mirrored graph differently from the original."""
+    write("a.py", "def one():\n    two()\n\n\ndef two():\n    pass\n", commit="forward")
+    store = build(repo)
+    forward = islands_report(store, "HEAD")
+    store.close()
+
+    write("a.py", "def one():\n    pass\n\n\ndef two():\n    one()\n", commit="reversed")
+    store = build(repo)
+    reversed_report = islands_report(store, "HEAD")
+
+    assert forward.summary["islands"] == reversed_report.summary["islands"] == 1
+    assert named(forward) == named(reversed_report) == {"a.py::one", "a.py::two"}
+    store.close()
+
+
+def test_symbols_joined_only_through_a_shared_callee_are_one_island(repo, write):
+    """Two callers of one helper are one island even though neither can
+    reach the other by following calls forward. Sharing a callee is a call
+    relationship; only an undirected traversal sees it."""
+    write(
+        "a.py",
+        "def first():\n    helper()\n\n\ndef second():\n    helper()\n\n\ndef helper():\n    pass\n",
+        commit="shared callee",
+    )
+    store = build(repo)
+    report = islands_report(store, "HEAD")
+    assert report.summary["islands"] == 1
+    assert report.summary["largest"] == 3
+    store.close()
+
+
+def test_a_repo_with_no_python_files_reports_no_islands(repo, write):
+    """An empty graph is a real answer, not a crash and not a division by
+    zero on `largest`: zero symbols, zero islands, and no groups at all."""
+    git(repo, "rm", "-q", "a.py")
+    git(repo, "commit", "-qm", "drop the only module")
+    store = build(repo)
+    report = islands_report(store, "HEAD")
+    assert report.summary == {
+        "symbols": 0,
+        "islands": 0,
+        "largest": 0,
+        "singletons": 0,
+        "basis": "undirected CALLS edges",
+    }
+    assert report.groups == []
+    assert report.truncated is False
+    store.close()
+
+
+def test_a_repo_where_every_symbol_is_a_singleton(repo, write):
+    """The degenerate opposite of one big island: N symbols, N islands, no
+    `islands` group at all. The singleton tail is one group of N rows and
+    never N groups of one row -- 167 headings reading `island` on
+    psf/requests would be noise, not structure."""
+    write(
+        "a.py",
+        "".join(f"def solo_{index}():\n    pass\n\n\n" for index in range(5)),
+        commit="five singletons",
+    )
+    store = build(repo)
+    report = islands_report(store, "HEAD")
+    assert report.summary["symbols"] == 5
+    assert report.summary["islands"] == 5
+    assert report.summary["singletons"] == 5
+    assert report.summary["largest"] == 1
+    assert [group.title for group in report.groups] == ["singletons"]
+    assert len(rows(report, "singletons")) == 5
+    store.close()
+
+
+def test_a_module_scope_call_joins_the_symbols_it_links(repo, write):
+    """The synthetic `path::<module>` node carries connectivity even though
+    it is never a member: two functions called only from module scope share
+    an island through it. Dropping those edges would split psf/requests
+    into 174 islands instead of 172."""
+    write(
+        "a.py",
+        "def first():\n    pass\n\n\ndef second():\n    pass\n\n\nfirst()\nsecond()\n",
+        commit="module scope calls",
+    )
+    store = build(repo)
+    report = islands_report(store, "HEAD")
+    assert report.summary["islands"] == 1
+    assert report.summary["largest"] == 2
+    store.close()
+
+
+def test_module_nodes_are_never_reported_as_symbols(repo, write):
+    """`a.py::<module>` is synthetic, not something anyone wrote, so it is
+    excluded from `symbols`, from island sizes and from every row. Counting
+    them would invent one island per file whose top level calls nothing --
+    32 of them on psf/requests."""
+    write("a.py", "def only():\n    pass\n", commit="one symbol")
+    store = build(repo)
+    report = islands_report(store, "HEAD")
+    assert report.summary["symbols"] == 1
+    assert not any("<module>" in node_id for node_id in named(report))
+    store.close()
+
+
+def test_inherits_edges_do_not_join_an_island(repo, write):
+    """A subclass and its base are separate islands unless a call links
+    them. An island bounds what `impact` and `effects` can say about a
+    symbol, and both walk CALLS only -- folding INHERITS in would merge
+    psf/requests' 172 islands to 156, claiming boundaries are crossed by a
+    walk that cannot cross them."""
+    write(
+        "a.py",
+        "class Base:\n    def shared(self):\n        pass\n\n\n"
+        "class Child(Base):\n    def other(self):\n        pass\n",
+        commit="inheritance only",
+    )
+    store = build(repo)
+    inherits = store.connection.execute(
+        "SELECT COUNT(*) AS n FROM edges WHERE rev='HEAD' AND kind='INHERITS'"
+    ).fetchone()["n"]
+    assert inherits >= 1  # the edge exists; the report must still not use it
+    report = islands_report(store, "HEAD")
+    assert report.summary["islands"] == 4
+    assert report.summary["singletons"] == 4
+    store.close()
+
+
+def test_limit_is_a_total_budget_and_islands_outrank_singletons(repo, write):
+    """`--limit N` caps rows across both groups combined, the contract
+    `impact` already documents. Multi-symbol islands take the budget first:
+    the long singleton tail must never crowd out the structural finding."""
+    write(
+        "a.py",
+        "def top():\n    leaf()\n\n\ndef leaf():\n    pass\n\n\n"
+        + "".join(f"def solo_{index}():\n    pass\n\n\n" for index in range(5)),
+        commit="one island and five singletons",
+    )
+    store = build(repo)
+    report = islands_report(store, "HEAD", limit=3)
+    assert report.truncated is True
+    assert len(rows(report, "islands")) == 1
+    assert len(rows(report, "singletons")) == 2
+    store.close()
+
+
+def test_singleton_rows_do_not_claim_the_symbol_is_unused(repo, write):
+    """Issue #27 records why 'nothing calls this' is unsound today: a
+    dunder, a decorator, framework dispatch or an entry point invokes a
+    symbol with no call site anywhere in the source. A singleton row must
+    therefore describe the recorded edges, never the symbol's fate."""
+    write("a.py", "class Thing:\n    def __delitem__(self, key):\n        pass\n", commit="dunder")
+    store = build(repo)
+    report = islands_report(store, "HEAD")
+    details = {row.detail for row in rows(report, "singletons")}
+    assert details == {"size 1, no resolved call in either direction"}
+    text = " ".join(details).lower()
+    assert "dead" not in text
+    assert "unused" not in text
+    assert "unreachable" not in text
+    store.close()
+
+
+def test_islands_command_reports_and_exits_zero(repo, write, capsys):
+    """`islands` takes no symbol, so the 0/1/2 exit convention `resolve`,
+    `impact` and `effects` share for resolving a name cannot apply: a
+    report is always exit 0."""
+    write("a.py", "def top():\n    leaf()\n\n\ndef leaf():\n    pass\n", commit="m")
+    assert main(["islands", "--path", str(repo)]) == 0
+    out = capsys.readouterr().out
+    assert out.startswith("symbols: 2 · islands: 1 · largest: 2 · singletons: 0 ·")
+
+
+def test_islands_json_output_is_machine_readable(repo, write, capsys):
+    """`--json` goes through the same `Report` the text renderer takes, so
+    the summary keys are identical in both -- no second output format."""
+    write("a.py", "def top():\n    leaf()\n\n\ndef leaf():\n    pass\n", commit="m")
+    assert main(["islands", "--path", str(repo), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"]["islands"] == 1
+    assert payload["groups"][0]["title"] == "islands"


### PR DESCRIPTION
Stage 1 of #27, and only stage 1. Classifying *why* an island exists is
stage 2 and needs the `__init__` edge fix first, so this leaves #27 open.

Every query codegraph has today is node-local — "who calls X", "what can
X reach". Neither says anything about how the graph comes apart, and it
does come apart: psf/requests' 807 symbols sit in 172 separate
components. `codegraph islands` reports that shape.

```
$ codegraph islands --path bench/requests
symbols: 807 · islands: 172 · largest: 628 · singletons: 167 · basis: undirected CALLS edges
islands
  tests/conftest.py::httpbin  tests/conftest.py:35  size 628 across 25 files; also src/requests/api.py::get, src/requests/cookies.py::RequestsCookieJar.get
  src/requests/cookies.py::MockRequest.get_host  src/requests/cookies.py:54  size 4 across 1 file; also src/requests/cookies.py::MockRequest.get_origin_req_host, src/requests/cookies.py::MockRequest.host
  src/requests/utils.py::get_encodings_from_content  src/requests/utils.py:522  size 4 across 2 files; also tests/test_utils.py::TestContentEncodingDetection.test_none, tests/test_utils.py::TestContentEncodingDetection.test_pragmas
  src/requests/__init__.py::_check_cryptography  src/requests/__init__.py:99  size 2 across 1 file; also src/requests/__init__.py::check_compatibility
  src/requests/cookies.py::MockRequest.is_unverifiable  src/requests/cookies.py:80  size 2 across 1 file; also src/requests/cookies.py::MockRequest.unverifiable
singletons
  docs/_themes/flask_theme_support.py::FlaskyStyle  docs/_themes/flask_theme_support.py:7  size 1, no resolved call in either direction
  src/requests/_types.py::BaseRequestKwargs  src/requests/_types.py:157  size 1, no resolved call in either direction
  ... 13 more of the 167
```

## What it deliberately does not say

Issue #27 records exactly why "island of one" cannot be read as dead code
today: `AuthBase.__call__`, `BaseAdapter.__init__` and
`CaseInsensitiveDict.__delitem__` are all singletons on requests and not
one of them is unused — they are invoked by mechanisms that never appear
as a call site. So no row, group title or summary field here makes a
reachability claim. A singleton's `detail` reads `size 1, no resolved
call in either direction`, which is a statement about the recorded edges
and not about the symbol's fate, and README/`guide.md` both say plainly
what an island is and is not.

## Three design calls, each of which moves the numbers

- **Undirected.** `A -> B` and `B -> A` land on the same island; that is
  what the word means here. A directed (strongly-connected) reading would
  make almost every acyclic caller/callee pair its own component.
- **CALLS only — `INHERITS` does not join an island.** An island is meant
  to bound what `impact`/`effects` can ever say about a symbol, and both
  walk CALLS only, so a symbol's island is exactly the set of nodes an
  unlimited-hop walk could touch — a property a reader can check. Folding
  INHERITS in merges requests' 172 islands to 156, i.e. 16 boundaries
  would be reported as crossed by a walk that cannot cross them.
- **Synthetic `path::<module>` nodes connect islands but are never
  members.** Their edges are real (a module-scope `_init()` is the only
  thing tying `status_codes.py`'s helper to the graph); ignoring those 8
  edges on requests gives 174 islands instead of 172. But they are not
  symbols anyone wrote, and counting them as members invents 32 more
  islands out of files whose top level calls nothing.
- **Singletons get one group, not 166 groups of one row.** `--limit N`
  (default 20) is a total budget across `islands` and `singletons`,
  islands first — the same contract `impact` uses for dependents and
  tests.

## Difference from #27's headline figures, explained

#27 measured 807 symbols / 172 islands / largest 631 / 166 singletons.
This reports 807 / 172 / **628** / **167**. The island count is identical
and the whole difference is the module-node call above: #27 counted
`path::<module>` nodes as members.

- 631 = this report's 628 plus `setup.py::<module>`,
  `src/requests/help.py::<module>` and
  `src/requests/status_codes.py::<module>`, which sit inside the big
  island.
- 166 = this report's 167 minus
  `src/requests/compat.py::_resolve_char_detection`, whose only caller is
  its own module scope — a pair once the module node counts, a singleton
  once it does not.

Both reproduced exactly by re-running #27's rule against the same
database, so this is an accounted-for rule difference, not drift.

## Exit codes

`islands` takes no `<symbol>`, so the `0`/`1`/`2` convention `resolve`,
`impact` and `effects` share — which is entirely about resolving a name
to one node id — has nothing to resolve and cannot apply. It exits `0`
for a report (an empty repository included: "no symbols" is a real
answer) and `1` only for a bad `--rev`, matching `status`/`index`. Called
out in `guide.md` and the README rather than left implicit.

## Performance

Two queries and one union-find pass; no per-node query in the loop, and
`reconcile`'s narrowing is untouched. 0.2s on requests. On the django
clone (2,930 files, 43,684 symbols, ~395k CALLS edges) the whole command
including reconcile is **3.2s**.

## Gates

`uv run ruff check .` clean · `uv run pytest -q` 300 passed (285 before)
· `uv run pytest -q -m slow` 3 passed.

Every one of the 15 new tests was verified non-vacuous by mutating the
implementation and watching that named test fail — 14 mutations covering
all 15 (no-op union, merge-everything, drop singletons,
strongly-connected reading, always-emit-empty-group, singletons-as-island
-groups, ignore module-node edges, count module nodes, include INHERITS,
per-group limit, a `detail` claiming "unused (dead code)", exit 2,
`--json` rendering text, and dropping the `GitError` handler).
