### PR TITLE
feat: classify why an island exists, and label the ones that leave the process

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ slower on a cold cache.
 | `codegraph resolve <name>` | Fuzzy-match a name (trailing name, qualname, or full node id) to node ids. |
 | `codegraph effects <symbol> [--json]` | Report every side-effect kind reachable from a symbol, each with a witness chain down to the causing `file:line`. |
 | `codegraph impact <symbol> [--hops N] [--limit N] [--all] [--json]` | Report the ranked dependents of a symbol — everything a change to it could break. |
-| `codegraph islands [--rev REV] [--limit N] [--json]` | Report the connected components of the revision's `CALLS` edges, read as undirected: how many separate regions the codebase is in, how big each is, and which symbols anchor them. Structure only — an island of one is *not* a dead-code finding (see below). |
+| `codegraph islands [--rev REV] [--limit N] [--json]` | Report the connected components of the revision's `CALLS` edges, read as undirected: how many separate regions the codebase is in, how big each is, and which symbols anchor them, plus what the tool can say about why each one stands apart (implicit invocation, a `NETWORK` boundary, or nothing it recognises). An island of one is *not* a dead-code finding (see below). |
 | `codegraph diff [<base>..<head>] [--json]` | Report what changed between two revisions by content hash, never by line number: symbols added/removed/changed, plus any side effect newly reachable. Defaults to `merge-base(default branch, HEAD)..WORKTREE` — "what has this branch changed so far." |
 | `codegraph gc [--keep REV]` | Prune the Layer 1 parse cache down to what `HEAD`, the worktree, and any `--keep`-named revisions still reference. Never touches the graph itself, so it can only make a future answer slower to rebuild, never wrong. |
 | `codegraph init` | Make this repository's coding agents aware of codegraph: an `AGENTS.md` section, the `@AGENTS.md` bridge into an existing `CLAUDE.md`, and a commented `codegraph.toml` stub. Idempotent; never overwrites content it did not write; never touches `.git/`. |
@@ -123,19 +123,43 @@ slower on a cold cache.
 into connected components. That the call graph is *not* connected is real
 structure, not a defect: a service boundary, a config-gated region, and
 code nothing references all show up as separate islands. On psf/requests
-it reports 807 symbols in 172 islands, the biggest holding 628 of them and
-167 being islands of exactly one.
+it reports 807 symbols in 154 islands, the biggest holding 646 of them and
+149 being islands of exactly one.
 
-It deliberately stops there. **An island is not a reachability result, and
-a one-symbol island is not dead code.** Membership comes from the call
-edges the resolver recorded, and a great deal of Python is invoked by
-mechanisms that leave no call site in the source: dunders (`__delitem__`
-runs on every `del d[k]`), decorators, framework dispatch, ABC overrides,
-packaging entry points. `AuthBase.__call__`, `BaseAdapter.__init__` and
-`CaseInsensitiveDict.__delitem__` are each an island of one on requests,
-and not one of them is unused. Read a row as "this region shares no call
-edge with that one" and nothing more; classifying *why* an island exists
-is future work, and it needs edges this graph does not record yet.
+**An island is not a reachability result, and a one-symbol island is not
+dead code.** Membership comes from the call edges the resolver recorded,
+and a great deal of Python is invoked by mechanisms that leave no call site
+in the source: dunders (`__delitem__` runs on every `del d[k]`),
+decorators, framework dispatch, ABC overrides, packaging entry points.
+`AuthBase.__call__` and `CaseInsensitiveDict.__delitem__` are each an
+island of one on requests, and neither is unused.
+
+So each island is labelled with what can be said about why it stands
+apart, and no label is ever a claim that code is dead:
+
+- **`implicit: dunder, decorator, test, override, nested, import`** — a
+  mechanism found among the island's members by which something could reach
+  it without a call site. Not proof that it runs; counter-evidence to
+  "nothing reaches this". 125 of requests' 154 islands carry at least one.
+- **`boundary: NETWORK`** — a path inside the island leaves the process.
+  The handler lives in another repository, so the island boundary *is* the
+  service boundary. That is signal, not a false positive. `NETWORK` is
+  deliberately the only effect kind that marks one: a socket call leaving
+  the process is a structural fact, whereas coupling two functions through
+  a database means reading SQL and tracking a schema, which is a different
+  tool.
+- **`no implicit-invocation mechanism recognised`** — the remainder, 29
+  islands on requests, and still a statement about the tool rather than
+  about the code. Most of them are the library's own public surface
+  (`get_dict`, `dict_from_cookiejar`), called by users of the package and
+  by the stdlib — neither of which is in the tree.
+
+One thing that moved the numbers is worth naming separately, because it was
+a plain bug rather than a limit of static analysis: `Cls()` resolves to the
+class and nothing in the source ever spells `Cls.__init__`, so constructors
+had no incoming edge at all. Implying that edge (following the MRO for an
+inherited one) folded 18 of requests' 172 islands into the rest of the
+graph.
 
 `resolve`, `impact`, and `effects` share one exit-code convention for
 resolving `<symbol>` to a node id: `0` = a single unambiguous match, `1` =

--- a/skills/codegraph/SKILL.md
+++ b/skills/codegraph/SKILL.md
@@ -70,10 +70,28 @@ dead code.** It is computed from the call edges the resolver recorded, and
 plenty of code is invoked by a mechanism that leaves no call site in the
 source at all: dunders (`__delitem__` runs on every `del d[k]`),
 decorators, framework dispatch, ABC overrides, packaging entry points. On
-psf/requests, `AuthBase.__call__`, `BaseAdapter.__init__` and
-`CaseInsensitiveDict.__delitem__` are each an island of one and none of
-them is unused. Read an island as "this region shares no call edge with
-that one", never as "nothing uses this".
+psf/requests, `AuthBase.__call__` and `CaseInsensitiveDict.__delitem__` are
+each an island of one and neither is unused. Read an island as "this region
+shares no call edge with that one", never as "nothing uses this".
+
+Every island is therefore labelled with what codegraph can say about why it
+stands apart, and each row carries the label:
+
+- `implicit: dunder, decorator, test, override, nested, import` — one or
+  more mechanisms found among the island's members by which something could
+  reach it without a call site. Not a proof that the code runs; **it is
+  counter-evidence to "nothing reaches this"**, which is the reading that
+  gets working code deleted.
+- `boundary: NETWORK` — a path inside the island leaves the process. The
+  handler is in another repository, so the island boundary *is* the service
+  boundary: this is signal, not a defect. `ENV_READ` is printed alongside as
+  a legend ("this region is lit up by a variable") but is not a boundary.
+- `no implicit-invocation mechanism recognised` — the honest remainder, and
+  still a statement about the tool: no resolved call, and no mechanism from
+  a list codegraph knows to be incomplete. On psf/requests these 29 islands
+  are mostly the library's public surface (`get_dict`, `dict_from_cookiejar`)
+  — called by users of the package and by the stdlib, neither of which is in
+  the tree. **Do not read this bucket as dead code.**
 
 `codegraph diff [<base>..<head>]` reports what a branch actually changed —
 symbols added/removed/changed by content hash (never by line number) plus
@@ -128,24 +146,28 @@ the full set and how confident it is in each edge.
   — `HIGH`/`MEDIUM`/`LOW` reflects how certain the resolver is that the call
   really targets this symbol (e.g. a dynamic dispatch site is weaker
   evidence than a direct, unambiguous call).
