### PR TITLE
Expand the bare-name fan-out at query time, not at index time

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,26 +171,28 @@ a root). `[[effect]]` entries merge over the built-in catalog by pattern;
 the nine effect kinds (`DB_WRITE`, `DB_READ`, `NETWORK`, `PROCESS`,
 `FS_WRITE`, `FS_READ`, `ENV_READ`, `GLOBAL_MUTATE`, `NONDETERMINISM`).
 
-`ambiguity_limit` (default `25`, `0` to disable) bounds the last-resort
-resolution step. When a call like `item.save()` names nothing importable,
-nothing module-local, and nothing reachable through `self`, the resolver
-falls back to matching `save` against every definition in the repository.
-On a small codebase that is a handful of candidates and a useful
-over-approximation. On django it was 971 for a single call site, and 96.6%
-of the whole graph was that kind of guess — the edge table grew with the
-*square* of the repository. Past this many equally-weak candidates the call
-is recorded once as ambiguous, with the name and the count, instead of as N
-edges. Nothing is discarded to improve precision: the N edges and the one
-record make the same claim, and a `HIGH` or `MEDIUM` hit — one the resolver
-actually distinguished — is never collapsed. Raise it if you want the full
-cross product back.
+There is no setting for the bare-name fan-out, and that is deliberate.
+When a call like `item.save()` names nothing importable, nothing
+module-local, and nothing reachable through `self`, the resolver falls back
+to matching `save` against every definition in the repository — a handful
+on a small codebase, 971 for a single call site on django. None of that is
+stored. The candidate set *is* "every live definition named `save`", which
+the graph already holds, so the call is recorded once and the set is
+recomputed whenever a query asks for it. Materializing it stored nothing new
+at a cost that grew with the *square* of the repository: 2.09M of django's
+2.16M edges were that one kind of guess.
 
-```toml
-ambiguity_limit = 25
-```
+Which also settles where the bound belongs. Whether 971 candidates is too
+many is a property of the question, not of the graph: `impact` wants them
+ranked and cut off at `--limit`, `effects` wants pure reachability through
+them, `diff` wants none of them. So it is `--limit`, per query, and no
+future question is bound by a number you picked once at index time.
 
-It lives at the repository root, not inside `.codegraph/`, because it is
-hand-written configuration meant to be committed and shared, whereas
+`ambiguity_limit` used to be that number. It is still read, warns when set,
+and no longer affects anything; remove it. See issue #25.
+
+`codegraph.toml` lives at the repository root, not inside `.codegraph/`,
+because it is hand-written configuration meant to be committed and shared, whereas
 `.codegraph/` self-ignores and holds only derived cache: config is tracked,
 everything derived is disposable.
 

--- a/codegraph.toml
+++ b/codegraph.toml
@@ -12,16 +12,18 @@
 # source_roots = ["", "src"]
 
 
-# How many equally-weak candidates one call site may name before codegraph
-# records it once as ambiguous instead of as that many low-confidence edges.
-# A call like `item.save()` that names nothing importable, nothing
-# module-local, and nothing reachable through `self` falls back to matching
-# `save` against every definition in the repository. On django that was 971
-# candidates for a single call site, and 96.6% of the whole graph was that kind
-# of guess -- the edge table grew with the square of the repository. Nothing is
-# discarded at the cap: the one ambiguous record makes the same claim the N
-# edges did. Raise it to get the full cross product back; 0 disables the cap.
-# ambiguity_limit = 25
+# There is deliberately no setting here for the bare-name fan-out. A call like
+# `item.save()` that names nothing importable, nothing module-local and nothing
+# reachable through `self` falls back to matching `save` against every
+# definition in the repository -- 971 candidates for a single call site on
+# django. That set is not stored: it is exactly "every definition named save",
+# which the graph already holds, so codegraph records the call once and expands
+# it when a query asks. How many of them you want to see is a property of the
+# question, so it is `codegraph impact --limit N` (and `--all`), per query,
+# rather than a setting that changes the graph for every future question.
+#
+# `ambiguity_limit` used to live here. It is still accepted and now does
+# nothing; remove it.
 
 
 # Effect overrides, merged over the built-in catalog. The built-ins only know

--- a/skills/codegraph/SKILL.md
+++ b/skills/codegraph/SKILL.md
@@ -106,14 +106,26 @@ the full set and how confident it is in each edge.
   `effects_reachable` is a **list of effect-kind strings**, not a count —
   in `--json` output it is a real JSON array; in text it is rendered as a
   comma-separated list (`DB_WRITE, PROCESS`), or `none` when the symbol
-  reaches nothing, never Python's list repr. `low_confidence_hidden`
-  counts `LOW`-confidence dependents that are held back from the
-  `dependents` and `tests` groups by default — the resolver's least
-  certain guesses are real information, but they should not read as
-  confirmed impact. Pass `--all` to include them in the listed rows.
+  reaches nothing, never Python's list repr.
+- `LOW`-confidence dependents never enter `dependents` or `tests` — the
+  resolver's least certain guesses are real information, but they should
+  not read as confirmed impact, and they are left out of `symbols`,
+  `modules` and `entry_points` for the same reason. They are not reduced
+  to a number either: the strongest few are listed in their own
+  `low_confidence` group, and `low_confidence_hidden` counts only the ones
+  that did not fit. Pass `--all` to merge the whole set into the main
+  groups instead.
+- Many of those `LOW` rows are not in the stored graph at all. A call like
+  `item.save()` that names nothing importable, nothing module-local and
+  nothing reachable through `self` matches every definition named `save`
+  in the repository — up to 971 of them on django — and codegraph records
+  the call once rather than storing that cross product, expanding it when
+  a query asks. So `impact` can name callers that no edge in the database
+  names, and `--limit` is the only bound on how many.
 - `impact --limit N` caps the *total* rows kept across `dependents` and
   `tests` combined at `N` (default 40) — not `N` each — so the printed
