### PR TITLE
--rebuild rebuilds the graph, not just the parse cache

### DIFF
--- a/src/codegraph/cli.py
+++ b/src/codegraph/cli.py
@@ -64,7 +64,19 @@ def _cmd_index(args: argparse.Namespace) -> int:
     store, indexer = open_workspace(root)
     try:
         if args.rebuild:
+            # Both layers, and in this order. Clearing only `blobs` re-parsed
+            # Layer 1 and then reconciled straight into the unchanged-tree fast
+            # path, because the tree and the fingerprint were untouched -- so
+            # Layer 2 was served from the previous build and `--rebuild` did
+            # not rebuild. Dropping the `revisions` row is what makes the fast
+            # path (and the narrowing that follows it) see no current state to
+            # keep. See issue #30.
+            #
+            # The flag is most likely to be reached for by someone who already
+            # suspects the graph is stale, which is exactly when silently
+            # serving the old one is worst.
             store.connection.execute("DELETE FROM blobs")
+            store.connection.execute("DELETE FROM revisions WHERE rev=?", (args.rev,))
             store.connection.commit()
         try:
             stats = indexer.reconcile(args.rev)
@@ -340,7 +352,7 @@ def build_parser() -> argparse.ArgumentParser:
     index_parser.add_argument(
         "--rebuild",
         action="store_true",
-        help="Discard the Layer 1 parse cache before reconciling",
+        help="Discard the parse cache AND the revision's graph, forcing a cold rebuild",
     )
     index_parser.add_argument(
         "--quiet", action="store_true", help="Suppress stats output (used by warming hooks)"

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -589,3 +589,38 @@ def test_a_definition_added_elsewhere_updates_another_files_edges(repo, write):
     assert targets() == {"one.py::One.save", "two.py::Two.save"}
     assert dump_graph(store, WORKTREE) == cold_dump(repo, WORKTREE)
     store.close()
+
+
+def test_rebuild_rebuilds_layer_2_not_just_the_parse_cache(repo, write):
+    """`--rebuild` used to clear only the `blobs` cache. The tree and the
+    fingerprint were untouched, so the reconcile that followed took the
+    unchanged-tree fast path and served Layer 2 from the previous build --
+    the flag re-parsed everything and changed nothing. See #30.
+
+    Deleting the edges by hand is the whole point: it makes the stored graph
+    provably wrong, so a `--rebuild` that returns it to the cold-rebuild
+    answer can only have re-resolved. A no-op `--rebuild` leaves them gone.
+    """
+    from codegraph.cli import main
+
+    write("lib.py", "def helper():\n    return 1\n")
+    write(
+        "app.py",
+        "from lib import helper\n\n\ndef caller():\n    return helper()\n",
+        commit="two",
+    )
+    store = Store.open(repo)
+    Indexer(repo, store, GitTreeSource(repo)).reconcile(WORKTREE)
+    expected = dump_graph(store, WORKTREE)
+    assert expected["edges"], "the fixture stopped producing any edges to lose"
+
+    store.connection.execute("DELETE FROM edges WHERE rev=?", (WORKTREE,))
+    store.connection.commit()
+    assert dump_graph(store, WORKTREE)["edges"] == []
+    store.close()
+
+    assert main(["index", "--rebuild", "--quiet", "--path", str(repo)]) == 0
+
+    store = Store.open(repo)
+    assert dump_graph(store, WORKTREE) == expected
+    store.close()


### PR DESCRIPTION
Closes #30.

`--rebuild` cleared the `blobs` cache, so Layer 1 was re-parsed. But the tree and the
fingerprint were untouched, so the reconcile that followed took the unchanged-tree fast path
added in #7 and served Layer 2 from the previous build.

The flag re-parsed every file in the repository and changed nothing.

Fix is one line: drop the `revisions` row for the target revision, which is what the fast path
(and the narrowing behind it) keys off.

Worth noting why this was a sharp edge rather than a cosmetic one — the flag is most likely to
be reached for by someone who already suspects their graph is stale, which is exactly when
silently serving the old one does the most damage. Until now the only real escape was deleting
`graph.db` by hand, plus its `-wal` and `-shm` siblings, or stale rows resurrect.

The test deletes the edges by hand before running `--rebuild`. That makes the stored graph
provably wrong, so returning it to the cold-rebuild answer can only have re-resolved — a no-op
leaves them gone. Verified non-vacuous against the unfixed code.