-- `islands`' summary reads `symbols: 807 · islands: 172 · largest: 628 ·
-  singletons: 167 · basis: undirected CALLS edges` (the real figures for
-  psf/requests). `symbols` excludes the synthetic `path::<module>` node
-  each file gets: those carry connectivity — a module-scope call is
-  sometimes the only thing tying a helper to the rest of the graph — but
-  they are not symbols anyone wrote, so they are never members and never
-  rows. `INHERITS` edges deliberately do not join an island, which keeps a
-  symbol's island exactly equal to the set of nodes an unlimited-hop
-  `impact` or `effects` walk could reach.
+- `islands`' summary reads `symbols: 807 · islands: 154 · largest: 646 ·
+  singletons: 149 · implicit: 125 · network: 1 · unexplained: 29 · basis:
+  undirected CALLS edges` (the real figures for psf/requests). `symbols`
+  excludes the synthetic `path::<module>` node each file gets: those carry
+  connectivity — a module-scope call is sometimes the only thing tying a
+  helper to the rest of the graph — but they are not symbols anyone wrote,
+  so they are never members and never rows. `INHERITS` edges deliberately
+  do not join an island, which keeps a symbol's island exactly equal to the
+  set of nodes an unlimited-hop `impact` or `effects` walk could reach; they
+  are read only to label one. `implicit` and `network` overlap and are not
+  meant to sum — an island can be both — while `unexplained` is exactly the
+  complement of their union.
 - An `islands` row summarizes a whole component rather than listing it:
   its `id` and `location` are the island's most-called member, and
-  `detail` reads `size N across M files; also <two more members>`. Islands
-  of exactly one are collected into a single `singletons` group — one
-  group of 167 rows on psf/requests, not 167 groups of one — and each such
-  row's `detail` reads `size 1, no resolved call in either direction`,
-  which is a statement about the recorded edges and not about the symbol.
-  `--limit N` (default 20) is a total budget across both groups, islands
-  first, exactly as `impact` budgets dependents ahead of tests.
+  `detail` reads `size N across M files; <classification>; also <two more
+  members>`. Islands of exactly one are collected into a single
+  `singletons` group — one group of 149 rows on psf/requests, not 149
+  groups of one — and each such row's `detail` opens `size 1, no resolved
+  call in either direction`, which is a statement about the recorded edges
+  and not about the symbol. `--limit N` (default 20) is a total budget
+  across both groups, islands first, exactly as `impact` budgets dependents
+  ahead of tests.
 - Each `effects` row's `detail` reads `<KIND> <CONFIDENCE> via <chain>` —
   the chain is the call path from the queried symbol down to the concrete
   call site; `location` is that call site's `file:line`, clickable evidence

--- a/src/codegraph/cli.py
+++ b/src/codegraph/cli.py
@@ -189,7 +189,7 @@ def _cmd_islands(args: argparse.Namespace) -> int:
         except gitio.GitError:
             print(f"revision not found: {args.rev}", file=sys.stderr)
             return 1
-        report = islands_report(store, args.rev, limit=args.limit)
+        report = islands_report(store, args.rev, indexer.config, limit=args.limit)
         print(render_json(report) if args.json else render_text(report))
         return 0
     finally:

--- a/src/codegraph/guide.md
+++ b/src/codegraph/guide.md
@@ -65,10 +65,28 @@ dead code.** It is computed from the call edges the resolver recorded, and
 plenty of code is invoked by a mechanism that leaves no call site in the
 source at all: dunders (`__delitem__` runs on every `del d[k]`),
 decorators, framework dispatch, ABC overrides, packaging entry points. On
-psf/requests, `AuthBase.__call__`, `BaseAdapter.__init__` and
-`CaseInsensitiveDict.__delitem__` are each an island of one and none of
-them is unused. Read an island as "this region shares no call edge with
-that one", never as "nothing uses this".
+psf/requests, `AuthBase.__call__` and `CaseInsensitiveDict.__delitem__` are
+each an island of one and neither is unused. Read an island as "this region
+shares no call edge with that one", never as "nothing uses this".
+
+Every island is therefore labelled with what codegraph can say about why it
+stands apart, and each row carries the label:
+
+- `implicit: dunder, decorator, test, override, nested, import` — one or
+  more mechanisms found among the island's members by which something could
+  reach it without a call site. Not a proof that the code runs; **it is
+  counter-evidence to "nothing reaches this"**, which is the reading that
+  gets working code deleted.
+- `boundary: NETWORK` — a path inside the island leaves the process. The
+  handler is in another repository, so the island boundary *is* the service
+  boundary: this is signal, not a defect. `ENV_READ` is printed alongside as
+  a legend ("this region is lit up by a variable") but is not a boundary.
+- `no implicit-invocation mechanism recognised` — the honest remainder, and
+  still a statement about the tool: no resolved call, and no mechanism from
+  a list codegraph knows to be incomplete. On psf/requests these 29 islands
+  are mostly the library's public surface (`get_dict`, `dict_from_cookiejar`)
+  — called by users of the package and by the stdlib, neither of which is in
+  the tree. **Do not read this bucket as dead code.**
 
 `codegraph diff [<base>..<head>]` reports what a branch actually changed —
 symbols added/removed/changed by content hash (never by line number) plus
@@ -123,24 +141,28 @@ the full set and how confident it is in each edge.
   — `HIGH`/`MEDIUM`/`LOW` reflects how certain the resolver is that the call
   really targets this symbol (e.g. a dynamic dispatch site is weaker
   evidence than a direct, unambiguous call).
-- `islands`' summary reads `symbols: 807 · islands: 172 · largest: 628 ·
-  singletons: 167 · basis: undirected CALLS edges` (the real figures for
-  psf/requests). `symbols` excludes the synthetic `path::<module>` node
-  each file gets: those carry connectivity — a module-scope call is
-  sometimes the only thing tying a helper to the rest of the graph — but
-  they are not symbols anyone wrote, so they are never members and never
-  rows. `INHERITS` edges deliberately do not join an island, which keeps a
-  symbol's island exactly equal to the set of nodes an unlimited-hop
-  `impact` or `effects` walk could reach.
+- `islands`' summary reads `symbols: 807 · islands: 154 · largest: 646 ·
+  singletons: 149 · implicit: 125 · network: 1 · unexplained: 29 · basis:
+  undirected CALLS edges` (the real figures for psf/requests). `symbols`
+  excludes the synthetic `path::<module>` node each file gets: those carry
+  connectivity — a module-scope call is sometimes the only thing tying a
+  helper to the rest of the graph — but they are not symbols anyone wrote,
+  so they are never members and never rows. `INHERITS` edges deliberately
+  do not join an island, which keeps a symbol's island exactly equal to the
+  set of nodes an unlimited-hop `impact` or `effects` walk could reach; they
+  are read only to label one. `implicit` and `network` overlap and are not
+  meant to sum — an island can be both — while `unexplained` is exactly the
+  complement of their union.
 - An `islands` row summarizes a whole component rather than listing it:
   its `id` and `location` are the island's most-called member, and
-  `detail` reads `size N across M files; also <two more members>`. Islands
-  of exactly one are collected into a single `singletons` group — one
-  group of 167 rows on psf/requests, not 167 groups of one — and each such
-  row's `detail` reads `size 1, no resolved call in either direction`,
-  which is a statement about the recorded edges and not about the symbol.
-  `--limit N` (default 20) is a total budget across both groups, islands
-  first, exactly as `impact` budgets dependents ahead of tests.
+  `detail` reads `size N across M files; <classification>; also <two more
+  members>`. Islands of exactly one are collected into a single
+  `singletons` group — one group of 149 rows on psf/requests, not 149
+  groups of one — and each such row's `detail` opens `size 1, no resolved
+  call in either direction`, which is a statement about the recorded edges
+  and not about the symbol. `--limit N` (default 20) is a total budget
+  across both groups, islands first, exactly as `impact` budgets dependents
+  ahead of tests.
 - Each `effects` row's `detail` reads `<KIND> <CONFIDENCE> via <chain>` —
   the chain is the call path from the queried symbol down to the concrete
   call site; `location` is that call site's `file:line`, clickable evidence

--- a/src/codegraph/indexer.py
+++ b/src/codegraph/indexer.py
@@ -546,6 +546,7 @@ class Indexer:
                         node["line_end"],
                         node["body_hash"],
                         node["name_binding"],
+                        node["decorators"],
                     )
                 )
             rows.append(
@@ -559,11 +560,12 @@ class Indexer:
                     1,
                     module_hashes.get(sha) or sha,
                     "live",
+                    "",
                 )
             )
         connection.executemany(
             "INSERT OR REPLACE INTO nodes(rev, id, path, qualname, kind, line_start,"
-            " line_end, body_hash, name_binding) VALUES(?,?,?,?,?,?,?,?,?)",
+            " line_end, body_hash, name_binding, decorators) VALUES(?,?,?,?,?,?,?,?,?,?)",
             rows,
         )
         return shadowed

--- a/src/codegraph/query/islands.py
+++ b/src/codegraph/query/islands.py
@@ -1,5 +1,6 @@
 """The `islands` report: the revision's call graph split into connected
-components, treated as undirected.
+components, treated as undirected, and each component labelled with what
+codegraph can say about *why* it stands apart.
 
 `impact` and `effects` are node-local -- "who calls X", "what can X reach".
 Neither says anything about the graph's global shape, and that shape is
@@ -13,17 +14,51 @@ anything outside it.
 **An island is not a reachability claim, and a one-symbol island is not a
 dead-code finding.** Membership is computed from the call edges the
 resolver actually recorded, and a symbol can be invoked by a mechanism
-that leaves no call site anywhere in the source: a dunder (`__delitem__`
-runs on every `del d[k]`), a decorator, framework dispatch, an ABC
-override, a packaging entry point. On psf/requests
-`src/requests/auth.py::AuthBase.__call__`,
-`src/requests/adapters.py::BaseAdapter.__init__` and
-`src/requests/structures.py::CaseInsensitiveDict.__delitem__` are each an
-island of exactly one, and not one of them is unused. This report says
-where the graph comes apart; *why* a given island exists is issue #27's
-stage 2, and it needs edges this graph does not record yet.
+that leaves no call site anywhere in the source. Issue #27 names three
+different reasons an island exists and observes that they render
+identically; two of the three are things this report can now say.
 
-Three deliberate calls here, each of which moves the numbers:
+## Why an island exists
+
+*It is invoked by a mechanism that is not a call site.* Each island is
+tagged with every such mechanism codegraph recognises among its members
+(`_MECHANISMS` below): a dunder, a decorator, a test-runner entry point,
+an override of an inherited method, a nested definition its enclosing
+scope can pass around as a value, or an import naming it. None of these
+is a proof that the symbol runs. Each is counter-evidence to "nothing
+reaches this", which is the reading a bare island count invites and the
+one that gets code deleted.
+
+*The path leaves the process.* An island holding a `NETWORK` effect is a
+boundary: the call graph provably ends there because the next hop is a
+socket, and the handler is in another repo. This is the report's most
+useful positive finding, and it is deliberately the ONLY effect kind
+counted as a boundary -- a socket call leaving the process is a
+structural fact needing no schema knowledge, whereas establishing that
+two functions are coupled through a database means reading SQL and
+tracking a schema, which is a different tool (see #27's scope decision,
+and #26 for the annotation treadmill that parks). `ENV_READ` rides along
+in the row as a legend entry -- "this region is lit up by a variable" --
+but is not itself a boundary and never makes an island `explained`.
+
+*Nothing codegraph recognises reaches it.* The remainder, counted as
+`unexplained`. That is the strongest claim available and it is still a
+statement about this tool: no resolved call, and no implicit-invocation
+mechanism from the list above. On psf/requests the 29 islands left in
+this bucket are almost all a library's public surface -- `get_dict`,
+`list_domains`, `dict_from_cookiejar` -- called by users of the package
+and by stdlib `cookiejar`, neither of which is in the tree. Reading the
+bucket as dead code would be wrong in exactly that case.
+
+Measured on psf/requests: 807 symbols, 154 islands, largest 646, 149
+singletons; 125 islands carry at least one recognised mechanism, 1 holds a
+`NETWORK` boundary, 29 are unexplained. Before the constructor edge
+(`resolve.with_constructors`, the plain bug #27 names) the same repository
+reported 172 islands with a largest of 628 and 167 singletons: linking
+`Cls()` to the `__init__` it runs folded 18 islands into the rest of the
+graph.
+
+## Three deliberate calls about membership, each of which moves the numbers
 
 *Undirected.* `A -> B` and `B -> A` put A and B on the same island. That
 is what the word means here -- a region sharing no call relationship of
@@ -38,10 +73,9 @@ exactly the set of nodes an unlimited-hop `impact` or `effects` walk could
 ever touch, which is a property a reader can check. Folding INHERITS in
 would break that correspondence: measured on psf/requests it merges 172
 islands down to 156, so 16 boundaries would be reported as crossed by a
-walk that cannot in fact cross them. Subclasses and their bases are of
-course coupled -- `INHERITS` exists so the resolver can do method
-resolution, and the coupling reaches `impact` through the CALLS edges that
-resolution produces, which is where it belongs.
+walk that cannot in fact cross them. Inheritance still gets read here --
+it is what the `override` mechanism is computed from -- but it labels an
+island rather than merging two.
 
 *Synthetic `path::<module>` nodes connect islands but are never members.*
 Their edges are real: a module-scope call (`_init()` at the foot of
@@ -51,32 +85,50 @@ of the graph, and ignoring those 8 edges on psf/requests splits it into
 wrote, and counting one per file would invent 32 further islands on
 requests out of files whose top level simply calls nothing. So module
 nodes carry connectivity and are excluded from `symbols`, from island
-sizes, and from the rows.
-
-Counting them as members instead is exactly what #27's headline figures
-do, which is the whole of the difference from them: its largest island of
-631 is this report's 628 plus `setup.py::<module>`,
-`src/requests/help.py::<module>` and
-`src/requests/status_codes.py::<module>`, and its 166 singletons are this
-report's 167 minus `src/requests/compat.py::_resolve_char_detection`,
-whose only caller is its own module scope and which is therefore a pair
-rather than a singleton once the module node counts. The island count,
-172, is identical under both rules.
+sizes, and from the rows. They can still carry an effect, so a boundary is
+attributed by component root rather than by membership.
 """
 
 from __future__ import annotations
 
 from collections import Counter
 
+from codegraph.config import Config
 from codegraph.render import Group, Report, Row, budget
+from codegraph.resolve import module_for_path
 from codegraph.store import Store
 
 #: How many of an island's members a single row names: the row's `id` is
 #: the first, `detail` names the rest. An island can hold hundreds of
-#: symbols (628 of psf/requests' 807 sit on one), so a row summarizes
+#: symbols (646 of psf/requests' 807 sit on one), so a row summarizes
 #: rather than dumps -- and the ones worth naming are the hubs, the
 #: members with the most distinct callers inside the graph.
 _HUBS_PER_ROW = 3
+
+#: Every implicit-invocation mechanism this report recognises, in the order
+#: a row lists them: strongest claim first.
+#:
+#: None of these is proof that a symbol runs, and that asymmetry is the
+#: whole design. A false "nothing reaches this" gets working code deleted;
+#: a mechanism named on an island that turns out to be genuinely
+#: unreferenced costs the reader one line of output. So each test below is
+#: deliberately permissive, and a mechanism is claimed on the island as a
+#: whole as soon as ONE member matches.
+DUNDER = "dunder"  # `del d[k]` runs `__delitem__`; `Cls()` runs `__init__`
+DECORATOR = "decorator"  # ran at definition time; may register/wrap/replace
+TEST = "test"  # matches pytest's default collection convention
+OVERRIDE = "override"  # same name declared on a class linked by INHERITS
+NESTED = "nested"  # defined inside a function that can pass it as a value
+IMPORT = "import"  # its dotted name is imported somewhere in this revision
+_MECHANISMS = (DUNDER, DECORATOR, TEST, OVERRIDE, NESTED, IMPORT)
+
+#: The effect kinds a row reports, in display order. `NETWORK` is the only
+#: one that marks a boundary or makes an island explained; `ENV_READ` is
+#: printed as a legend entry only. See the module docstring and #27's scope
+#: decision for why the list stops there.
+NETWORK = "NETWORK"
+ENV_READ = "ENV_READ"
+_BOUNDARY_KINDS = (NETWORK, ENV_READ)
 
 
 class _Components:
@@ -109,45 +161,190 @@ def _plural(count: int, noun: str) -> str:
     return f"{count} {noun}" if count == 1 else f"{count} {noun}s"
 
 
-def islands_report(store: Store, rev: str, limit: int = 20) -> Report:
-    """Connected components of `rev`'s CALLS edges, read as undirected.
+def _is_dunder(leaf: str) -> bool:
+    """`__delitem__` yes, `__init__` yes, `_private` no, `__` no.
 
-    Two queries and one pass over the edges, never a query per node: on a
+    `__init__` counts even though `resolve.with_constructors` now gives it
+    a real edge from every `Cls()` in the tree: a class instantiated only
+    by a caller outside the repository -- which is every library base class
+    -- still has none.
+    """
+    return len(leaf) > 4 and leaf.startswith("__") and leaf.endswith("__")
+
+
+def _is_test_entry_point(path: str, qualname: str) -> bool:
+    """Would pytest collect this under its default configuration?
+
+    `python_files = test_*.py *_test.py`, `python_classes = Test*`,
+    `python_functions = test*`, and collection only reaches module-level
+    functions and the methods of a collected class -- so the qualname has
+    to be one or two segments and a `<locals>` definition never qualifies.
+    Spelling the rule out rather than reusing `impact._is_test` is
+    deliberate: that one splits report groups and is happy to over-match on
+    any `tests/` path, whereas over-matching here would silently explain
+    away every unreferenced helper in the test tree.
+    """
+    stem = path.rpartition("/")[2].removesuffix(".py")
+    if not (stem.startswith("test_") or stem.endswith("_test")):
+        return False
+    parts = qualname.split(".")
+    if len(parts) == 1:
+        return parts[0].startswith(("test", "Test"))
+    return len(parts) == 2 and parts[0].startswith("Test") and parts[1].startswith("test")
+
+
+def _imported_dotted_names(store: Store, rev: str) -> set[str]:
+    """Every dotted name this revision's `from a.b import c` lines name.
+
+    `resolve.build_import_maps` already resolved relative imports into
+    absolute dotted names before these rows were written, so an entry is
+    directly comparable with a node's own `module.qualname`. A hit means
+    something in the tree refers to the symbol by name -- not that it calls
+    it, which is exactly why the call graph does not have the edge.
+    """
+    return {
+        row["module"]
+        for row in store.connection.execute(
+            "SELECT DISTINCT module FROM imports WHERE rev=?", (rev,)
+        )
+    }
+
+
+def _describe(
+    size: int,
+    files: int,
+    mechanisms: set[str],
+    boundary: set[str],
+) -> str:
+    """The `detail` column for one island's row.
+
+    The size clause comes first because it is what orders the report; then
+    the classification, which is the answer to "why is this apart"; the
+    hub names the caller appends last, because they are the longest and
+    least structured part.
+    """
+    if size == 1:
+        # Deliberately phrased as a statement about the recorded edges, not
+        # about the symbol: "nothing calls it" is a claim this graph cannot
+        # make (see the module docstring).
+        detail = "size 1, no resolved call in either direction"
+    else:
+        detail = f"size {size} across {_plural(files, 'file')}"
+
+    named = [name for name in _MECHANISMS if name in mechanisms]
+    if named:
+        detail += f"; implicit: {', '.join(named)}"
+    else:
+        # The strongest negative claim available, and still a statement
+        # about this tool rather than about the code.
+        detail += "; no implicit-invocation mechanism recognised"
+    kinds = [kind for kind in _BOUNDARY_KINDS if kind in boundary]
+    if kinds:
+        detail += f"; boundary: {', '.join(kinds)}"
+    return detail
+
+
+def islands_report(
+    store: Store, rev: str, config: Config | None = None, limit: int = 20
+) -> Report:
+    """Connected components of `rev`'s CALLS edges, read as undirected, each
+    labelled with the implicit-invocation mechanisms and process boundaries
+    found inside it.
+
+    Four queries and one pass over the edges, never a query per node: on a
     2,930-file repository this walks ~395k edge rows, and a per-node
     lookup in that loop would be the whole cost of the command.
     """
     connection = store.connection
-
-    members: dict[str, tuple[str, int]] = {}
-    for row in connection.execute(
-        "SELECT id, path, kind, line_start FROM nodes WHERE rev=?", (rev,)
-    ):
-        if row["kind"] == "module":
-            continue
-        members[row["id"]] = (row["path"], row["line_start"])
+    source_roots = (config or Config()).source_roots
 
     # Distinct (src, dst) pairs, never raw edge rows: the same call written
     # twice in a body, or one candidate reached through two import aliases,
     # writes two rows for one relationship and would inflate the fan-in
     # that picks each island's hubs (see rank.fan_in for the same care).
+    # INHERITS is read in the SAME pass -- it never joins an island, but it
+    # is what `override` is computed from, and a second scan of 395k rows
+    # to fetch a few thousand of them would be the more expensive half.
     components = _Components()
     pairs: set[tuple[str, str]] = set()
+    inherits: set[tuple[str, str]] = set()
     for row in connection.execute(
-        "SELECT src, dst FROM edges WHERE rev=? AND kind='CALLS'", (rev,)
+        "SELECT src, dst, kind FROM edges WHERE rev=? AND kind IN ('CALLS', 'INHERITS')", (rev,)
     ):
-        pairs.add((row["src"], row["dst"]))
+        if row["kind"] == "CALLS":
+            pairs.add((row["src"], row["dst"]))
+        else:
+            inherits.add((row["src"], row["dst"]))
     for src, dst in pairs:
         components.union(src, dst)
     fan_in = Counter(dst for _, dst in pairs)
 
+    imported = _imported_dotted_names(store, rev)
+
+    members: dict[str, tuple[str, int]] = {}
     grouped: dict[str, list[str]] = {}
-    for node_id in members:
-        grouped.setdefault(components.find(node_id), []).append(node_id)
+    mechanisms: dict[str, set[str]] = {}
+    # (class node id) -> {method leaf name: node id}, for the override pass.
+    # Built here rather than by a second query because the node scan is
+    # already reading every qualname it needs.
+    methods: dict[str, dict[str, str]] = {}
+    module_names: dict[str, str] = {}
+    for row in connection.execute(
+        "SELECT id, path, qualname, kind, line_start, decorators FROM nodes WHERE rev=?", (rev,)
+    ):
+        if row["kind"] == "module":
+            continue
+        node_id, path, qualname = row["id"], row["path"], row["qualname"]
+        members[node_id] = (path, row["line_start"])
+        root = components.find(node_id)
+        grouped.setdefault(root, []).append(node_id)
+        marks = mechanisms.setdefault(root, set())
+
+        owner, dot, leaf = qualname.rpartition(".")
+        if _is_dunder(leaf):
+            marks.add(DUNDER)
+        if row["decorators"]:
+            marks.add(DECORATOR)
+        if ".<locals>." in qualname:
+            marks.add(NESTED)
+        if _is_test_entry_point(path, qualname):
+            marks.add(TEST)
+        if path not in module_names:
+            module_names[path] = module_for_path(path, source_roots)
+        if f"{module_names[path]}.{qualname}" in imported:
+            marks.add(IMPORT)
+        if dot:
+            methods.setdefault(f"{path}::{owner}", {})[leaf] = node_id
+
+    # A method declared on both ends of an INHERITS edge is reached by
+    # dispatch through the other declaration -- the ABC/subclass shape #27
+    # names. Driven from the edges rather than from the nodes so it costs
+    # one dict intersection per inheritance link, not a hierarchy walk per
+    # method.
+    for subclass, base in inherits:
+        shared = methods.get(subclass, {}).keys() & methods.get(base, {}).keys()
+        for leaf in shared:
+            for class_id in (subclass, base):
+                node_id = methods[class_id][leaf]
+                mechanisms.setdefault(components.find(node_id), set()).add(OVERRIDE)
+
+    # Attributed by component root, not by membership: a direct effect can
+    # sit on a `path::<module>` node, which carries connectivity but is
+    # never a member. `direct=1` only -- a propagated effect is reached over
+    # CALLS edges, which never leave the island, so the island holding the
+    # direct one is the same island either way.
+    boundaries: dict[str, set[str]] = {}
+    for row in connection.execute(
+        "SELECT DISTINCT node_id, kind FROM effects WHERE rev=? AND direct=1 AND kind IN (?, ?)",
+        (rev, NETWORK, ENV_READ),
+    ):
+        boundaries.setdefault(components.find(row["node_id"]), set()).add(row["kind"])
 
     island_rows: list[Row] = []
     singleton_rows: list[Row] = []
     largest = 0
-    for island in grouped.values():
+    implicit_count = network_count = unexplained_count = 0
+    for root, island in grouped.items():
         size = len(island)
         largest = max(largest, size)
         # Hubs first, then id, so a tie between two never-called members
@@ -157,17 +354,17 @@ def islands_report(store: Store, rev: str, limit: int = 20) -> Report:
         head, *rest = island
         path, line_start = members[head]
 
-        if size == 1:
-            # Deliberately phrased as a statement about the recorded edges,
-            # not about the symbol: "nothing calls it" is a claim this
-            # graph cannot make (see the module docstring).
-            detail = "size 1, no resolved call in either direction"
-        else:
-            files = len({members[node_id][0] for node_id in island})
-            detail = f"size {size} across {_plural(files, 'file')}"
-            named = rest[: _HUBS_PER_ROW - 1]
-            if named:
-                detail += f"; also {', '.join(named)}"
+        marks = mechanisms.get(root, set())
+        boundary = boundaries.get(root, set())
+        implicit_count += bool(marks)
+        network_count += NETWORK in boundary
+        unexplained_count += not marks and NETWORK not in boundary
+
+        files = len({members[node_id][0] for node_id in island})
+        detail = _describe(size, files, marks, boundary)
+        named = rest[: _HUBS_PER_ROW - 1]
+        if size > 1 and named:
+            detail += f"; also {', '.join(named)}"
 
         row = Row(
             id=head,
@@ -178,7 +375,7 @@ def islands_report(store: Store, rev: str, limit: int = 20) -> Report:
         (singleton_rows if size == 1 else island_rows).append(row)
 
     # `budget` sorts by score (the island size) and is stable, so ordering
-    # the rows here is what decides ties -- and every one of the 167
+    # the rows here is what decides ties -- and every one of the 149
     # singletons on psf/requests is a tie. Without this the printed rows
     # would be in whatever order SQLite handed back the `nodes` rows,
     # which is stable for one database file and not a contract across a
@@ -189,7 +386,7 @@ def islands_report(store: Store, rev: str, limit: int = 20) -> Report:
     # `limit` is a TOTAL budget across both groups, the same contract
     # `impact` uses for dependents and tests: multi-symbol islands are the
     # structural finding and get first claim, and the long singleton tail
-    # (167 of psf/requests' 172 islands) budgets whatever is left rather
+    # (149 of psf/requests' 154 islands) budgets whatever is left rather
     # than crowding them out.
     kept, truncated = budget(island_rows, limit)
     groups = [Group("islands", kept)] if kept else []
@@ -204,6 +401,13 @@ def islands_report(store: Store, rev: str, limit: int = 20) -> Report:
         "islands": len(grouped),
         "largest": largest,
         "singletons": len(singleton_rows),
+        # `implicit` and `network` overlap and are not meant to sum: an
+        # island can be both, and `ENV_READ` alone is neither. `unexplained`
+        # is the exact complement of their union, so the three answer "for
+        # how many islands can this tool say nothing at all".
+        "implicit": implicit_count,
+        "network": network_count,
+        "unexplained": unexplained_count,
         # Says what the partition was computed from, so a row is read as
         # "these share no call edge" and never as "nothing reaches this".
         "basis": "undirected CALLS edges",

--- a/src/codegraph/resolve.py
+++ b/src/codegraph/resolve.py
@@ -145,6 +145,25 @@ class ResolveContext:
     descendant_cache: dict[str, list[str]] = field(default_factory=dict)
 
 
+def breadth_first(start: str, adjacency: dict[str, list[str]]) -> list[str]:
+    """Breadth-first walk from `start` over `adjacency`, cycle-safe.
+
+    Module level rather than a method because two different walks need it:
+    the resolver's MRO/override walks over `bases`/`subclasses`, and
+    `_inherited_constructor` below, which is not resolution of a name at
+    all and so does not belong to a `Resolver`.
+    """
+    order, seen, queue = [], {start}, [start]
+    while queue:
+        current = queue.pop(0)
+        order.append(current)
+        for nxt in adjacency.get(current, ()):
+            if nxt not in seen:
+                seen.add(nxt)
+                queue.append(nxt)
+    return order
+
+
 class Resolver(Protocol):
     def resolve_call(self, ref: ParsedRef, ctx: ResolveContext) -> list[tuple[str, str]]:
         """Return `(node_id, confidence)` candidates for `ref`; [] if unresolved."""
@@ -252,29 +271,16 @@ class AstResolver:
         return ctx.qualname_index.get((class_path, f"{class_qualname}.{attribute}"))
 
     @staticmethod
-    def _walk(start: str, adjacency: dict[str, list[str]]) -> list[str]:
-        """Breadth-first walk from `start` over `adjacency`, cycle-safe."""
-        order, seen, queue = [], {start}, [start]
-        while queue:
-            current = queue.pop(0)
-            order.append(current)
-            for nxt in adjacency.get(current, ()):
-                if nxt not in seen:
-                    seen.add(nxt)
-                    queue.append(nxt)
-        return order
-
-    @classmethod
-    def _mro(cls, start: str, ctx: ResolveContext) -> list[str]:
+    def _mro(start: str, ctx: ResolveContext) -> list[str]:
         """The class and its known bases, nearest first."""
-        return cls._walk(start, ctx.bases)
+        return breadth_first(start, ctx.bases)
 
-    @classmethod
-    def _descendants(cls, start: str, ctx: ResolveContext) -> list[str]:
+    @staticmethod
+    def _descendants(start: str, ctx: ResolveContext) -> list[str]:
         """Every known subclass of `start`, transitively (excluding `start`)."""
         cached = ctx.descendant_cache.get(start)
         if cached is None:
-            cached = cls._walk(start, ctx.subclasses)[1:]
+            cached = breadth_first(start, ctx.subclasses)[1:]
             ctx.descendant_cache[start] = cached
         return cached
 
@@ -384,6 +390,10 @@ class _SymbolTable:
             self.name_index.setdefault(row["qualname"].rpartition(".")[2], []).append(row["id"])
             if row["kind"] == "class":
                 class_ids[key] = row["id"]
+
+        #: Live class nodes, by id -- the test `_constructor_target` applies
+        #: to a resolved call before treating it as an instantiation.
+        self.class_node_ids: frozenset[str] = frozenset(class_ids.values())
 
         self.enclosing_class: dict[str, str] = {}
         for row in live_rows:
@@ -514,6 +524,76 @@ def split_by_ambiguity_limit(
     return [hit for hit in hits if hit[1] != LOW], len(weak)
 
 
+#: The method a call to a class actually runs. `Cls()` resolves to the class
+#: node, and nothing in the source ever writes `Cls.__init__`, so without the
+#: edge below a constructor has no incoming call at all -- on psf/requests that
+#: left `src/requests/adapters.py::BaseAdapter.__init__` an island of exactly
+#: one. #27 records this as a plain bug rather than a limit of static analysis:
+#: the caller IS in the source, it just spells the callee's name as the class's.
+CONSTRUCTOR = "__init__"
+
+
+def constructor_target(
+    class_id: str, table: _SymbolTable, bases: dict[str, list[str]]
+) -> str | None:
+    """The `__init__` that `class_id()` runs, or None if it neither defines
+    nor inherits one.
+
+    The walk is the same breadth-first approximation of the MRO that
+    `AstResolver._through_self` already resolves an inherited method with,
+    and is deliberately the same: the class a name is declared on is what a
+    reader looking the call up would find. It is not a C3 linearization, so
+    under multiple inheritance the branch reached first can differ from the
+    one Python picks -- but every candidate it can return is a real
+    `__init__` on a real base, and the alternative is the missing edge this
+    exists to fix.
+
+    Subclass overrides are deliberately NOT candidates, which is the one
+    place this differs from `_through_self`. `self.x()` may run a subclass's
+    override because `self` may be an instance of a subclass; `Cls()` names
+    the exact class being instantiated, so its `__init__` is looked up on
+    `Cls` and its bases and nowhere else.
+    """
+    for owner in breadth_first(class_id, bases):
+        path, _, qualname = owner.partition("::")
+        found = table.qualname_index.get((path, f"{qualname}.{CONSTRUCTOR}"))
+        if found:
+            return found
+    return None
+
+
+def with_constructors(
+    hits: list[tuple[str, str]],
+    table: _SymbolTable,
+    bases: dict[str, list[str]],
+    cache: dict[str, str | None],
+) -> list[tuple[str, str]]:
+    """`hits`, plus the `__init__` each class among them would run.
+
+    Applied AFTER `split_by_ambiguity_limit`, so a reference whose LOW tail
+    the cap declined to enumerate cannot be re-expanded through the back
+    door -- the constructor edges follow exactly the class edges that are
+    actually materialized.
+
+    A constructor edge carries the confidence of the class edge implying it.
+    It makes the same claim ("this call site may instantiate this class")
+    and `Cls()` running `Cls.__init__` adds no uncertainty of its own, so
+    weakening it would understate an edge that is certain given the class.
+    """
+    extra: list[tuple[str, str]] = []
+    seen = {node_id for node_id, _ in hits}
+    for node_id, confidence in hits:
+        if node_id not in table.class_node_ids:
+            continue
+        if node_id not in cache:
+            cache[node_id] = constructor_target(node_id, table, bases)
+        target = cache[node_id]
+        if target is not None and target not in seen:
+            seen.add(target)
+            extra.append((target, confidence))
+    return hits + extra if extra else hits
+
+
 def _load_bases(connection: sqlite3.Connection, rev: str) -> dict[str, list[str]]:
     """Rebuild the class hierarchy from already-materialized INHERITS edges.
 
@@ -633,6 +713,10 @@ def resolve_revision(
     # runs once per class for the whole revision rather than once per reference.
     descendant_cache: dict[str, list[str]] = {}
 
+    # `Cls()` -> `Cls.__init__` is the same lookup for every call site that
+    # names the same class, and on django that is tens of thousands of them.
+    constructor_cache: dict[str, str | None] = {}
+
     call_refs = _refs_by_path(store, rev, "call", scan_paths)
     for path in target_paths:
         ctx = table.context(rev, path, bases, subclasses, descendant_cache)
@@ -640,6 +724,7 @@ def resolve_revision(
             src = _source_id(ref, table, path)
             hits = resolver.resolve_call(ref, ctx)
             kept, ambiguous_count = split_by_ambiguity_limit(hits, limit)
+            kept = with_constructors(kept, table, bases, constructor_cache)
             for node_id, confidence in kept:
                 edge_rows.append(
                     (rev, src, node_id, "CALLS", confidence, PROVENANCE, path, ref.line)

--- a/src/codegraph/store.py
+++ b/src/codegraph/store.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 
 WORKTREE = "WORKTREE"
 
@@ -89,6 +89,14 @@ CREATE TABLE IF NOT EXISTS nodes (
     line_end INTEGER NOT NULL,
     body_hash TEXT NOT NULL,
     name_binding TEXT NOT NULL,
+    -- Comma-joined decorator names, copied through from `blob_nodes`. A
+    -- decorator runs at definition time and can register, wrap or replace
+    -- the thing it decorates, which is one of the ways a symbol is invoked
+    -- with no call site naming it anywhere (#27); `query/islands.py` reads
+    -- this to say so. Layer 2 carries it rather than joining back to Layer
+    -- 1 because a node id encodes `shadow_index` and `blob_nodes` does not,
+    -- so the join key would have to reconstruct the id format by hand.
+    decorators TEXT NOT NULL DEFAULT '',
     PRIMARY KEY (rev, id)
 );
 CREATE TABLE IF NOT EXISTS edges (

--- a/tests/fixtures/labelled_calls.json
+++ b/tests/fixtures/labelled_calls.json
@@ -10,32 +10,45 @@
     "pkg/inherit.py": "class Named:\n    def identify(self):\n        return f\"I am {self.__class__.__name__}\"\n\n\nclass Widget(Named):\n    def report(self):\n        return self.identify()\n",
     "pkg/duck_unique.py": "class Renderer:\n    def render(self):\n        return \"rendered\"\n\n\ndef show(widget):\n    return widget.render()\n",
     "pkg/duck_ambiguous.py": "class Document:\n    def save(self):\n        return \"document saved\"\n\n\nclass Settings:\n    def save(self):\n        return \"settings saved\"\n\n\ndef persist(item):\n    return item.save()\n",
-    "pkg/shapes.py": "class Shape:\n    def area(self):\n        return 0\n\n    def describe(self):\n        return f\"area={self.area()}\"\n\n\nclass Square(Shape):\n    def __init__(self, side):\n        self.side = side\n\n    def area(self):\n        return self.side * self.side\n"
+    "pkg/shapes.py": "class Shape:\n    def area(self):\n        return 0\n\n    def describe(self):\n        return f\"area={self.area()}\"\n\n\nclass Square(Shape):\n    def __init__(self, side):\n        self.side = side\n\n    def area(self):\n        return self.side * self.side\n",
+    "pkg/construct.py": "from pkg.shapes import Square\n\n\nclass Vessel:\n    def __init__(self, size):\n        self.size = size\n\n\nclass Barrel(Vessel):\n    def capacity(self):\n        return self.size\n\n\ndef build_square():\n    return Square(2)\n\n\ndef build_barrel():\n    return Barrel(3)\n"
   },
   "calls": [
     {
       "src": "pkg/plain_import.py::call_helper",
-      "expected": ["pkg/utils.py::helper"]
+      "expected": [
+        "pkg/utils.py::helper"
+      ]
     },
     {
       "src": "pkg/from_alias.py::call_via_alias",
-      "expected": ["pkg/utils.py::helper"]
+      "expected": [
+        "pkg/utils.py::helper"
+      ]
     },
     {
       "src": "pkg/relative.py::call_relative",
-      "expected": ["pkg/utils.py::helper"]
+      "expected": [
+        "pkg/utils.py::helper"
+      ]
     },
     {
       "src": "pkg/counter.py::Counter.increment",
-      "expected": ["pkg/counter.py::Counter._report"]
+      "expected": [
+        "pkg/counter.py::Counter._report"
+      ]
     },
     {
       "src": "pkg/inherit.py::Widget.report",
-      "expected": ["pkg/inherit.py::Named.identify"]
+      "expected": [
+        "pkg/inherit.py::Named.identify"
+      ]
     },
     {
       "src": "pkg/duck_unique.py::show",
-      "expected": ["pkg/duck_unique.py::Renderer.render"]
+      "expected": [
+        "pkg/duck_unique.py::Renderer.render"
+      ]
     },
     {
       "src": "pkg/duck_ambiguous.py::persist",
@@ -49,6 +62,20 @@
       "expected": [
         "pkg/shapes.py::Shape.area",
         "pkg/shapes.py::Square.area"
+      ]
+    },
+    {
+      "src": "pkg/construct.py::build_square",
+      "expected": [
+        "pkg/shapes.py::Square",
+        "pkg/shapes.py::Square.__init__"
+      ]
+    },
+    {
+      "src": "pkg/construct.py::build_barrel",
+      "expected": [
+        "pkg/construct.py::Barrel",
+        "pkg/construct.py::Vessel.__init__"
       ]
     }
   ]

--- a/tests/test_islands.py
+++ b/tests/test_islands.py
@@ -47,6 +47,9 @@ def test_a_fully_connected_call_graph_is_one_island(repo, write):
         "islands": 1,
         "largest": 3,
         "singletons": 0,
+        "implicit": 0,
+        "network": 0,
+        "unexplained": 1,
         "basis": "undirected CALLS edges",
     }
     store.close()
@@ -139,6 +142,9 @@ def test_a_repo_with_no_python_files_reports_no_islands(repo, write):
         "islands": 0,
         "largest": 0,
         "singletons": 0,
+        "implicit": 0,
+        "network": 0,
+        "unexplained": 0,
         "basis": "undirected CALLS edges",
     }
     assert report.groups == []
@@ -242,12 +248,20 @@ def test_singleton_rows_do_not_claim_the_symbol_is_unused(repo, write):
     """Issue #27 records why 'nothing calls this' is unsound today: a
     dunder, a decorator, framework dispatch or an entry point invokes a
     symbol with no call site anywhere in the source. A singleton row must
-    therefore describe the recorded edges, never the symbol's fate."""
+    therefore describe the recorded edges, never the symbol's fate --
+    including the rows stage 2 could say nothing about, whose wording is
+    the weakest negative claim in the tool."""
     write("a.py", "class Thing:\n    def __delitem__(self, key):\n        pass\n", commit="dunder")
     store = build(repo)
     report = islands_report(store, "HEAD")
     details = {row.detail for row in rows(report, "singletons")}
-    assert details == {"size 1, no resolved call in either direction"}
+    assert details == {
+        "size 1, no resolved call in either direction; implicit: dunder",
+        (
+            "size 1, no resolved call in either direction;"
+            " no implicit-invocation mechanism recognised"
+        ),
+    }
     text = " ".join(details).lower()
     assert "dead" not in text
     assert "unused" not in text
@@ -273,3 +287,204 @@ def test_islands_json_output_is_machine_readable(repo, write, capsys):
     payload = json.loads(capsys.readouterr().out)
     assert payload["summary"]["islands"] == 1
     assert payload["groups"][0]["title"] == "islands"
+
+
+def detail_for(report, node_id):
+    """The one row naming `node_id` as its head."""
+    return next(
+        row.detail for group in report.groups for row in group.rows if row.id == node_id
+    )
+
+
+def test_a_dunder_only_singleton_is_not_reported_as_unexplained(repo, write):
+    """`del d[k]` runs `__delitem__` with no call site naming it, which is
+    #27's first cause and the reason a singleton count must never be read as
+    a dead-code count. On psf/requests `structures.py::CaseInsensitiveDict.
+    __delitem__` is an island of one and runs on every deletion."""
+    write(
+        "a.py",
+        "class Store:\n    def __delitem__(self, key):\n        pass\n",
+        commit="dunder only",
+    )
+    store = build(repo)
+    report = islands_report(store, "HEAD")
+    assert report.summary["implicit"] == 1
+    assert report.summary["unexplained"] == 1  # the class itself, which nothing builds
+    assert detail_for(report, "a.py::Store.__delitem__").endswith("implicit: dunder")
+    store.close()
+
+
+def test_a_decorated_definition_is_not_reported_as_unexplained(repo, write):
+    """A decorator runs at definition time and can register, wrap or replace
+    what it decorates -- `@app.route` never produces a call site for the view
+    it registers. codegraph does not model what any particular decorator does
+    (that is #26's parked annotation treadmill), so the presence of one is
+    the whole test."""
+    write(
+        "a.py",
+        "import registry\n\n\n@registry.handler\ndef on_event():\n    pass\n",
+        commit="decorated",
+    )
+    store = build(repo)
+    report = islands_report(store, "HEAD")
+    assert detail_for(report, "a.py::on_event").endswith("implicit: decorator")
+    assert report.summary["unexplained"] == 0
+    store.close()
+
+
+def test_a_pytest_entry_point_is_not_reported_as_unexplained(repo, write):
+    """A test runner discovers and invokes by naming convention, so a test
+    with no caller is the runner's entry point rather than an orphan."""
+    write(
+        "tests/test_thing.py",
+        "class TestThing:\n    def test_works(self):\n        pass\n",
+        commit="pytest shapes",
+    )
+    store = build(repo)
+    report = islands_report(store, "HEAD")
+    assert detail_for(report, "tests/test_thing.py::TestThing.test_works").endswith(
+        "implicit: test"
+    )
+    store.close()
+
+
+def test_a_helper_in_a_test_file_is_not_excused_by_its_neighbours(repo, write):
+    """The pytest rule is deliberately narrower than `impact._is_test`, which
+    treats any `tests/` path as a test. Over-matching here would silently
+    explain away every unreferenced helper in the test tree -- the exact
+    false negative that makes an island report unsafe to act on."""
+    write(
+        "tests/test_thing.py",
+        "def helper():\n    pass\n\n\ndef test_works():\n    pass\n",
+        commit="helper beside a test",
+    )
+    store = build(repo)
+    report = islands_report(store, "HEAD")
+    assert detail_for(report, "tests/test_thing.py::helper").endswith(
+        "no implicit-invocation mechanism recognised"
+    )
+    store.close()
+
+
+def test_an_override_of_an_inherited_method_is_not_reported_as_unexplained(repo, write):
+    """The ABC/subclass shape: a base declares `send`, a subclass overrides
+    it, and a caller holding the base type reaches the override by dispatch.
+    INHERITS still does not join the two islands (that would misreport what
+    an `impact` walk can cross); it labels them instead."""
+    write(
+        "a.py",
+        "class Base:\n    def send(self):\n        pass\n\n\n"
+        "class Child(Base):\n    def send(self):\n        pass\n",
+        commit="override",
+    )
+    store = build(repo)
+    report = islands_report(store, "HEAD")
+    assert "override" in detail_for(report, "a.py::Base.send")
+    assert "override" in detail_for(report, "a.py::Child.send")
+    store.close()
+
+
+def test_a_nested_definition_is_not_reported_as_unexplained(repo, write):
+    """A closure is handed to something as a value -- a callback, a hook, a
+    returned function. codegraph records calls and never a reference to a
+    name as a value, so its enclosing scope is a mechanism the graph cannot
+    show."""
+    write(
+        "a.py",
+        "def outer(bus):\n    def on_event():\n        pass\n\n    bus.append(on_event)\n",
+        commit="closure",
+    )
+    store = build(repo)
+    report = islands_report(store, "HEAD")
+    assert detail_for(report, "a.py::outer.<locals>.on_event").endswith("implicit: nested")
+    store.close()
+
+
+def test_an_imported_symbol_is_not_reported_as_unexplained(repo, write):
+    """`from a import Thing` is recorded evidence that something in the tree
+    refers to `Thing`, even though referring is not calling and so leaves no
+    call edge. This is what covers an exception class named only in a `raise`
+    or an `except`: on psf/requests it is why `exceptions.py::Timeout` is not
+    left in the unexplained bucket."""
+    write("a.py", "class Timeout(Exception):\n    pass\n")
+    write("b.py", "from a import Timeout\n\n\ndef go():\n    return 1\n", commit="imported")
+    store = build(repo)
+    report = islands_report(store, "HEAD")
+    assert detail_for(report, "a.py::Timeout").endswith("implicit: import")
+    store.close()
+
+
+def test_an_island_whose_path_leaves_the_process_is_labelled_a_boundary(repo, write):
+    """#27's second cause, and the one that is signal rather than defect: the
+    call graph ends at the socket because the handler is in another repo, so
+    the island boundary IS the service boundary. NETWORK is the only effect
+    kind that marks one -- see the module docstring for why DB coupling is
+    not, and is not to be reintroduced."""
+    write(
+        "a.py",
+        "import requests\n\n\ndef fetch():\n    return requests.get('http://x')\n",
+        commit="network",
+    )
+    store = build(repo)
+    report = islands_report(store, "HEAD")
+    assert report.summary["network"] == 1
+    assert report.summary["unexplained"] == 0
+    assert "boundary: NETWORK" in detail_for(report, "a.py::fetch")
+    store.close()
+
+
+def test_an_env_read_alone_is_a_legend_entry_and_not_a_boundary(repo, write):
+    """`ENV_READ` says a region is lit up by a variable, which is worth
+    printing; it is not a point where the process ends. Counting it as a
+    boundary would claim the graph stops somewhere it does not, and stage 4
+    -- which branch of an `if` a variable actually gates -- needs control
+    flow codegraph does not have."""
+    write(
+        "a.py",
+        "import os\n\n\ndef configured():\n    return os.getenv('MODE')\n",
+        commit="env",
+    )
+    store = build(repo)
+    report = islands_report(store, "HEAD")
+    assert report.summary["network"] == 0
+    assert report.summary["unexplained"] == 1
+    assert "boundary: ENV_READ" in detail_for(report, "a.py::configured")
+    store.close()
+
+
+def test_an_isolated_function_is_still_never_called_dead(repo, write):
+    """The strongest negative claim stage 2 permits, and it is still a
+    statement about this tool: no resolved call, and no mechanism from a list
+    codegraph knows to be incomplete. A user who reads an island row as
+    'delete this' has been told something the graph cannot support."""
+    write("a.py", "def orphan():\n    pass\n", commit="orphan")
+    store = build(repo)
+    report = islands_report(store, "HEAD")
+    assert report.summary["unexplained"] == 1
+    detail = detail_for(report, "a.py::orphan")
+    assert detail == (
+        "size 1, no resolved call in either direction;"
+        " no implicit-invocation mechanism recognised"
+    )
+    assert not {"dead", "unused", "unreachable", "orphaned"} & set(detail.lower().split())
+    store.close()
+
+
+def test_a_constructor_call_removes_the_island_the_missing_edge_created(repo, write):
+    """The half of stage 2 that is a plain bug rather than a limit: `Cls()`
+    implies `Cls.__init__`, so a constructor is not an island of its own.
+    Fixing it folded 18 of psf/requests' 172 islands into the rest of the
+    graph, taking singletons from 167 to 149 -- every number stage 2 reports
+    sits downstream of this edge."""
+    write(
+        "a.py",
+        "class Thing:\n    def __init__(self):\n        pass\n\n\n"
+        "def build():\n    return Thing()\n",
+        commit="constructed",
+    )
+    store = build(repo)
+    report = islands_report(store, "HEAD")
+    assert report.summary["islands"] == 1
+    assert report.summary["largest"] == 3
+    assert report.summary["singletons"] == 0
+    store.close()

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -691,3 +691,92 @@ def test_an_imported_definition_still_shadows_the_builtin(repo, write):
     indexer.reconcile("HEAD")
     assert ("app.py::caller", "lib.py::set", "HIGH") in edges(store)
     store.close()
+
+
+def test_instantiating_a_class_calls_its_own_constructor(repo, write):
+    """`Cls()` runs `Cls.__init__`, and no source line anywhere spells that
+    name -- so without an implied edge the constructor of every class in the
+    repository has zero callers. #27 measured the result on psf/requests:
+    `adapters.py::BaseAdapter.__init__` reported as an island of one."""
+    write(
+        "a.py",
+        "class Thing:\n    def __init__(self):\n        self.x = 1\n\n\n"
+        "def build():\n    return Thing()\n",
+        commit="constructor",
+    )
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    assert ("a.py::build", "a.py::Thing", "HIGH") in edges(store)
+    assert ("a.py::build", "a.py::Thing.__init__", "HIGH") in edges(store)
+    store.close()
+
+
+def test_instantiating_a_class_calls_the_constructor_it_inherits(repo, write):
+    """A subclass that defines no `__init__` runs its base's, so the edge has
+    to follow the MRO rather than stopping at the class named. This is the
+    shape that matters in practice: a base holding the only `__init__` and
+    every subclass relying on it."""
+    write(
+        "a.py",
+        "class Base:\n    def __init__(self, tag):\n        self.tag = tag\n\n\n"
+        "class Middle(Base):\n    pass\n\n\n"
+        "class Leaf(Middle):\n    def run(self):\n        return self.tag\n\n\n"
+        "def build():\n    return Leaf('x')\n",
+        commit="inherited constructor",
+    )
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    assert ("a.py::build", "a.py::Base.__init__", "HIGH") in edges(store)
+    store.close()
+
+
+def test_the_nearest_constructor_in_the_mro_wins(repo, write):
+    """The base's `__init__` is shadowed by the subclass's own, exactly as
+    Python's attribute lookup shadows it -- one constructor edge, not both."""
+    write(
+        "a.py",
+        "class Base:\n    def __init__(self):\n        pass\n\n\n"
+        "class Child(Base):\n    def __init__(self):\n        pass\n\n\n"
+        "def build():\n    return Child()\n",
+        commit="shadowed constructor",
+    )
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    found = edges(store)
+    assert ("a.py::build", "a.py::Child.__init__", "HIGH") in found
+    assert ("a.py::build", "a.py::Base.__init__", "HIGH") not in found
+    store.close()
+
+
+def test_a_class_with_no_constructor_anywhere_implies_no_edge(repo, write):
+    """`Thing()` on a class that neither defines nor inherits an `__init__`
+    runs `object.__init__`, which is not a repository symbol. Inventing an
+    edge to some same-named `__init__` elsewhere in the tree would be the
+    over-approximation bias pointing at a definition Python never reaches."""
+    write(
+        "a.py",
+        "class Other:\n    def __init__(self):\n        pass\n\n\n"
+        "class Thing:\n    pass\n\n\n"
+        "def build():\n    return Thing()\n",
+        commit="no constructor",
+    )
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    assert not [dst for src, dst, _ in edges(store) if src == "a.py::build" and "__init__" in dst]
+    store.close()
+
+
+def test_a_constructor_edge_is_no_more_confident_than_the_class_edge(repo, write):
+    """A LOW guess at which class a bare name means stays a LOW guess about
+    which `__init__` runs. The implied edge restates the class edge's claim
+    and must not launder it into a stronger one."""
+    write("one.py", "class Widget:\n    def __init__(self):\n        pass\n")
+    write("two.py", "class Widget:\n    def __init__(self):\n        pass\n")
+    write("use.py", "def build(box):\n    return box.Widget()\n", commit="ambiguous")
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    found = edges(store)
+    assert ("use.py::build", "one.py::Widget", "LOW") in found
+    assert ("use.py::build", "one.py::Widget.__init__", "LOW") in found
+    assert ("use.py::build", "two.py::Widget.__init__", "LOW") in found
+    store.close()


### PR DESCRIPTION
Stages 2 and 3 of #27. Stage 4 (gating an island on a specific env-var value)
is **not** attempted and the issue stays open — it needs conditional edges the
model does not have.

## The bug first, because every later number depends on it

`Cls()` resolved to the class node and nothing in any source file ever spells
`Cls.__init__`, so **every constructor in every repository had zero incoming
edges**. `resolve.with_constructors` implies that edge, following the same
breadth-first MRO approximation `AstResolver._through_self` already uses for
an inherited method. Subclass overrides are deliberately not candidates:
`self.x()` may run a subclass's override because `self` may be a subclass
instance, but `Cls()` names the exact class being instantiated.

It is applied *after* `split_by_ambiguity_limit`, so a reference whose LOW tail
the cap declined to enumerate cannot be re-expanded through the back door, and
it carries the confidence of the class edge implying it — the same claim, not a
stronger one.

psf/requests, cold rebuild both sides:

```
before  symbols: 807 · islands: 172 · largest: 628 · singletons: 167
after   symbols: 807 · islands: 154 · largest: 646 · singletons: 149
```

django: 8732 → 8171 islands, 405,499 → 438,513 edges.

It is not only an `islands` fix. On main, `impact src/requests/adapters.py::HTTPAdapter.__init__`
returned `symbols: 0`. It now returns 84 dependents, correctly routed through
`Session.__init__` → `requests.get`.

## Stage 2 — why an island exists

Each island is labelled with every implicit-invocation mechanism found among
its members, and one matching member labels the island:

| mechanism | what it asserts |
|---|---|
| `dunder` | Python syntax invokes it — `del d[k]`, `Cls()`, `with`, `repr` |
| `decorator` | a decorator ran at definition time and may have registered, wrapped or replaced it |
| `test` | matches pytest's default collection convention, so a runner invokes it |
| `override` | the same name is declared on a class linked by `INHERITS` — the ABC/subclass shape |
| `nested` | defined inside a function whose body can pass it as a value; codegraph records calls, never a name used as a value |
| `import` | its dotted name is imported somewhere in the tree, so something refers to it without calling it |

**None of these is proof that a symbol runs.** Each is counter-evidence to
"nothing reaches this", which is the reading that gets working code deleted, so
every test is deliberately permissive. The asymmetry is the design: a false
"nothing reaches this" costs a user working code; a mechanism named on an
island that turns out to be genuinely unreferenced costs one line of output.

The remainder reads `no implicit-invocation mechanism recognised` — the
strongest negative claim available, and still a statement about this tool. On
requests those 29 islands are mostly the library's public surface (`get_dict`,
`list_domains`, `dict_from_cookiejar`), called by users of the package and by
stdlib `cookiejar`, neither of which is in the tree. Nothing anywhere in the
output says dead, unused, unreachable or orphaned; a test asserts it.

`INHERITS` still does not join an island — that would misreport what an
`impact` walk can cross, and #28 measured the cost (172 → 156). It is now read
to *label* one, in the same edge scan.

## Stage 3 — boundaries

`NETWORK` only, per the scope decision recorded in #27's comments. Pure
attribution of effects already detected: a direct effect is mapped to the
component root of the node carrying it, which is why a `path::<module>` node —
never a member, but a real connectivity carrier — still contributes its
boundary. `ENV_READ` rides along in the row as a legend entry, never counts as
a boundary and never makes an island explained. DB coupling does not appear.

## The three symbols #27 names

```
before
  src/requests/adapters.py::BaseAdapter.__init__   size 1, no resolved call in either direction
  src/requests/auth.py::AuthBase.__call__          size 1, no resolved call in either direction
  src/requests/structures.py::CaseInsensitiveDict.__delitem__
                                                   size 1, no resolved call in either direction