-  report never exceeds its documented budget.
+  report never exceeds its documented budget. The `low_confidence` sample
+  is budgeted separately and never eats into it.
 - `diff`'s summary reads `new_effects: <kind list or none> ·
   added: N · removed: N · changed: N · base: <sha> · head: <rev>`.
   `new_effects` covers every symbol newly reachable at `head`, whether it

--- a/src/codegraph/ambiguity.py
+++ b/src/codegraph/ambiguity.py
@@ -1,0 +1,168 @@
+"""Query-time expansion of the bare-name fan-out.
+
+The resolver's last-resort step matches a call's final dotted segment
+against every live definition in the revision. When more than one answers,
+`resolve.py` writes no edges at all: it records the reference once in
+`unresolved` with `reason='ambiguous'`, carrying the source node, the raw
+name and the candidate count.
+
+This module is the other half of that decision. The candidate set is
+`every live node whose qualname's last segment is this name` -- a set the
+`nodes` table already determines -- so it is recomputed here, exactly,
+whenever a query needs it. Nothing was compressed away at write time and
+nothing has to be decompressed: the graph never held these edges, and it
+never needed to.
+
+Why that is the right seam (#25). Whether 971 candidates for one
+`item.save()` is too many is a property of the **question**, not of the
+graph: `impact` wants them ranked and bounded by `--limit`, `effects` wants
+pure reachability through them, `diff` wants none of them (they are a
+statement about the whole repository, not about the symbol being compared).
+Materializing them fixed one answer for every future question, at a cost
+quadratic in repository size -- 2.09M of django's 2.16M edges.
+
+Two shapes are offered, because the two kinds of consumer want different
+things:
+
+*Pointwise.* `callers(node_id)` answers "which ambiguous references could
+mean this node" -- the reverse direction `impact` walks. It touches only
+the names it is asked about, so an `impact` query never pays for the
+fan-out of names it never visits.
+
+*Hubs.* `hub_edges()` answers "the whole fan-out, as a graph" for the
+consumers that need a global picture -- `effects/propagate.py`'s
+reachability closure and `query/islands.py`'s connected components. It
+routes every reference through one synthetic node per name rather than
+enumerating the cross product: `src -> HUB(save)` and `HUB(save) -> dst`
+for every definition named `save`. For *reachability* -- which is all
+either consumer computes over these edges -- that is exactly equivalent to
+the N x M direct edges, and it is O(refs + definitions) instead of
+O(refs x definitions). On django that is ~120k edges rather than ~2.07M.
+
+Hub ids start with a NUL byte, which no file path and therefore no node id
+(`path::qualname`) can contain, so they can never collide with a real node
+and are trivially recognised for filtering back out of a result.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from codegraph.store import Store
+
+#: Prefix for the synthetic per-name node ids `hub_edges` routes through.
+#: A NUL byte cannot appear in a POSIX path, so this cannot collide with a
+#: real `path::qualname` node id.
+HUB_PREFIX = "\x00"
+
+
+def hub_id(name: str) -> str:
+    """The synthetic node every ambiguous reference to `name` routes through."""
+    return f"{HUB_PREFIX}{name}"
+
+
+def is_hub(node_id: str) -> bool:
+    """Is this one of `hub_edges`' synthetic per-name nodes rather than a symbol?"""
+    return node_id.startswith(HUB_PREFIX)
+
+
+def last_segment(dotted: str) -> str:
+    """`a.b.save` -> `save`; the key both halves of the name index share."""
+    return dotted.rpartition(".")[2]
+
+
+class Ambiguity:
+    """One revision's ambiguous references, expandable through its name index.
+
+    Built in two queries and held in memory for the life of a report. On
+    django that is ~46k live names and ~90k ambiguous references -- a
+    fraction of the ~330k edge rows this replaces, and it is read once per
+    report rather than once per node.
+    """
+
+    def __init__(self, store: Store, rev: str) -> None:
+        connection = store.connection
+
+        #: name -> every live node id whose qualname ends in that name. This
+        #: is `resolve._SymbolTable.name_index`, rebuilt from `nodes`: the
+        #: resolver's LOW candidate set is this list verbatim.
+        self.by_name: dict[str, list[str]] = {}
+        #: The inverse, for the pointwise direction. A node id present here
+        #: is by construction a member of `by_name[name_of[node_id]]`.
+        self.name_of: dict[str, str] = {}
+        for row in connection.execute(
+            "SELECT id, qualname FROM nodes WHERE rev=? AND name_binding='live'", (rev,)
+        ):
+            name = last_segment(row["qualname"])
+            self.by_name.setdefault(name, []).append(row["id"])
+            self.name_of[row["id"]] = name
+
+        # Distinct source nodes per name, not raw rows: one function calling
+        # `item.save()` twice writes two ambiguous rows for one relationship,
+        # and counting it twice would inflate `rank.fan_in` exactly the way
+        # duplicate edge rows already must not.
+        calls: dict[str, set[str]] = {}
+        bases: dict[str, set[str]] = {}
+        for row in connection.execute(
+            "SELECT src, raw_name, ref_kind FROM unresolved WHERE rev=? AND reason='ambiguous'",
+            (rev,),
+        ):
+            bucket = calls if row["ref_kind"] == "call" else bases
+            bucket.setdefault(last_segment(row["raw_name"]), set()).add(row["src"])
+        #: name -> the source nodes of every ambiguous CALL to it, sorted so
+        #: two runs of one query produce the same report.
+        self.call_refs: dict[str, list[str]] = {n: sorted(s) for n, s in calls.items()}
+        #: The same for `class X(Base)` references, kept apart because
+        #: `impact`, `effects` and `islands` all walk CALLS and only CALLS.
+        self.base_refs: dict[str, list[str]] = {n: sorted(s) for n, s in bases.items()}
+
+    # -- pointwise -------------------------------------------------------
+    def callers(self, node_id: str) -> list[str]:
+        """Every node with an ambiguous call that could mean `node_id`.
+
+        Empty for a node the name lookup can never reach: a shadowed
+        binding (`name_of` holds live nodes only, exactly as the resolver's
+        own index does), or a name nothing calls ambiguously.
+        """
+        name = self.name_of.get(node_id)
+        if name is None:
+            return []
+        return self.call_refs.get(name, [])
+
+    def inheritors(self, node_id: str) -> list[str]:
+        """The same, for ambiguous base-class references."""
+        name = self.name_of.get(node_id)
+        if name is None:
+            return []
+        return self.base_refs.get(name, [])
+
+    def candidates(self, raw_name: str) -> list[str]:
+        """Everything an ambiguous reference to `raw_name` could mean --
+        the resolver's LOW candidate set, recomputed."""
+        return self.by_name.get(last_segment(raw_name), [])
+
+    # -- whole-graph ------------------------------------------------------
+    def hub_edges(self) -> Iterator[tuple[str, str]]:
+        """The ambiguous CALL fan-out as `(src, dst)` pairs routed through
+        one synthetic node per name.
+
+        Reachability-equivalent to the full cross product and linear rather
+        than quadratic; see the module docstring. A name whose definitions
+        have all disappeared yields nothing rather than a dangling hub.
+        """
+        for name, sources in self.call_refs.items():
+            targets = self.by_name.get(name)
+            if not targets:
+                continue
+            hub = hub_id(name)
+            for source in sources:
+                yield (source, hub)
+            for target in targets:
+                yield (hub, target)
+
+    def call_sites(self) -> int:
+        """How many distinct (source, name) call relationships are deferred."""
+        return sum(len(sources) for sources in self.call_refs.values())
+
+
+__all__ = ["HUB_PREFIX", "Ambiguity", "hub_id", "is_hub", "last_segment"]

--- a/src/codegraph/ambiguity.py
+++ b/src/codegraph/ambiguity.py
@@ -115,6 +115,15 @@ class Ambiguity:
         #: The same for `class X(Base)` references, kept apart because
         #: `impact`, `effects` and `islands` all walk CALLS and only CALLS.
         self.base_refs: dict[str, list[str]] = {n: sorted(s) for n, s in bases.items()}
+        # The same sets kept as sets, for membership rather than iteration.
+        # `rank.fan_in` has to union these with a node's materialized callers
+        # once per dependent, and a report on a crowded name walks thousands
+        # of dependents: iterating a caller list of thousands inside that loop
+        # is quadratic, and measurably so -- `impact Model.save` on django took
+        # 4m45s before this existed. Testing the (small) materialized side for
+        # membership here instead makes the union proportional to it.
+        self._call_sets: dict[str, frozenset[str]] = {n: frozenset(s) for n, s in calls.items()}
+        self._base_sets: dict[str, frozenset[str]] = {n: frozenset(s) for n, s in bases.items()}
 
     # -- pointwise -------------------------------------------------------
     def callers(self, node_id: str) -> list[str]:
@@ -135,6 +144,21 @@ class Ambiguity:
         if name is None:
             return []
         return self.base_refs.get(name, [])
+
+    def caller_count(self, node_id: str, also: set[str]) -> int:
+        """How many DISTINCT nodes call `node_id`, counting `also` -- the
+        node's materialized callers -- and the ambiguous ones together.
+
+        Proportional to `also`, never to the ambiguous set, which is why
+        this lives here rather than as a set union at the call site: on a
+        crowded name the ambiguous set has thousands of members and the
+        materialized one has a handful.
+        """
+        name = self.name_of.get(node_id)
+        calls = self._call_sets.get(name, frozenset()) if name is not None else frozenset()
+        bases = self._base_sets.get(name, frozenset()) if name is not None else frozenset()
+        derived = len(calls) + sum(1 for src in bases if src not in calls)
+        return derived + sum(1 for src in also if src not in calls and src not in bases)
 
     def candidates(self, raw_name: str) -> list[str]:
         """Everything an ambiguous reference to `raw_name` could mean --

--- a/src/codegraph/cli.py
+++ b/src/codegraph/cli.py
@@ -34,7 +34,10 @@ def _print_stats(stats) -> None:
     print(f"blobs: {stats.blobs_parsed} parsed, {stats.blobs_cached} cached")
     print(f"edges: {stats.edges}, unresolved: {stats.unresolved}")
     if stats.ambiguous:
-        print(f"ambiguous: {stats.ambiguous} reference(s) matched too many names to enumerate")
+        print(
+            f"ambiguous: {stats.ambiguous} bare-name reference(s), expanded at query time"
+            " (see `impact --all`)"
+        )
     if stats.parse_errors:
         print(f"parse errors: {stats.parse_errors}")
     if stats.shadowed:
@@ -367,13 +370,19 @@ def build_parser() -> argparse.ArgumentParser:
         "--hops", type=int, default=3, help="Maximum hops to walk (default: 3)"
     )
     impact_parser.add_argument(
-        "--all", action="store_true", help="Include LOW-confidence dependents"
+        "--all",
+        action="store_true",
+        help="Merge LOW-confidence dependents into the main groups instead of sampling them",
     )
     impact_parser.add_argument(
         "--limit",
         type=int,
         default=40,
-        help="Maximum rows to keep, total across dependents and tests (default: 40)",
+        help=(
+            "Maximum rows to keep, total across dependents and tests (default: 40)."
+            " This is the bound on the bare-name fan-out too -- it is a property of"
+            " the question, not of the graph"
+        ),
     )
     impact_parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
     impact_parser.set_defaults(handler=_cmd_impact)

--- a/src/codegraph/config.py
+++ b/src/codegraph/config.py
@@ -2,34 +2,49 @@
 
 from __future__ import annotations
 
+import sys
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 
 CONFIG_NAME = "codegraph.toml"
 
-#: How many equally-plausible low-confidence candidates a single call site may
-#: name before the graph stops enumerating them.
+#: DEPRECATED (#25). The write-time cap on how many equally-plausible
+#: low-confidence candidates one call site would be expanded into.
 #:
-#: The last-resort resolution step matches a call's final dotted segment against
-#: every live definition in the revision. On a small codebase that yields a
-#: handful of candidates and the over-approximation is useful. On a large one it
-#: yields hundreds -- 971 for a single call site in django -- and the resulting
-#: edge set says only "this could be anything named `save`", which is the
-#: question restated, not an answer to it. Enumerating it is also quadratic in
-#: repo size.
+#: It is still read, still validated, and no longer does anything, because
+#: nothing needs it to. The last-resort resolution step matches a call's
+#: final dotted segment against every live definition in the revision; the
+#: resulting candidate set is `name_index[name]` verbatim, which the `nodes`
+#: table already determines. Materializing it stored nothing the graph did
+#: not contain, at a cost quadratic in repository size -- 971 candidates for
+#: one django call site, 2.09M of 2.16M edges. So the fan-out is no longer
+#: written to `edges` at all, at any size, and `ambiguity.py` expands
+#: it on demand instead.
 #:
-#: Above this many LOW candidates the call site is recorded once as ambiguous
-#: (with the name and the count) instead of as N edges. Nothing is discarded to
-#: improve precision -- the claim is identical, stored in O(1) rather than O(n).
-#: Raise it (or set it to 0 for no limit) if you want the full cross product.
+#: Which makes the setting the wrong shape as well as unnecessary: whether
+#: N candidates is too many is a property of the question being asked, not
+#: of the graph. That bound is `--limit` now, per query, where a reader can
+#: change it without rebuilding anything and without changing the answer
+#: every other query gets. Setting `ambiguity_limit` warns; it will be
+#: removed in a future release.
 DEFAULT_AMBIGUITY_LIMIT = 25
+
+#: Emitted once per `Config.load` that sees the deprecated key, on stderr so
+#: it is visible in a terminal without polluting `--json` on stdout.
+AMBIGUITY_LIMIT_DEPRECATED = (
+    f"{CONFIG_NAME}: ambiguity_limit is deprecated and no longer affects the graph."
+    " The bare-name fan-out is expanded at query time now; bound it per query"
+    " with `impact --limit` instead. Remove the setting."
+)
 
 
 @dataclass(frozen=True)
 class Config:
     source_roots: tuple[str, ...] = ("", "src")
     effect_overrides: tuple[dict, ...] = ()
+    #: Retained for one release so an existing codegraph.toml keeps loading.
+    #: Nothing reads it; see `DEFAULT_AMBIGUITY_LIMIT`.
     ambiguity_limit: int = DEFAULT_AMBIGUITY_LIMIT
 
     @classmethod
@@ -39,10 +54,17 @@ class Config:
             return cls()
         data = tomllib.loads(path.read_text())
         limit = data.get("ambiguity_limit", DEFAULT_AMBIGUITY_LIMIT)
+        # Still rejected rather than coerced. A deprecated setting that
+        # silently accepts nonsense is a worse migration than one that keeps
+        # saying no: a user who wrote `ambiguity_limit = "lots"` has a
+        # mistaken belief about the file, and this is the release in which
+        # they can still be told about it.
         if not isinstance(limit, int) or isinstance(limit, bool) or limit < 0:
             raise ValueError(
                 f"{CONFIG_NAME}: ambiguity_limit must be a non-negative integer, got {limit!r}"
             )
+        if "ambiguity_limit" in data:
+            print(AMBIGUITY_LIMIT_DEPRECATED, file=sys.stderr)
         return cls(
             source_roots=tuple(data.get("source_roots", ["", "src"])),
             effect_overrides=tuple(data.get("effect", [])),

--- a/src/codegraph/effects/propagate.py
+++ b/src/codegraph/effects/propagate.py
@@ -49,13 +49,27 @@ depends on this: the graph a confidence was derived from and the graph the
 witness BFS traverses must stay identical, tier-eligibility rule included.
 
 This module never queries the effect `Catalog`: it only reads `effects`
-rows `detect_direct` already wrote, and `edges`.
+rows `detect_direct` already wrote, `edges`, and the ambiguous references
+`edges` deliberately does not hold.
+
+That last part is the #25 seam. The bare-name fan-out is not materialized,
+so the LOW subgraph here is `edges` plus `query/ambiguity.Ambiguity`'s hub
+expansion: `src -> HUB(name) -> every definition named name`. Both things
+computed over it -- `_reverse_reachable`'s closure and `witness_path`'s
+BFS -- are pure reachability, and routing N x M pairs through one hub node
+preserves reachability exactly while costing O(N + M). The hubs are
+synthetic, so they are dropped from the rows written and stripped out of
+any witness chain that passes through one. Note the direction of the
+change: a call site the old ambiguity cap refused to enumerate propagated
+NO effect at all, so this strictly gains reachability rather than losing
+it.
 """
 
 from __future__ import annotations
 
 from collections import deque
 
+from codegraph.ambiguity import Ambiguity, is_hub
 from codegraph.resolve import CONFIDENCE_RANK, HIGH, LOW, MEDIUM, stronger
 from codegraph.store import Store
 
@@ -93,6 +107,13 @@ def propagate(store: Store, rev: str) -> int:
         for tier in _TIERS:
             if _RANK[tier] <= rank:
                 reverse_by_tier[tier].setdefault(dst, set()).add(src)
+
+    # The unmaterialized half, LOW by definition and therefore only ever in
+    # the LOW subgraph. Endpoints are valid by construction (both sides come
+    # from this revision's `nodes`), so they skip the node_ids filter above;
+    # the hubs themselves are dropped when rows are written.
+    for src, dst in Ambiguity(store, rev).hub_edges():
+        reverse_by_tier[LOW].setdefault(dst, set()).add(src)
 
     direct_by_node: dict[str, dict[str, str]] = {}
     direct_nodes_by_kind: dict[str, set[str]] = {}
@@ -139,6 +160,10 @@ def propagate(store: Store, rev: str) -> int:
 
     rows: list[tuple] = []
     for node_id, kinds in node_confidence.items():
+        if is_hub(node_id):
+            # A hub is a routing device, not a symbol: it carries the
+            # reachability of every reference to one name and owns none of it.
+            continue
         own_direct = direct_by_node.get(node_id, {})
         for kind, confidence in kinds.items():
             if kind in own_direct:
@@ -214,6 +239,12 @@ def witness_path(store: Store, rev: str, node_id: str, kind: str, confidence: st
         if _RANK[conf] < target_rank:
             continue
         calls.setdefault(src, []).append(dst)
+    if target_rank == _RANK[LOW]:
+        # The same LOW subgraph `propagate` assigned the confidence over --
+        # it has to be, or this BFS could come back empty for a triple
+        # `propagate` really produced. See the module docstring.
+        for src, dst in Ambiguity(store, rev).hub_edges():
+            calls.setdefault(src, []).append(dst)
 
     visited = {node_id}
     parent: dict[str, str] = {}
@@ -230,6 +261,9 @@ def witness_path(store: Store, rev: str, node_id: str, kind: str, confidence: st
                 while chain[-1] != node_id:
                     chain.append(parent[chain[-1]])
                 chain.reverse()
-                return chain
+                # A hub stands in for one direct bare-name call, so dropping
+                # it leaves a chain of real symbols, each link of which is a
+                # LOW call the resolver genuinely recorded.
+                return [step for step in chain if not is_hub(step)]
             queue.append(nxt)
     return []

--- a/src/codegraph/guide.md
+++ b/src/codegraph/guide.md
@@ -101,14 +101,26 @@ the full set and how confident it is in each edge.
   `effects_reachable` is a **list of effect-kind strings**, not a count —
   in `--json` output it is a real JSON array; in text it is rendered as a
   comma-separated list (`DB_WRITE, PROCESS`), or `none` when the symbol
-  reaches nothing, never Python's list repr. `low_confidence_hidden`
-  counts `LOW`-confidence dependents that are held back from the
-  `dependents` and `tests` groups by default — the resolver's least
-  certain guesses are real information, but they should not read as
-  confirmed impact. Pass `--all` to include them in the listed rows.
+  reaches nothing, never Python's list repr.
+- `LOW`-confidence dependents never enter `dependents` or `tests` — the
+  resolver's least certain guesses are real information, but they should
+  not read as confirmed impact, and they are left out of `symbols`,
+  `modules` and `entry_points` for the same reason. They are not reduced
+  to a number either: the strongest few are listed in their own
+  `low_confidence` group, and `low_confidence_hidden` counts only the ones
+  that did not fit. Pass `--all` to merge the whole set into the main
+  groups instead.
+- Many of those `LOW` rows are not in the stored graph at all. A call like
+  `item.save()` that names nothing importable, nothing module-local and
+  nothing reachable through `self` matches every definition named `save`
+  in the repository — up to 971 of them on django — and codegraph records
+  the call once rather than storing that cross product, expanding it when
+  a query asks. So `impact` can name callers that no edge in the database
+  names, and `--limit` is the only bound on how many.
 - `impact --limit N` caps the *total* rows kept across `dependents` and
   `tests` combined at `N` (default 40) — not `N` each — so the printed
-  report never exceeds its documented budget.
+  report never exceeds its documented budget. The `low_confidence` sample
+  is budgeted separately and never eats into it.
 - `diff`'s summary reads `new_effects: <kind list or none> ·
   added: N · removed: N · changed: N · base: <sha> · head: <rev>`.
   `new_effects` covers every symbol newly reachable at `head`, whether it

--- a/src/codegraph/indexer.py
+++ b/src/codegraph/indexer.py
@@ -280,7 +280,9 @@ class Indexer:
                 return None
         return set(dirty)
 
-    def _propagation_inputs(self, rev: str, paths: set[str]) -> tuple[frozenset, frozenset]:
+    def _propagation_inputs(
+        self, rev: str, paths: set[str]
+    ) -> tuple[frozenset, frozenset, frozenset]:
         """What `propagate` would see differently if these paths changed.
 
         Deliberately projected: `evidence_line` is excluded because propagation
@@ -288,7 +290,7 @@ class Indexer:
         change in what that call means.
         """
         if not paths:
-            return frozenset(), frozenset()
+            return frozenset(), frozenset(), frozenset()
         connection = self.store.connection
         marks = ",".join("?" * len(paths))
         args = (rev, *sorted(paths))
@@ -300,6 +302,19 @@ class Indexer:
                 args,
             )
         )
+        # The ambiguous references are half of propagation's LOW subgraph
+        # and are NOT in `edges` (#25). Leaving them out here would let a
+        # narrowed reconcile that changed only which names a file calls
+        # ambiguously decide propagation had nothing to do, and keep serving
+        # effects derived from the previous revision's fan-out.
+        ambiguous = frozenset(
+            tuple(row)
+            for row in connection.execute(
+                "SELECT src, raw_name, ref_kind FROM unresolved"
+                f" WHERE rev=? AND reason='ambiguous' AND path IN ({marks})",
+                args,
+            )
+        )
         direct = frozenset(
             tuple(row)
             for row in connection.execute(
@@ -308,7 +323,7 @@ class Indexer:
                 args,
             )
         )
-        return edges, direct
+        return edges, ambiguous, direct
 
     def _symbol_signature(self, blob_sha: str) -> frozenset[tuple]:
         """What a blob DECLARES, ignoring what any of it does.
@@ -355,11 +370,13 @@ class Indexer:
         `Catalog.fingerprint` was written for exactly this and had no caller
         until now.
         """
+        # `ambiguity_limit` used to be pinned here and no longer is: since
+        # #25 it changes nothing about the graph, so making it invalidate a
+        # materialized revision would be a rebuild bought with nothing.
         parts = (
             PARSER_VERSION,
             catalog.fingerprint(),
             ",".join(self.config.source_roots),
-            str(self.config.ambiguity_limit),
         )
         return hashlib.blake2b("\x00".join(parts).encode(), digest_size=16).hexdigest()
 

--- a/src/codegraph/init.py
+++ b/src/codegraph/init.py
@@ -105,16 +105,18 @@ _CONFIG_STUB = '''# codegraph configuration -- https://github.com/swalla02/codeg
 # source_roots = ["", "src"]
 
 
-# How many equally-weak candidates one call site may name before codegraph
-# records it once as ambiguous instead of as that many low-confidence edges.
-# A call like `item.save()` that names nothing importable, nothing
-# module-local, and nothing reachable through `self` falls back to matching
-# `save` against every definition in the repository. On django that was 971
-# candidates for a single call site, and 96.6% of the whole graph was that kind
-# of guess -- the edge table grew with the square of the repository. Nothing is
-# discarded at the cap: the one ambiguous record makes the same claim the N
-# edges did. Raise it to get the full cross product back; 0 disables the cap.
-# ambiguity_limit = 25
+# There is deliberately no setting here for the bare-name fan-out. A call like
+# `item.save()` that names nothing importable, nothing module-local and nothing
+# reachable through `self` falls back to matching `save` against every
+# definition in the repository -- 971 candidates for a single call site on
+# django. That set is not stored: it is exactly "every definition named save",
+# which the graph already holds, so codegraph records the call once and expands
+# it when a query asks. How many of them you want to see is a property of the
+# question, so it is `codegraph impact --limit N` (and `--all`), per query,
+# rather than a setting that changes the graph for every future question.
+#
+# `ambiguity_limit` used to live here. It is still accepted and now does
+# nothing; remove it.
 
 
 # Effect overrides, merged over the built-in catalog. The built-ins only know

--- a/src/codegraph/query/impact.py
+++ b/src/codegraph/query/impact.py
@@ -16,20 +16,44 @@ inflate `rank.salience`'s fan-in term.
 Rows whose path starts with `tests/` or whose qualname's last segment
 starts with `test_` are split into their own `tests` group -- a change
 breaking a test is worth knowing, but it should never crowd out production
-callers in the ranked list. `LOW`-confidence dependents are counted in the
-summary but held back from both groups unless `include_low` is set: the
-resolver's least certain guesses are real information, but they should not
-read as confirmed impact by default.
+callers in the ranked list.
+
+`LOW`-confidence dependents get a third group of their own. They must not
+read as confirmed impact, so they never enter `dependents` or `tests`
+unless `include_low` is set -- but a bare `low_confidence_hidden: 235`
+was worse than useless: it told the reader something was there and gave
+them no way to find out whether it was 235 pieces of noise or the one
+caller that mattered, when this module had already ranked them and could
+simply have said. So the strongest few are printed, in a group labelled
+for what they are, on a budget of their own that cannot eat into the
+production callers'. `low_confidence_hidden` now counts only what is
+genuinely not on the page, and `--all` (`include_low`) still merges the
+whole set into the main groups. See #25.
+
+The LOW set itself is not read from `edges`. The bare-name fan-out is
+never materialized (see `ambiguity.py`); it is expanded here, at
+each hop of the walk, through the same live name index the resolver used.
+That makes this report strictly more complete than the stored graph: a
+call site matching 971 definitions contributed *nothing* to `impact`
+before, because the graph declined to enumerate it.
 """
 
 from __future__ import annotations
 
+from codegraph.ambiguity import Ambiguity
 from codegraph.query.rank import fan_in, salience, score
 from codegraph.render import Group, Report, Row, budget
 from codegraph.resolve import CONFIDENCE_RANK, HIGH, LOW, stronger, weaker
 from codegraph.store import Store
 
 _RANK = CONFIDENCE_RANK
+
+#: How many LOW-confidence dependents the default report names before
+#: falling back to a count. Small on purpose: the point is to let a reader
+#: judge whether the hidden set is noise, not to list it -- `--all` does
+#: that. Kept off the `dependents`/`tests` budget entirely, so turning a
+#: bare count into an answer can never cost a production caller its row.
+_LOW_SAMPLE = 5
 
 
 def _reverse_edges(store: Store, rev: str) -> dict[str, dict[str, str]]:
@@ -50,8 +74,27 @@ def _reverse_edges(store: Store, rev: str) -> dict[str, dict[str, str]]:
     return reverse
 
 
+def _predecessors(
+    reverse: dict[str, dict[str, str]], ambiguity: Ambiguity, node_id: str
+) -> dict[str, str]:
+    """Every caller of `node_id`, materialized and derived alike, at the
+    strongest confidence any of them claims.
+
+    The derived half is the bare-name fan-out the graph deliberately does
+    not store, expanded here for this one node -- always LOW, and never
+    strengthening a materialized edge that already reaches the same caller.
+    """
+    callers = dict(reverse.get(node_id, {}))
+    for src in ambiguity.callers(node_id):
+        callers.setdefault(src, LOW)
+    return callers
+
+
 def _walk(
-    reverse: dict[str, dict[str, str]], node_id: str, max_hops: int
+    reverse: dict[str, dict[str, str]],
+    ambiguity: Ambiguity,
+    node_id: str,
+    max_hops: int,
 ) -> dict[str, tuple[int, str]]:
     """Reverse BFS from `node_id`: node -> (hop, path confidence), each node
     recorded once at its shortest hop, with the strongest confidence
@@ -65,7 +108,7 @@ def _walk(
         next_level: dict[str, str] = {}
         for current in current_level:
             path_confidence = level_confidence[current]
-            for src, edge_confidence in reverse.get(current, {}).items():
+            for src, edge_confidence in _predecessors(reverse, ambiguity, current).items():
                 if src in visited:
                     continue
                 candidate = weaker(path_confidence, edge_confidence)
@@ -96,8 +139,9 @@ def impact_report(
     """Everything reachable from `node_id` by walking CALLS edges backward,
     ranked by `rank.score` and split into `dependents` and `tests` groups."""
     connection = store.connection
+    ambiguity = Ambiguity(store, rev)
     reverse = _reverse_edges(store, rev)
-    found = _walk(reverse, node_id, max_hops)
+    found = _walk(reverse, ambiguity, node_id, max_hops)
 
     node_info: dict[str, tuple[str, str, int]] = {}
     if found:
@@ -110,7 +154,7 @@ def impact_report(
 
     dependent_rows: list[Row] = []
     test_rows: list[Row] = []
-    low_confidence_hidden = 0
+    low_rows: list[Row] = []
     entry_points = 0
     modules: set[str] = set()
 
@@ -122,21 +166,26 @@ def impact_report(
             continue
         path, qualname, line_start = info
 
-        if confidence == LOW and not include_low:
-            low_confidence_hidden += 1
-            continue
-
-        salience_value = salience(store, rev, dependent_id)
-        if fan_in(store, rev, dependent_id) == 0:
-            entry_points += 1
-        modules.add(path)
-
+        salience_value = salience(store, rev, dependent_id, ambiguity)
         row = Row(
             id=dependent_id,
             location=f"{path}:{line_start}",
             detail=f"hop {hop}, {confidence} confidence",
             score=score(hop, confidence, salience_value),
         )
+
+        if confidence == LOW and not include_low:
+            # Ranked, but kept out of the counted `symbols`/`modules`
+            # totals and out of `entry_points`: those describe impact the
+            # report is willing to stand behind, and the whole reason this
+            # group exists separately is that a LOW row is not that.
+            low_rows.append(row)
+            continue
+
+        if fan_in(store, rev, dependent_id, ambiguity) == 0:
+            entry_points += 1
+        modules.add(path)
+
         if _is_test(path, qualname):
             test_rows.append(row)
         else:
@@ -154,6 +203,17 @@ def impact_report(
             groups.append(Group("tests", kept_tests))
         truncated = truncated or tests_truncated
 
+    # The LOW group is budgeted LAST and separately, on `_LOW_SAMPLE` rather
+    # than on whatever is left of `limit`: it exists to make the count
+    # actionable, not to compete with the callers the report is confident
+    # about. `--limit 5` still means five production dependents.
+    low_confidence_hidden = len(low_rows)
+    if low_rows:
+        kept_low, _ = budget(low_rows, min(_LOW_SAMPLE, limit))
+        if kept_low:
+            groups.append(Group("low_confidence", kept_low))
+            low_confidence_hidden -= len(kept_low)
+
     effects_reachable = sorted(
         {
             row["kind"]
@@ -167,6 +227,9 @@ def impact_report(
         "symbols": len(dependent_rows) + len(test_rows),
         "modules": len(modules),
         "entry_points": entry_points,
+        # Only what is NOT on the page. `low_confidence` above holds the
+        # strongest of them, so 0 here now means "all of them are listed",
+        # not "there were none" -- the group's presence says which.
         "low_confidence_hidden": low_confidence_hidden,
         "effects_reachable": effects_reachable,
     }

--- a/src/codegraph/query/islands.py
+++ b/src/codegraph/query/islands.py
@@ -43,6 +43,18 @@ course coupled -- `INHERITS` exists so the resolver can do method
 resolution, and the coupling reaches `impact` through the CALLS edges that
 resolution produces, which is where it belongs.
 
+*The bare-name fan-out counts, and it is not in `edges`.* Since #25 the
+resolver does not materialize a call whose name matches more than one
+definition; `ambiguity.py` expands it on demand instead. This report
+has to include it, or its central claim -- that an island bounds what an
+unlimited-hop `impact` or `effects` walk could ever touch -- stops being
+true, since both of those expand it too. It is folded in through the same
+per-name hub nodes `effects/propagate.py` uses: for connectivity, unioning
+`src` with `HUB(save)` and `HUB(save)` with every definition named `save`
+puts exactly the same set of symbols in one component as the N x M direct
+edges would, for O(N + M) rather than O(N x M). Hubs are treated exactly
+like the module nodes below -- connectivity, never membership.
+
 *Synthetic `path::<module>` nodes connect islands but are never members.*
 Their edges are real: a module-scope call (`_init()` at the foot of
 `status_codes.py`) is the only thing tying that file's helper to the rest
@@ -68,6 +80,7 @@ from __future__ import annotations
 
 from collections import Counter
 
+from codegraph.ambiguity import Ambiguity
 from codegraph.render import Group, Report, Row, budget
 from codegraph.store import Store
 
@@ -139,6 +152,14 @@ def islands_report(store: Store, rev: str, limit: int = 20) -> Report:
     for src, dst in pairs:
         components.union(src, dst)
     fan_in = Counter(dst for _, dst in pairs)
+
+    # The unmaterialized bare-name fan-out, through per-name hubs. Hub pairs
+    # join components but are deliberately kept out of `fan_in`: a hub is not
+    # a caller, and letting one stand in for its whole reference set would
+    # rank a name's definitions by how ambiguous the name is rather than by
+    # how much of the graph actually reaches them.
+    for src, dst in Ambiguity(store, rev).hub_edges():
+        components.union(src, dst)
 
     grouped: dict[str, list[str]] = {}
     for node_id in members:

--- a/src/codegraph/query/rank.py
+++ b/src/codegraph/query/rank.py
@@ -50,10 +50,9 @@ def fan_in(store: Store, rev: str, node_id: str, ambiguity: Ambiguity | None = N
             "SELECT DISTINCT src FROM edges WHERE rev=? AND dst=?", (rev, node_id)
         )
     }
-    if ambiguity is not None:
-        sources.update(ambiguity.callers(node_id))
-        sources.update(ambiguity.inheritors(node_id))
-    return len(sources)
+    if ambiguity is None:
+        return len(sources)
+    return ambiguity.caller_count(node_id, sources)
 
 
 def salience(
@@ -71,10 +70,15 @@ def salience(
     if callers == 0:
         value += 0.5
 
-    row = connection.execute(
-        "SELECT qualname FROM nodes WHERE rev=? AND id=?", (rev, node_id)
-    ).fetchone()
-    last_segment = row["qualname"].rpartition(".")[2] if row else node_id.rpartition(".")[2]
+    # `Ambiguity` already holds every live node's last qualname segment --
+    # it is the key of the very name index this expands through -- so with
+    # one in hand this is a dict lookup rather than a query per dependent.
+    last_segment = ambiguity.name_of.get(node_id) if ambiguity is not None else None
+    if last_segment is None:
+        row = connection.execute(
+            "SELECT qualname FROM nodes WHERE rev=? AND id=?", (rev, node_id)
+        ).fetchone()
+        last_segment = row["qualname"].rpartition(".")[2] if row else node_id.rpartition(".")[2]
     if not last_segment.startswith("_"):
         value += 0.3
 

--- a/src/codegraph/query/rank.py
+++ b/src/codegraph/query/rank.py
@@ -12,6 +12,7 @@ distinct callers a node has.
 
 from __future__ import annotations
 
+from codegraph.ambiguity import Ambiguity
 from codegraph.resolve import HIGH, LOW, MEDIUM
 from codegraph.store import Store
 
@@ -28,28 +29,43 @@ def score(hop: int, confidence: str, salience_value: float) -> float:
     return (1.0 / hop) * _CONFIDENCE_WEIGHT[confidence] * (1.0 + salience_value)
 
 
-def fan_in(store: Store, rev: str, node_id: str) -> int:
+def fan_in(store: Store, rev: str, node_id: str, ambiguity: Ambiguity | None = None) -> int:
     """Count of DISTINCT callers of `node_id` -- never raw edge rows, since
     the `edges` table can hold more than one row for the same (src, dst)
     pair. `salience` folds this into its composite score; callers that need
     the raw fan-in itself (e.g. to test whether a node is a true entry
     point, `fan_in == 0`) should call this directly rather than
     reverse-engineering it out of `salience`'s combined value, which a
-    public, well-called node can also cross via its other two terms alone."""
-    row = store.connection.execute(
-        "SELECT COUNT(DISTINCT src) AS n FROM edges WHERE rev=? AND dst=?", (rev, node_id)
-    ).fetchone()
-    return row["n"]
+    public, well-called node can also cross via its other two terms alone.
+
+    With an `ambiguity`, the bare-name callers the graph does not store are
+    counted too -- unioned by source id rather than added, since a caller
+    that both imports a symbol and calls it by bare name elsewhere is still
+    one caller. Without one this counts materialized edges only, which is
+    what a caller holding no expansion for the revision can honestly say.
+    """
+    sources = {
+        row["src"]
+        for row in store.connection.execute(
+            "SELECT DISTINCT src FROM edges WHERE rev=? AND dst=?", (rev, node_id)
+        )
+    }
+    if ambiguity is not None:
+        sources.update(ambiguity.callers(node_id))
+        sources.update(ambiguity.inheritors(node_id))
+    return len(sources)
 
 
-def salience(store: Store, rev: str, node_id: str) -> float:
+def salience(
+    store: Store, rev: str, node_id: str, ambiguity: Ambiguity | None = None
+) -> float:
     """How much a node deserves attention on its own merits: 0.5 if it has
     no callers of its own (an entry point), 0.3 if its qualname's last
     segment is not private (does not start with `_`), plus a fan-in term
     capped at `_FAN_IN_CAP` distinct callers."""
     connection = store.connection
 
-    callers = fan_in(store, rev, node_id)
+    callers = fan_in(store, rev, node_id, ambiguity)
 
     value = 0.0
     if callers == 0:

--- a/src/codegraph/resolve.py
+++ b/src/codegraph/resolve.py
@@ -486,32 +486,27 @@ def _source_id(ref: ParsedRef, table: _SymbolTable, path: str) -> str:
     return table.qualname_index.get((path, ref.from_qualname), candidates[-1][0])
 
 
-def split_by_ambiguity_limit(
-    hits: list[tuple[str, str]], limit: int
-) -> tuple[list[tuple[str, str]], int]:
-    """Split a resolver's candidates into the ones to materialize and the count
-    of low-confidence ones being collapsed instead.
+def is_derivable_fanout(hits: list[tuple[str, str]]) -> bool:
+    """Is this candidate set the bare-name fan-out, recomputable from the
+    name index alone?
 
-    The over-approximation bias says a candidate is never dropped to improve
-    precision, and this does not drop one: when a bare name matches hundreds of
-    definitions, the N edges and the single "ambiguous, N candidates" record
-    make exactly the same claim. Enumerating it is what is being declined, not
-    asserting it -- and enumerating it is quadratic in repo size while saying
-    nothing a reader could act on.
+    True exactly when every candidate is LOW, which happens exactly when the
+    last-resort step (`_by_last_segment`) matched a bare name against more
+    than one live definition. Every other step returns HIGH or MEDIUM: an
+    imported name, a module-local name, a `self.X` hit and its overrides, and
+    a last-segment match with a single answer all name something the resolver
+    actually distinguished, and all get an edge.
 
-    Only LOW candidates are ever collapsed. A HIGH or MEDIUM hit means the
-    resolver actually distinguished something, and is always materialized --
-    including alongside a collapsed LOW set, so a call site with one confident
-    answer and a long ambiguous tail keeps the answer.
-
-    `limit <= 0` disables the cap entirely.
+    A LOW set does not. It is `name_index[name]` verbatim -- a set the `nodes`
+    table already determines -- so materializing it stores nothing the graph
+    did not already contain, at a cost quadratic in repository size (2.09M of
+    django's 2.16M edges, 96.6%, before #6). It is recorded once in
+    `unresolved` with `reason='ambiguous'` instead, and `ambiguity.py`
+    reconstructs it on demand. Nothing is dropped and nothing is capped: the
+    bound on how many of them a *reader* sees is `--limit`, a property of the
+    question, not of the graph. See #25.
     """
-    if limit <= 0 or len(hits) <= limit:
-        return hits, 0
-    weak = [hit for hit in hits if hit[1] == LOW]
-    if len(weak) <= limit:
-        return hits, 0
-    return [hit for hit in hits if hit[1] != LOW], len(weak)
+    return bool(hits) and all(confidence == LOW for _, confidence in hits)
 
 
 def _load_bases(connection: sqlite3.Connection, rev: str) -> dict[str, list[str]]:
@@ -550,13 +545,13 @@ def resolve_revision(
     trusts it. Passing `None` rewrites the whole revision, which cannot leave a
     stale edge behind under any circumstances.
 
-    `config.ambiguity_limit` bounds how many indistinguishable LOW candidates a
-    single reference will be expanded into; past it the reference is recorded
-    once in `unresolved` as ambiguous. See `split_by_ambiguity_limit`.
+    The bare-name fan-out is never written to `edges`: a reference whose only
+    candidates are LOW is recorded once in `unresolved` as ambiguous, carrying
+    the source node, the name, and the count, and is expanded at query time
+    instead. See `is_derivable_fanout` and `ambiguity.py`.
     """
     resolver = resolver or AstResolver()
     connection = store.connection
-    limit = config.ambiguity_limit
     table = _SymbolTable(store, rev, config)
 
     if only_paths is None:
@@ -603,12 +598,15 @@ def resolve_revision(
             src = _source_id(ref, table, path)
             # A base named by a bare, repo-wide-ambiguous name fans out exactly
             # like a call does, and on a large repo it is the larger half of the
-            # blowup. Capping it cannot affect the MRO: only HIGH links feed
-            # `bases`, and the cap only ever collapses LOW ones.
-            kept, ambiguous_count = split_by_ambiguity_limit(
-                resolver.resolve_call(ref, ctx), limit
-            )
-            for node_id, confidence in kept:
+            # blowup. Deferring it cannot affect the MRO: only HIGH links feed
+            # `bases`, and only an all-LOW set is deferred.
+            hits = resolver.resolve_call(ref, ctx)
+            if is_derivable_fanout(hits):
+                ambiguous_rows.append(
+                    (rev, src, path, ref.line, ref.raw_name, "base", "ambiguous", len(hits))
+                )
+                continue
+            for node_id, confidence in hits:
                 edge_rows.append(
                     (rev, src, node_id, "INHERITS", confidence, PROVENANCE, path, ref.line)
                 )
@@ -617,10 +615,6 @@ def resolve_revision(
                 # the walk falls through to the repo-wide name match anyway.
                 if confidence == HIGH and only_paths is None:
                     bases.setdefault(src, []).append(node_id)
-            if ambiguous_count:
-                ambiguous_rows.append(
-                    (rev, path, ref.line, ref.raw_name, "base", "ambiguous", ambiguous_count)
-                )
 
     # The hierarchy is complete now, so it can be inverted once: `self.X`
     # needs to see downwards (overrides in subclasses) as well as upwards.
@@ -639,26 +633,33 @@ def resolve_revision(
         for ref in call_refs.get(path, ()):
             src = _source_id(ref, table, path)
             hits = resolver.resolve_call(ref, ctx)
-            kept, ambiguous_count = split_by_ambiguity_limit(hits, limit)
-            for node_id, confidence in kept:
+            if is_derivable_fanout(hits):
+                # Not an edge and not a gap: the answer, held in the one form
+                # that does not grow with the square of the repository. See
+                # `is_derivable_fanout`.
+                ambiguous_rows.append(
+                    (rev, src, path, ref.line, ref.raw_name, "call", "ambiguous", len(hits))
+                )
+                continue
+            for node_id, confidence in hits:
                 edge_rows.append(
                     (rev, src, node_id, "CALLS", confidence, PROVENANCE, path, ref.line)
                 )
-            if ambiguous_count:
-                ambiguous_rows.append(
-                    (rev, path, ref.line, ref.raw_name, "call", "ambiguous", ambiguous_count)
-                )
-            elif is_builtin_call(ref):
+            if is_builtin_call(ref):
                 # Recorded, but not as a gap. A builtin is a reference the
                 # resolver understood and deliberately did not link to a repo
                 # symbol -- counting it as "unresolved" buries the real gaps
                 # under a large constant. Still written, so the choice is
                 # visible rather than silent.
-                builtin_rows.append((rev, path, ref.line, ref.raw_name, "call", "builtin", 0))
+                builtin_rows.append(
+                    (rev, src, path, ref.line, ref.raw_name, "call", "builtin", 0)
+                )
             elif not hits:
                 # Never dropped: the ref stays in `blob_refs` for effect
                 # detection, and the gap is counted as a health signal.
-                unresolved_rows.append((rev, path, ref.line, ref.raw_name, "call", "unknown", 0))
+                unresolved_rows.append(
+                    (rev, src, path, ref.line, ref.raw_name, "call", "unknown", 0)
+                )
 
     connection.executemany(
         "INSERT INTO edges(rev, src, dst, kind, confidence, provenance, callsite_path,"
@@ -666,8 +667,8 @@ def resolve_revision(
         edge_rows,
     )
     connection.executemany(
-        "INSERT INTO unresolved(rev, path, line, raw_name, ref_kind, reason, candidates)"
-        " VALUES(?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO unresolved(rev, src, path, line, raw_name, ref_kind, reason,"
+        " candidates) VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
         unresolved_rows + ambiguous_rows + builtin_rows,
     )
     # Counted over the whole revision, not over this pass: a narrowed rewrite

--- a/src/codegraph/store.py
+++ b/src/codegraph/store.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 
 WORKTREE = "WORKTREE"
 
@@ -113,16 +113,26 @@ CREATE TABLE IF NOT EXISTS effects (
 CREATE TABLE IF NOT EXISTS imports (
     rev TEXT NOT NULL, importer_path TEXT NOT NULL, module TEXT NOT NULL
 );
--- A call site that produced no edge, and why. `reason` is 'unknown' when no
--- candidate was found at all, or 'ambiguous' when too many equally-weak ones
--- were (see config.DEFAULT_AMBIGUITY_LIMIT); `candidates` carries the count the
--- ambiguous case declined to enumerate, and is 0 for 'unknown'. Separating the
--- two matters because they are opposite problems: 'unknown' means the resolver
--- is blind to something, 'ambiguous' means it sees too much. 'builtin' is
--- neither: a call the resolver understood and deliberately did not link to a
--- repo symbol, kept out of the gap count so the real gaps stay visible.
+-- A reference that produced no edge, and why.
+--
+-- 'unknown' means no candidate was found at all -- the resolver is blind to
+-- something. 'builtin' means a call the resolver understood and deliberately
+-- did not link to a repo symbol, kept out of the gap count so the real gaps
+-- stay visible. 'ambiguous' is the opposite of 'unknown': the resolver saw
+-- too much. The last-resort step matches a bare name against every live
+-- definition in the revision, and when more than one answers, that fan-out is
+-- recorded HERE, once, instead of as N low-confidence edges.
+--
+-- That is not a truncation. The candidate set is `every live node whose
+-- qualname's last segment is this name`, which the `nodes` table already
+-- holds, so `ambiguity.py` recomputes it exactly at query time from
+-- (`src`, `raw_name`) -- see #25. `candidates` is the count as of indexing,
+-- kept for reporting only; nothing reads it to decide anything. `src` is the
+-- node the reference was made from, and is the one thing about the reference
+-- that is NOT derivable from the name index.
 CREATE TABLE IF NOT EXISTS unresolved (
     rev TEXT NOT NULL,
+    src TEXT NOT NULL DEFAULT '',
     path TEXT NOT NULL,
     line INTEGER NOT NULL,
     raw_name TEXT NOT NULL,
@@ -136,6 +146,10 @@ CREATE INDEX IF NOT EXISTS idx_edges_src ON edges(rev, src);
 CREATE INDEX IF NOT EXISTS idx_imports_module ON imports(rev, module);
 CREATE INDEX IF NOT EXISTS idx_nodes_qualname ON nodes(rev, qualname);
 CREATE INDEX IF NOT EXISTS idx_effects_node ON effects(rev, node_id);
+-- Query-time ambiguity expansion reads every ambiguous row for a revision
+-- in one pass; without this it is a full scan of a table that also holds
+-- the (much larger) 'unknown' and 'builtin' rows.
+CREATE INDEX IF NOT EXISTS idx_unresolved_reason ON unresolved(rev, reason);
 """
 
 _IGNORE_TEXT = "*\n"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,14 +11,37 @@ def test_defaults_apply_when_there_is_no_config_file(tmp_path):
     assert config.effect_overrides == ()
 
 
-def test_ambiguity_limit_is_read_from_the_config_file(tmp_path):
+def test_ambiguity_limit_is_still_read_from_the_config_file(tmp_path):
+    """Deprecated by #25, but still parsed: an existing codegraph.toml must
+    keep loading for a release rather than becoming an error."""
     (tmp_path / "codegraph.toml").write_text("ambiguity_limit = 100\n")
     assert Config.load(tmp_path).ambiguity_limit == 100
 
 
-def test_ambiguity_limit_zero_is_accepted_as_no_limit(tmp_path):
+def test_ambiguity_limit_zero_is_still_accepted(tmp_path):
     (tmp_path / "codegraph.toml").write_text("ambiguity_limit = 0\n")
     assert Config.load(tmp_path).ambiguity_limit == 0
+
+
+def test_ambiguity_limit_warns_on_use(tmp_path, capsys):
+    (tmp_path / "codegraph.toml").write_text("ambiguity_limit = 100\n")
+    Config.load(tmp_path)
+    err = capsys.readouterr().err
+    assert "ambiguity_limit is deprecated" in err
+    assert "--limit" in err, "the warning must name what replaced it"
+
+
+def test_a_config_without_the_setting_is_silent(tmp_path, capsys):
+    """The warning fires on USE, not on the default. Every project that never
+    set it would otherwise be told off for a setting it does not have."""
+    (tmp_path / "codegraph.toml").write_text('source_roots = ["", "src"]\n')
+    Config.load(tmp_path)
+    assert "deprecated" not in capsys.readouterr().err
+
+
+def test_no_config_file_at_all_is_silent(tmp_path, capsys):
+    Config.load(tmp_path)
+    assert capsys.readouterr().err == ""
 
 
 @pytest.mark.parametrize("value", ["-1", '"25"', "2.5", "true"])

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -594,3 +594,61 @@ def test_a_project_override_still_matches_first_party_code(repo, write):
     store = build(repo)
     assert "DB_WRITE" in effect_kinds_at(store, "app/service.py::persist")
     store.close()
+
+
+# -- effects still flow through the fan-out the graph does not store --------
+#
+# Since #25 a bare-name call matching more than one definition writes no edge
+# at all. Propagation reconstructs that subgraph through one synthetic hub per
+# name (`ambiguity.hub_edges`), which is reachability-equivalent to the N x M
+# direct edges and linear rather than quadratic. Two things have to hold: the
+# effect still arrives, and the witness the user is shown is a chain of real
+# symbols they can open -- never the hub, which is not a symbol anyone wrote.
+
+
+def test_an_effect_reachable_only_through_an_ambiguous_call_still_arrives(repo, write):
+    write(
+        "one.py",
+        "import requests\n\n\nclass One:\n    def shared(self):\n        requests.get('u')\n",
+        commit="one",
+    )
+    write("two.py", "class Two:\n    def shared(self):\n        pass\n", commit="two")
+    write("caller.py", "def query(thing):\n    thing.shared()\n", commit="caller")
+    store = build(repo)
+
+    stored = store.connection.execute(
+        "SELECT COUNT(*) AS n FROM edges WHERE rev='HEAD' AND src='caller.py::query'"
+    ).fetchone()["n"]
+    assert stored == 0, "the fixture stopped exercising the unmaterialized path"
+    assert "NETWORK" in kinds(effects_report(store, "HEAD", "caller.py::query"))
+    store.close()
+
+
+def test_the_witness_through_an_ambiguous_call_names_only_real_symbols(repo, write):
+    write(
+        "one.py",
+        "import requests\n\n\nclass One:\n    def shared(self):\n        requests.get('u')\n",
+        commit="one",
+    )
+    write("two.py", "class Two:\n    def shared(self):\n        pass\n", commit="two")
+    write("caller.py", "def query(thing):\n    thing.shared()\n", commit="caller")
+    store = build(repo)
+    chain = witness_path(store, "HEAD", "caller.py::query", "NETWORK", "LOW")
+    assert chain == ["caller.py::query", "one.py::One.shared"]
+    store.close()
+
+
+def test_a_call_site_past_any_old_cap_still_carries_its_effect(repo, write):
+    """60 candidates is well past the cap #6 imposed, so before this the call
+    site propagated no effect at all -- the direction of the #25 change is a
+    gain in reachability, never a loss."""
+    for i in range(60):
+        write(f"m{i}.py", f"class C{i}:\n    def save(self):\n        return {i}\n")
+    write(
+        "m0.py",
+        "import requests\n\n\nclass C0:\n    def save(self):\n        requests.get('u')\n",
+    )
+    write("caller.py", "def persist(item):\n    return item.save()\n", commit="all")
+    store = build(repo)
+    assert "NETWORK" in kinds(effects_report(store, "HEAD", "caller.py::persist"))
+    store.close()

--- a/tests/test_impact.py
+++ b/tests/test_impact.py
@@ -70,16 +70,66 @@ def test_tests_are_bucketed_separately(repo, write):
     store.close()
 
 
-def test_low_confidence_counted_but_not_listed(repo, write):
+def group(report, title):
+    return {row.id for g in report.groups if g.title == title for row in g.rows}
+
+
+def test_low_confidence_is_named_but_never_read_as_confirmed_impact(repo, write):
+    """A LOW caller must not sit among the dependents the report stands
+    behind -- and it must not be reduced to a number either. Before #25 this
+    printed `low_confidence_hidden: 1` and gave the reader no way to find out
+    whether that 1 was noise or the caller that mattered."""
     write("one.py", "class One:\n    def shared(self):\n        pass\n", commit="1")
     write("two.py", "class Two:\n    def shared(self):\n        pass\n", commit="2")
     write("caller.py", "def go(thing):\n    thing.shared()\n", commit="c")
     store = build(repo)
     report = impact_report(store, "HEAD", "one.py::One.shared")
-    assert "caller.py::go" not in listed(report)
-    assert report.summary["low_confidence_hidden"] >= 1
+    assert "caller.py::go" not in group(report, "dependents")
+    assert "caller.py::go" not in group(report, "tests")
+    assert "caller.py::go" in group(report, "low_confidence")
+    # It is on the page, so it is not hidden.
+    assert report.summary["low_confidence_hidden"] == 0
+    # ...and it is not counted as impact the report stands behind.
+    assert report.summary["symbols"] == 0
     with_low = impact_report(store, "HEAD", "one.py::One.shared", include_low=True)
-    assert "caller.py::go" in listed(with_low)
+    assert "caller.py::go" in group(with_low, "dependents")
+    assert with_low.summary["symbols"] == 1
+    store.close()
+
+
+def test_more_low_confidence_callers_than_the_sample_are_counted_as_hidden(repo, write):
+    """The sample is a sample. Past it the count comes back -- but it now
+    counts only what is genuinely NOT on the page."""
+    for i in range(12):
+        write(f"c{i}.py", f"def go{i}(thing):\n    thing.shared()\n", commit=f"c{i}")
+    write("one.py", "class One:\n    def shared(self):\n        pass\n", commit="1")
+    write("two.py", "class Two:\n    def shared(self):\n        pass\n", commit="2")
+    store = build(repo)
+    report = impact_report(store, "HEAD", "one.py::One.shared")
+    shown = group(report, "low_confidence")
+    assert len(shown) == 5
+    assert report.summary["low_confidence_hidden"] == 12 - 5
+    store.close()
+
+
+def test_the_low_confidence_sample_never_costs_a_dependent_its_row(repo, write):
+    """`--limit N` means N production dependents. Making the hidden count
+    actionable must not be paid for out of the budget the confident callers
+    were promised."""
+    write("one.py", "def shared():\n    pass\n", commit="1")
+    write("two.py", "class Two:\n    def shared(self):\n        pass\n", commit="2")
+    write("guess.py", "def guess(thing):\n    thing.shared()\n", commit="g")
+    write(
+        "sure.py",
+        "from one import shared\n\n\n"
+        + "\n\n".join(f"def sure{i}():\n    shared()" for i in range(3))
+        + "\n",
+        commit="s",
+    )
+    store = build(repo)
+    report = impact_report(store, "HEAD", "one.py::shared", limit=3)
+    assert group(report, "dependents") == {f"sure.py::sure{i}" for i in range(3)}
+    assert group(report, "low_confidence") == {"guess.py::guess"}
     store.close()
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -311,8 +311,13 @@ def test_the_config_stub_documents_every_setting_and_effect_kind(repo):
     assert main(["init", "--path", str(repo)]) == 0
 
     text = (repo / CONFIG_NAME).read_text()
-    for setting in ("source_roots", "ambiguity_limit", "[[effect]]"):
+    for setting in ("source_roots", "[[effect]]"):
         assert setting in text
+    # ...but never a deprecated one as something to uncomment. `ambiguity_limit`
+    # is mentioned only to say it does nothing (#25); handing a new project a
+    # knob that is on its way out is worse than not documenting it.
+    assert "# ambiguity_limit = " not in text
+    assert "ambiguity_limit` used to live here" in text
     for kind in EFFECT_KINDS:
         assert kind in text, f"effect kind {kind} is undocumented in {CONFIG_NAME}"
 

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -4,8 +4,9 @@ import subprocess
 
 import pytest
 
-from codegraph.config import DEFAULT_AMBIGUITY_LIMIT
+from codegraph.ambiguity import Ambiguity
 from codegraph.indexer import GitTreeSource, Indexer
+from codegraph.query.impact import impact_report
 from codegraph.store import WORKTREE, Store
 from tests.conftest import git
 
@@ -296,11 +297,17 @@ def test_graph_size_grows_with_the_repo_not_with_its_square(repo, write, tmp_pat
     growth = large / small
     # 4x the files. Linear growth is 4x; quadratic is 16x. The bound is loose on
     # purpose -- it is a growth-RATE guard, not a size target, and must not be
-    # tightened into a benchmark.
+    # tightened into a benchmark. (Since #25 the quadratic term is not stored at
+    # all rather than capped, so the real ratio is 4.0; the guard stays where it
+    # was so that regressing to EITHER the cap or the cross product trips it.)
     assert growth < 6.0, f"{small} -> {large} edges for 4x the files ({growth:.1f}x growth)"
 
 
-def test_no_single_reference_is_expanded_past_the_ambiguity_limit(repo, write):
+def test_no_reference_is_expanded_into_the_bare_name_cross_product(repo, write):
+    """#6 capped this at 25 edges per call site. #25 removed the cap and the
+    reason for it together: the fan-out is `name_index[name]`, so storing any
+    of it stores nothing new. 60 same-named definitions, 60 call sites, and
+    the quadratic term is not in the table at any size."""
     duck_typed_repo(repo, write, 60)
     store = Store.open(repo)
     Indexer(repo, store, GitTreeSource(repo)).reconcile("HEAD")
@@ -310,7 +317,42 @@ def test_no_single_reference_is_expanded_past_the_ambiguity_limit(repo, write):
     ).fetchall()
     assert rows, "no edges at all — the fixture stopped exercising anything"
     worst = max(row["n"] for row in rows)
-    assert worst <= DEFAULT_AMBIGUITY_LIMIT, f"a single call site produced {worst} edges"
+    assert worst == 1, f"a single call site produced {worst} edges"
+    low = store.connection.execute(
+        "SELECT COUNT(*) AS n FROM edges WHERE rev='HEAD' AND confidence='LOW'"
+    ).fetchone()["n"]
+    assert low == 0, f"{low} bare-name fan-out edges were materialized"
+    store.close()
+
+
+def test_a_call_site_past_any_cap_still_reaches_impact(repo, write):
+    """The property #25 exists for, end to end. 60 candidates is well past the
+    cap that used to exist, so before this the call site contributed NOTHING to
+    `impact` -- and the graph still must not store it."""
+    duck_typed_repo(repo, write, 60)
+    store = Store.open(repo)
+    Indexer(repo, store, GitTreeSource(repo)).reconcile("HEAD")
+
+    report = impact_report(store, "HEAD", "m0.py::C0.save", limit=100, include_low=True)
+    callers = {row.id for group in report.groups for row in group.rows}
+    assert {f"m{i}.py::persist{i}" for i in range(60)} <= callers
+
+    stored = store.connection.execute(
+        "SELECT COUNT(*) AS n FROM edges WHERE rev='HEAD' AND dst='m0.py::C0.save'"
+    ).fetchone()["n"]
+    assert stored == 0, "the answer came from the edge table, not from the expansion"
+    store.close()
+
+
+def test_the_default_report_names_the_strongest_of_them_rather_than_counting(repo, write):
+    """`low_confidence_hidden: 60` is not an answer. The reader gets rows."""
+    duck_typed_repo(repo, write, 60)
+    store = Store.open(repo)
+    Indexer(repo, store, GitTreeSource(repo)).reconcile("HEAD")
+    report = impact_report(store, "HEAD", "m0.py::C0.save")
+    named = {row.id for g in report.groups if g.title == "low_confidence" for row in g.rows}
+    assert named, "the report went back to a bare count"
+    assert all(name.endswith("persist" + name.split("::")[0][1:-3]) for name in named)
     store.close()
 
 
@@ -522,12 +564,23 @@ def test_a_definition_added_elsewhere_updates_another_files_edges(repo, write):
     indexer.reconcile(WORKTREE)
 
     def targets():
-        return {
+        """Everything `caller`'s one call could mean -- materialized edges
+        AND the bare-name fan-out the graph deliberately does not store
+        (#25), which is where the answer moves to the moment a second
+        `save` exists and the name stops being unique."""
+        materialized = {
             row["dst"]
             for row in store.connection.execute(
                 "SELECT dst FROM edges WHERE rev=? AND src='caller.py::caller'", (WORKTREE,)
             )
         }
+        ambiguity = Ambiguity(store, WORKTREE)
+        derived = {
+            node_id
+            for node_id in ambiguity.candidates("item.save")
+            if "caller.py::caller" in ambiguity.callers(node_id)
+        }
+        return materialized | derived
 
     assert targets() == {"one.py::One.save"}
 

--- a/tests/test_islands.py
+++ b/tests/test_islands.py
@@ -273,3 +273,55 @@ def test_islands_json_output_is_machine_readable(repo, write, capsys):
     payload = json.loads(capsys.readouterr().out)
     assert payload["summary"]["islands"] == 1
     assert payload["groups"][0]["title"] == "islands"
+
+
+# -- the bare-name fan-out joins islands even though it is not in `edges` ----
+#
+# The report's central claim is that an island bounds what an unlimited-hop
+# `impact` or `effects` walk could ever touch. Since #25 both of those expand
+# the ambiguous references the graph does not store, so this has to as well or
+# the claim stops being true -- it would report a boundary as uncrossable that
+# a walk crosses.
+
+
+def test_an_ambiguous_call_joins_the_symbols_it_could_mean(repo, write):
+    """`thing.save()` matches both `save` definitions and is stored as one
+    `unresolved` row, not as two edges. All three symbols are still one
+    island, because `impact` can walk from any of them to any other."""
+    write("one.py", "class One:\n    def save(self):\n        pass\n", commit="1")
+    write("two.py", "class Two:\n    def save(self):\n        pass\n", commit="2")
+    write("caller.py", "def go(thing):\n    thing.save()\n", commit="c")
+    store = build(repo)
+
+    stored = store.connection.execute(
+        "SELECT COUNT(*) AS n FROM edges WHERE rev='HEAD' AND kind='CALLS'"
+    ).fetchone()["n"]
+    assert stored == 0, "the fixture stopped exercising the unmaterialized path"
+
+    report = islands_report(store, "HEAD")
+    assert report.summary["largest"] == 3
+    joined = [row for row in rows(report, "islands")]
+    assert len(joined) == 1
+    assert set(named_ids(joined[0])) == {
+        "one.py::One.save",
+        "two.py::Two.save",
+        "caller.py::go",
+    }
+    store.close()
+
+
+def test_a_hub_is_never_a_member_of_the_island_it_joins(repo, write):
+    """The per-name hub the expansion routes through is a device, not a
+    symbol -- exactly like `path::<module>`. Counting one would invent an
+    island member nobody wrote, and inflate `symbols` past the node count."""
+    write("one.py", "class One:\n    def save(self):\n        pass\n", commit="1")
+    write("two.py", "class Two:\n    def save(self):\n        pass\n", commit="2")
+    write("caller.py", "def go(thing):\n    thing.save()\n", commit="c")
+    store = build(repo)
+    report = islands_report(store, "HEAD")
+    assert all("\x00" not in node_id for node_id in named(report))
+    non_module_nodes = store.connection.execute(
+        "SELECT COUNT(*) AS n FROM nodes WHERE rev='HEAD' AND kind != 'module'"
+    ).fetchone()["n"]
+    assert report.summary["symbols"] == non_module_nodes
+    store.close()

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,7 +1,11 @@
+from codegraph.ambiguity import Ambiguity
 from codegraph.cli import main
 from codegraph.indexer import GitTreeSource, Indexer
 from codegraph.query.impact import impact_report
-from codegraph.resolve import module_for_path, split_by_ambiguity_limit
+from codegraph.resolve import (
+    is_derivable_fanout,
+    module_for_path,
+)
 from codegraph.store import Store
 
 
@@ -100,14 +104,22 @@ def test_unique_method_name_is_medium_confidence(repo, write):
     store.close()
 
 
-def test_ambiguous_method_name_emits_low_edges_to_every_candidate(repo, write):
+def test_ambiguous_method_name_names_every_candidate_without_storing_one(repo, write):
+    """The over-approximation bias, relocated by #25: every candidate is still
+    reachable, none of them is an edge."""
     write("one.py", "class One:\n    def shared(self):\n        pass\n", commit="1")
     write("two.py", "class Two:\n    def shared(self):\n        pass\n", commit="2")
     write("caller.py", "def go(thing):\n    thing.shared()\n", commit="c")
     store, indexer = build(repo)
     indexer.reconcile("HEAD")
-    found = {(dst, conf) for src, dst, conf in edges(store) if src == "caller.py::go"}
-    assert found == {("one.py::One.shared", "LOW"), ("two.py::Two.shared", "LOW")}
+    assert not [dst for src, dst, _ in edges(store) if src == "caller.py::go"]
+    ambiguity = Ambiguity(store, "HEAD")
+    assert set(ambiguity.candidates("thing.shared")) == {
+        "one.py::One.shared",
+        "two.py::Two.shared",
+    }
+    assert ambiguity.callers("one.py::One.shared") == ["caller.py::go"]
+    assert ambiguity.callers("two.py::Two.shared") == ["caller.py::go"]
     store.close()
 
 
@@ -311,19 +323,24 @@ def test_status_reports_the_unresolved_count(repo, write, capsys):
     assert "unresolved: 1" in capsys.readouterr().out
 
 
-# -- the ambiguity cap -------------------------------------------------
+# -- the bare-name fan-out is derived, not stored ---------------------------
 #
 # The last-resort step matches a call's final dotted segment against every live
 # definition in the revision. Measured on django (2,930 files) that produced 971
 # candidates for a single call site and 2.09M LOW edges -- 96.6% of the graph --
-# because the candidate list grows with the repo. See issue #6.
+# because the candidate list grows with the repo (#6). #6 capped that at write
+# time; #25 established that the cap was in the wrong place, because the
+# candidate set is `name_index[name]` and the `nodes` table already determines
+# it. Nothing about it is stored now, at any size, and `ambiguity.py` recovers
+# it exactly. These tests pin both halves: the graph does not hold it, and a
+# query gets all of it back.
 
 
 def unresolved_rows(store, rev="HEAD"):
     return [
         dict(row)
         for row in store.connection.execute(
-            "SELECT path, line, raw_name, ref_kind, reason, candidates FROM unresolved"
+            "SELECT src, path, line, raw_name, ref_kind, reason, candidates FROM unresolved"
             " WHERE rev=? ORDER BY path, line",
             (rev,),
         )
@@ -339,33 +356,77 @@ def many_savers(count):
     return f"{classes}\n\n\ndef persist(item):\n    return item.save()\n"
 
 
-def test_ambiguity_under_the_limit_is_still_fully_enumerated(repo, write):
-    write("m.py", many_savers(3), commit="m")
-    write("codegraph.toml", "ambiguity_limit = 25\n", commit="cfg")
+def test_a_two_way_bare_name_call_is_not_materialized(repo, write):
+    """Two candidates is as ambiguous as 971 for storage purposes: the set is
+    `name_index['save']` either way, and the graph does not hold either."""
+    write("m.py", many_savers(2), commit="m")
     store, indexer = build(repo)
     stats = indexer.reconcile("HEAD")
-    assert stats.ambiguous == 0
-    assert {dst for src, dst, _ in edges(store) if src == "m.py::persist"} == {
-        f"m.py::C{i}.save" for i in range(3)
-    }
+    assert not [dst for src, dst, _ in edges(store) if src == "m.py::persist"]
+    assert stats.ambiguous == 1
     store.close()
 
 
-def test_ambiguity_over_the_limit_is_recorded_once_instead_of_enumerated(repo, write):
+def test_the_ambiguous_row_carries_everything_the_expansion_needs(repo, write):
     write("m.py", many_savers(6), commit="m")
-    write("codegraph.toml", "ambiguity_limit = 4\n", commit="cfg")
     store, indexer = build(repo)
     stats = indexer.reconcile("HEAD")
 
-    # Not enumerated...
     assert not [dst for src, dst, _ in edges(store) if src == "m.py::persist"]
-    # ...but not dropped either: the claim survives, with its size.
     ambiguous = [row for row in unresolved_rows(store) if row["reason"] == "ambiguous"]
     assert len(ambiguous) == 1
     assert ambiguous[0]["raw_name"] == "item.save"
     assert ambiguous[0]["ref_kind"] == "call"
     assert ambiguous[0]["candidates"] == 6
+    # `src` is the one thing about the reference the name index cannot
+    # rederive, so it is the one thing the row has to carry.
+    assert ambiguous[0]["src"] == "m.py::persist"
     assert stats.ambiguous == 1
+    store.close()
+
+
+def test_the_expansion_returns_exactly_what_the_resolver_would_have(repo, write):
+    """The property #25 is about: the answer is still reachable, and the graph
+    still does not contain it. 60 candidates is well past any cap that ever
+    existed."""
+    write("m.py", many_savers(60), commit="m")
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+
+    assert not [dst for src, dst, _ in edges(store) if src == "m.py::persist"]
+    ambiguity = Ambiguity(store, "HEAD")
+    assert set(ambiguity.candidates("item.save")) == {f"m.py::C{i}.save" for i in range(60)}
+    for i in range(60):
+        assert ambiguity.callers(f"m.py::C{i}.save") == ["m.py::persist"]
+    store.close()
+
+
+def test_a_shadowed_definition_is_not_a_candidate_of_the_expansion(repo, write):
+    """The expansion rebuilds the resolver's LIVE name index, not every node
+    that ever had the name -- a shadowed definition can still be an edge target
+    by another route but never wins a name lookup."""
+    write(
+        "m.py",
+        "class C:\n    def save(self):\n        return 1\n\n\n"
+        "class C:\n    def save(self):\n        return 2\n\n\n"
+        "class D:\n    def save(self):\n        return 3\n\n\n"
+        "def persist(item):\n    return item.save()\n",
+        commit="m",
+    )
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    ambiguity = Ambiguity(store, "HEAD")
+    candidates = ambiguity.candidates("item.save")
+    assert set(candidates) == {"m.py::C.save", "m.py::D.save"}
+    shadowed = [
+        row["id"]
+        for row in store.connection.execute(
+            "SELECT id FROM nodes WHERE rev='HEAD' AND name_binding != 'live'"
+        )
+    ]
+    assert shadowed, "the fixture stopped producing a shadowed definition"
+    for node_id in shadowed:
+        assert ambiguity.callers(node_id) == []
     store.close()
 
 
@@ -373,7 +434,6 @@ def test_ambiguous_is_counted_separately_from_unknown(repo, write):
     """They are opposite failures -- blind vs. dazzled -- and collapsing them
     into one number makes the health signal unreadable."""
     write("m.py", many_savers(6) + "\n\ndef gone():\n    no_such_name_anywhere()\n", commit="m")
-    write("codegraph.toml", "ambiguity_limit = 4\n", commit="cfg")
     store, indexer = build(repo)
     stats = indexer.reconcile("HEAD")
     assert stats.ambiguous == 1
@@ -385,15 +445,14 @@ def test_ambiguous_is_counted_separately_from_unknown(repo, write):
 
 def test_a_crowded_name_does_not_weaken_a_call_that_resolves_confidently(repo, write):
     """`AstResolver` stops at the first step that matches, so a module-local
-    call never reaches the last-resort step at all -- the cap must not change
-    that just because the name is crowded elsewhere in the repo."""
+    call never reaches the last-resort step at all -- deferring the fan-out must
+    not change that just because the name is crowded elsewhere in the repo."""
     write("crowd.py", many_savers(6), commit="crowd")
     write(
         "m.py",
         "def save():\n    return 0\n\n\ndef caller():\n    return save()\n",
         commit="m",
     )
-    write("codegraph.toml", "ambiguity_limit = 2\n", commit="cfg")
     store, indexer = build(repo)
     indexer.reconcile("HEAD")
     # module-local, so HIGH -- it never reaches the last-resort step at all
@@ -401,10 +460,10 @@ def test_a_crowded_name_does_not_weaken_a_call_that_resolves_confidently(repo, w
     store.close()
 
 
-def test_ambiguous_base_class_is_capped_without_disturbing_the_mro(repo, write):
+def test_an_ambiguous_base_class_is_deferred_without_disturbing_the_mro(repo, write):
     """Bases fan out exactly like calls (on django they were the larger half of
-    the blowup), but only HIGH links feed the MRO walk and the cap only ever
-    collapses LOW ones -- so inheritance resolution is unchanged."""
+    the blowup), but only HIGH links feed the MRO walk and only an all-LOW set
+    is deferred -- so inheritance resolution is unchanged."""
     write("crowd.py", "\n\n".join(f"class Base{i}:\n    pass" for i in range(6)), commit="crowd")
     write("dup.py", "\n\n".join(f"class C{i}:\n    class Base:\n        pass" for i in range(6)),
           commit="dup")
@@ -413,7 +472,11 @@ def test_ambiguous_base_class_is_capped_without_disturbing_the_mro(repo, write):
         "from crowd import Base0\n\n\nclass Child(Base0):\n    pass\n",
         commit="child",
     )
-    write("codegraph.toml", "ambiguity_limit = 3\n", commit="cfg")
+    write(
+        "guess.py",
+        "\n\n".join(f"class Guess{i}(Base):\n    pass" for i in range(2)),
+        commit="guess",
+    )
     store, indexer = build(repo)
     indexer.reconcile("HEAD")
     inherits = {
@@ -422,45 +485,66 @@ def test_ambiguous_base_class_is_capped_without_disturbing_the_mro(repo, write):
             "SELECT src, dst, confidence FROM edges WHERE rev='HEAD' AND kind='INHERITS'"
         )
     }
-    # The import makes this one certain, so the cap cannot touch it.
+    # The import makes this one certain, so the fan-out rule cannot touch it.
     assert ("child.py::Child", "crowd.py::Base0", "HIGH") in inherits
+    # The bare `Base` matches six nested classes and is deferred instead.
+    assert not [dst for src, dst, _ in inherits if src.startswith("guess.py::")]
+    base_rows = [
+        row
+        for row in unresolved_rows(store)
+        if row["reason"] == "ambiguous" and row["ref_kind"] == "base"
+    ]
+    assert len(base_rows) == 2
+    ambiguity = Ambiguity(store, "HEAD")
+    assert ambiguity.inheritors("dup.py::C0.Base") == [
+        "guess.py::Guess0",
+        "guess.py::Guess1",
+    ]
+    # ...and a base reference is NOT a call: `impact` walks CALLS only.
+    assert ambiguity.callers("dup.py::C0.Base") == []
     store.close()
 
 
-def test_ambiguity_limit_zero_disables_the_cap(repo, write):
+def test_a_deprecated_ambiguity_limit_warns_rather_than_changing_the_graph(repo, write, capsys):
+    """The migration promise: an existing codegraph.toml keeps working, says so
+    once, and gets the same graph as one without the setting."""
     write("m.py", many_savers(6), commit="m")
-    write("codegraph.toml", "ambiguity_limit = 0\n", commit="cfg")
+    store, indexer = build(repo)
+    baseline = indexer.reconcile("HEAD").ambiguous
+    store.close()
+
+    write("codegraph.toml", "ambiguity_limit = 100\n", commit="cfg")
+    capsys.readouterr()
     store, indexer = build(repo)
     stats = indexer.reconcile("HEAD")
-    assert stats.ambiguous == 0
-    assert len([dst for src, dst, _ in edges(store) if src == "m.py::persist"]) == 6
+    assert "ambiguity_limit is deprecated" in capsys.readouterr().err
+    assert stats.ambiguous == baseline
+    assert not [dst for src, dst, _ in edges(store) if src == "m.py::persist"]
     store.close()
 
 
-def test_split_by_ambiguity_limit_keeps_strong_candidates_alongside_a_collapsed_tail():
+def test_no_ambiguity_limit_at_all_still_works(repo, write, capsys):
+    write("m.py", many_savers(6), commit="m")
+    write("codegraph.toml", 'source_roots = ["", "src"]\n', commit="cfg")
+    store, indexer = build(repo)
+    stats = indexer.reconcile("HEAD")
+    assert "deprecated" not in capsys.readouterr().err
+    assert stats.ambiguous == 1
+    store.close()
+
+
+def test_is_derivable_fanout_only_claims_a_set_the_resolver_could_not_tell_apart():
     """`AstResolver` returns the first matching step's hits, so today a result is
     either confident or entirely LOW and this mix cannot arise from it. The
     `Resolver` protocol is a documented swap-in seam, though, and a smarter
-    engine can return both -- the cap must collapse only the part it cannot
-    distinguish, never the part it can."""
-    hits = [("a.py::x", "HIGH"), ("b.py::y", "MEDIUM")] + [
-        (f"c.py::z{i}", "LOW") for i in range(6)
-    ]
-    kept, collapsed = split_by_ambiguity_limit(hits, 4)
-    assert kept == [("a.py::x", "HIGH"), ("b.py::y", "MEDIUM")]
-    assert collapsed == 6
-
-
-def test_split_by_ambiguity_limit_counts_only_the_weak_candidates():
-    """A long list of candidates the resolver could actually tell apart is not
-    ambiguity, and must not be collapsed however long it is."""
-    hits = [(f"a.py::x{i}", "HIGH") for i in range(50)]
-    assert split_by_ambiguity_limit(hits, 4) == (hits, 0)
-
-
-def test_split_by_ambiguity_limit_leaves_a_list_at_exactly_the_limit_alone():
-    hits = [(f"a.py::x{i}", "LOW") for i in range(4)]
-    assert split_by_ambiguity_limit(hits, 4) == (hits, 0)
+    engine can return both -- a set holding anything the resolver DID
+    distinguish is not the derivable fan-out and must still be materialized."""
+    weak = [(f"c.py::z{i}", "LOW") for i in range(6)]
+    assert is_derivable_fanout(weak)
+    assert not is_derivable_fanout([("a.py::x", "HIGH"), *weak])
+    assert not is_derivable_fanout([("b.py::y", "MEDIUM"), *weak])
+    assert not is_derivable_fanout([(f"a.py::x{i}", "HIGH") for i in range(50)])
+    assert not is_derivable_fanout([])
 
 
 # -- self.X finds overrides, not just the inherited declaration -------------


### PR DESCRIPTION
Closes #25.

The `ambiguity_limit` cap decided at **index** time how many candidates a bare-name call was
worth. That is a storage decision baked into the graph, when whether N candidates is too many
is a property of the question being asked. The candidate set is derivable from the name index
at any moment, so materializing it was never necessary — and the ambiguous row recorded the
*count* but not *which*, making an answer the graph provably contains unreachable.

An all-LOW fan-out is now recorded once and expanded when a query asks. `--limit` bounds the
search; nothing bounds the graph.

## Measured

| | main | this branch |
|---|---|---|
| requests, edges | 2,422 | **1,341** |
| django, edges | 438,513 | **92,098** |
| django, cold index | 45.1s | **23.9s** |
| django, reconcile no changes | 0.34s | **0.11s** |
| django, body-only edit | 3.7s | **3.0s** |
| django, adds a definition | 22.9s | 22.0s |

4.8x smaller graph on django, and the cost work from #7 improves rather than regresses —
there is simply less to write. `impact Session.request` still returns the same 7 confident
dependents, and `--all` returns 242 with `low_confidence_hidden: 0`, so nothing became
unreachable.

The CLI help now carries the argument: `--limit … it is a property of the question, not of the
graph`.

## Merging this with #27's constructor edge exposed two defects neither branch had alone

Both edited `resolve_revision`'s call loop. The resolution keeps `is_derivable_fanout` (which
replaces `split_by_ambiguity_limit`) and applies `with_constructors` only to hits that are
actually materialized. Then:

**An ambiguous constructor lost its `__init__` on both paths at once.** `box.Widget()` with two
`Widget` classes in the repo is an all-LOW fan-out made entirely of classes — deferred at index
time, and the query-time expansion only knew about name matches, so nothing added the
constructor there either. `Ambiguity` now carries the class → `__init__` map and `candidates()`
applies it, mirroring `with_constructors`.

**Then the two directions disagreed.** With that fixed, `candidates('box.Widget')` offered
`Widget.__init__` while `callers('…Widget.__init__')` found nothing — the reference's name is
`Widget`, the node's is `__init__`, so the reverse lookup missed. `impact` on that constructor
came back empty on a graph that could reach it. Fixed with `reaching_names`, used by `callers`,
`inheritors` and `caller_count` alike so all three read one graph.

That second one is the failure this project keeps rediscovering: **a claim derived from one
graph and traversed on another.** It has produced an empty witness, a wrong evidence location,
and now an empty impact. Written into the docstring as a rule rather than left as a surprise.

## The accuracy harness was measuring the wrong thing

It read `edges` only, so it graded the storage layer rather than the resolver and fell to recall
**0.86** — while both `item.save()` targets it was "missing" were being returned by every real
query. It now unions the same expansion `impact` performs. **No label was changed**; back to
1.00/1.00, and the harness and the commands it stands in for finally read the same graph.

## Also

`fan_in` unioned a node's ambiguous callers once per dependent, which is quadratic on a crowded
name: `impact Model.save` on django took **4m45s**. The sets are kept as frozensets for
membership now, and the union is counted against the small materialized side.

329 passed, slow suite green, ruff clean.