after
  src/requests/adapters.py::BaseAdapter.__init__   ...; implicit: dunder, override
  src/requests/auth.py::AuthBase.__call__          ...; implicit: dunder, override
  src/requests/structures.py::CaseInsensitiveDict.__delitem__
                                                   ...; implicit: dunder
```

Full summary line on requests:

```
symbols: 807 · islands: 154 · largest: 646 · singletons: 149 · implicit: 125 · network: 1 · unexplained: 29 · basis: undirected CALLS edges
```

## Cost (#7), django, three runs each, same machine

| | main | this branch |
|---|---|---|
| cold index | 41.7 / 27.0 / 42.2s | 26.4 / 31.6 / 38.9s |
| reconcile, no changes | 0.14–0.18s | 0.15–0.19s |
| body-only edit | 2.33–3.23s | 2.36–2.99s |
| `islands_report` alone | 2.66 / 2.73 / 2.83s | 1.87 / 1.98 / 1.99s |

No regression; cold-index variance on this machine is larger than any effect
the change has. `islands_report` got faster because the component grouping now
happens inside the node cursor loop rather than in a second 43k-element pass.
`tests/test_invariants.py` is untouched and green.

`nodes` gains the `decorators` column `blob_nodes` already had (schema 4 → 5):
a node id encodes `shadow_index` and `blob_nodes` does not, so joining back to
Layer 1 would mean reconstructing the id format by hand in a second place.

## Accuracy

precision 1.00, recall 1.00 — unchanged. It was unchanged *because no labelled
call site in the fixture instantiated a class*, so the harness could not see
the new edge at all. Rather than report a number that measured nothing, I added
two new labelled call sites (a direct `Square(2)` and an inherited
`Barrel(3)` → `Vessel.__init__`). Existing labels are untouched; this adds
ground truth, it does not adjust any. Removing `with_constructors` now fails
the harness.

## Tests verified non-vacuous

Every one below was broken, the named test watched to fail, then restored
(committed first).

- constructor edge removed → 5 of the 6 constructor tests fail, **and** the
  accuracy harness fails
- MRO not walked → `test_instantiating_a_class_calls_the_constructor_it_inherits`
- MRO walked outermost-first → `test_the_nearest_constructor_in_the_mro_wins`
- constructor falls back to any same-named `__init__` →
  `test_a_class_with_no_constructor_anywhere_implies_no_edge` (this is a guard,
  so it does not fail when the feature is simply absent — it fails when the
  feature over-reaches, which is what it exists to catch)
- constructor edge laundered to HIGH →
  `test_a_constructor_edge_is_no_more_confident_than_the_class_edge`
- dunder / decorator / pytest / override / nested / import recognition each
  disabled → the matching classification test
- pytest rule widened to any `tests/` path →
  `test_a_helper_in_a_test_file_is_not_excused_by_its_neighbours`
- boundary attribution removed → the NETWORK test
- `ENV_READ` counted as a boundary → the legend test
- `no implicit-invocation mechanism recognised` reworded to `dead code` → two
  wording tests
- `INHERITS` folded into membership → `test_inherits_edges_do_not_join_an_island`
- `decorators` dropped on the way into `nodes` → the decorator test

## Found, not fixed

- **`super().__init__()` is still unresolved.** `parse.py` flattens it to
  `<attr>.__init__`, losing the fact that the receiver was `super()`, so it
  falls to the repo-wide last-segment match. Resolving it properly is a
  well-defined MRO walk but needs a new synthetic prefix out of the parser,
  which bumps `PARSER_VERSION` and invalidates every cache. This is why
  `BaseAdapter.__init__` is still an island of one on requests — it is reached
  only from `HTTPAdapter.__init__`'s `super().__init__()`.
- **`codegraph index --rebuild` does not re-resolve.** It clears the `blobs`
  parse cache, but the tree and fingerprint are unchanged, so reconcile
  short-circuits and the graph is never rewritten. Only deleting `graph.db`
  forces a true cold rebuild. Not touched here; it deserves its own issue.
- **Exception classes named only in `raise X` / `except X`** are recognised
  only when something also imports them. `parse.py` records calls, bases,
  imports and globals — never a bare name reference.
- **`inherited`** (a class that is merely a base of another) is not a
  mechanism. It would explain a handful more islands on requests
  (`RequestsWarning`, the two mixins) but blurs the deliberate line that
  `INHERITS` does not establish membership.
- **Packaging entry points** (`[project.scripts]`) are not read. It would mean
  parsing `pyproject.toml` at query time; no island on requests or django
  needed it.

## Weaknesses I would push back on myself

- `decorator` counts *any* decorator, `@staticmethod` included, which does not
  invoke anything. Distinguishing them means knowing what each decorator does,
  which is the per-library annotation treadmill #26 parked. It over-claims in
  the safe direction, and it is 41 of requests' 125 explained islands, so it is
  doing real work in the count.
- `import` is the weakest mechanism in the list: importing is not invoking. It
  is included because it is recorded, exact fact and it is what keeps
  `exceptions.Timeout` out of a bucket a user might act on.
- `network: 1` on requests and `2` on django is thin. Both are honest — all of
  requests' socket calls sit in the one big component — but stage 3 will only
  look valuable on a repo whose network calls are actually scattered.
- The `override` pass indexes methods by `f"{path}::{owner}"`, which is the
  class node id only for a live, non-shadowed class. A shadowed class's methods
  will not match; the effect is a missed label, never a false one.

## Merge note

`resolve.py` changes are deliberately surgical, for #25's concurrent work:
`AstResolver._mro` / `._descendants` (three lines, calling the extracted
module-level `breadth_first` instead of the removed `AstResolver._walk`), the
new module-level `breadth_first` / `constructor_target` / `with_constructors`,
one line added to `_SymbolTable.__init__` (`class_node_ids`), and two lines in
`resolve_revision`'s call loop. Nothing in `_by_last_segment`, `name_index`
construction, or `split_by_ambiguity_limit` was touched.

References #27. Does not close it — stage 4 remains.
