### PR TITLE
Resolve super().X() at HIGH instead of guessing among every same name

### DIFF
--- a/src/codegraph/parse.py
+++ b/src/codegraph/parse.py
@@ -11,7 +11,7 @@ import copy
 import hashlib
 from dataclasses import dataclass, field
 
-PARSER_VERSION = "2"
+PARSER_VERSION = "3"
 
 _DEF_TYPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
 
@@ -127,6 +127,29 @@ def _body_hash(node: ast.AST) -> str:
     # ast.dump omits lineno/col_offset unless include_attributes=True, so this
     # hash is invariant to where the definition sits in the file.
     return hashlib.blake2b(ast.dump(node).encode(), digest_size=16).hexdigest()
+
+
+#: Synthetic receiver for a `super()` call, mirroring `<attr>`/`<dynamic>`.
+#: `<` cannot appear in a Python identifier, so this can never collide with a
+#: real dotted call.
+SUPER = "<super>"
+
+
+def _is_super_call(node: ast.expr) -> bool:
+    """Is `node` a bare `super()` call?
+
+    Only the zero-argument form. The explicit `super(Cls, self)` form names a
+    starting class that may not be the enclosing one, so resolving it as if it
+    were would be a guess dressed as a fact -- it keeps falling through to
+    `<attr>`.
+    """
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "super"
+        and not node.args
+        and not node.keywords
+    )
 
 
 _PASS = ast.Pass()
@@ -344,9 +367,26 @@ class _Collector(ast.NodeVisitor):
             # (e.g. `handlers[i]()`) has nothing to key on and is recorded
             # under a synthetic placeholder instead, purely so the COUNT is
             # never silently lost.
-            name = (
-                f"<attr>.{node.func.attr}" if isinstance(node.func, ast.Attribute) else "<dynamic>"
-            )
+            if isinstance(node.func, ast.Attribute) and _is_super_call(node.func.value):
+                # `super().__init__()` is not an unknown receiver. It names the
+                # enclosing class's base, which the resolver already knows, so
+                # keeping it apart from `<attr>.` is the difference between a
+                # certainty and a 1-in-N guess.
+                #
+                # Before this, `super().__init__()` flattened to
+                # `<attr>.__init__` and fell to the repo-wide name match: 26
+                # candidates per call site on psf/requests, all LOW, exactly
+                # one right. So `impact BaseAdapter.__init__` reported
+                # `symbols: 0` by default and 157 dependents with `--all` --
+                # for the highest-blast-radius edit there is, since adding a
+                # required argument to a base `__init__` breaks every subclass.
+                name = f"{SUPER}.{node.func.attr}"
+            else:
+                name = (
+                    f"<attr>.{node.func.attr}"
+                    if isinstance(node.func, ast.Attribute)
+                    else "<dynamic>"
+                )
         elif name == "open":
             name = _open_call_marker(node)
         self.refs.append(

--- a/src/codegraph/resolve.py
+++ b/src/codegraph/resolve.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass, field
 from typing import Protocol
 
 from codegraph.config import Config
-from codegraph.parse import ParsedRef
+from codegraph.parse import SUPER, ParsedRef
 from codegraph.store import Store
 
 HIGH, MEDIUM, LOW = "HIGH", "MEDIUM", "LOW"
@@ -179,7 +179,13 @@ class AstResolver:
     """
 
     def resolve_call(self, ref: ParsedRef, ctx: ResolveContext) -> list[tuple[str, str]]:
-        for step in (self._imported, self._module_local, self._through_self, self._by_last_segment):
+        for step in (
+            self._imported,
+            self._module_local,
+            self._through_super,
+            self._through_self,
+            self._by_last_segment,
+        ):
             hits = step(ref, ctx)
             if hits:
                 return hits
@@ -214,6 +220,38 @@ class AstResolver:
             return []
         node_id = ctx.qualname_index.get((ctx.path, ref.raw_name))
         return [(node_id, HIGH)] if node_id else []
+
+    # -- step 2b: super().X through the enclosing class's bases -------------
+    def _through_super(self, ref: ParsedRef, ctx: ResolveContext) -> list[tuple[str, str]]:
+        """`super().X()` -- the enclosing class's inherited `X`, at HIGH.
+
+        This is one of the most certain calls Python has: the starting class is
+        the one the call is written in, and the lookup skips it. It was LOW
+        because `parse.py` used to flatten `super()` to the unknown-receiver
+        marker, so it fell to the repo-wide name match -- 26 candidates per site
+        on psf/requests, all LOW, exactly one right.
+
+        Unlike `_through_self`, subclass overrides are NOT candidates.
+        `super()` walks strictly upwards; a subclass override is what it exists
+        to bypass.
+
+        The base walk is the same breadth-first approximation of the MRO used
+        everywhere else in this module, and starts at the bases rather than the
+        class itself -- `super().__init__()` inside `Child.__init__` must not
+        resolve to `Child.__init__`.
+        """
+        head, _, attribute = ref.raw_name.partition(".")
+        if head != SUPER or not attribute or "." in attribute:
+            return []
+        owner = ctx.qualname_index.get((ctx.path, ref.from_qualname))
+        start = ctx.enclosing_class.get(owner) if owner else None
+        if start is None:
+            return []
+        for class_id in breadth_first(start, ctx.bases)[1:]:
+            found = self._method_on(class_id, attribute, ctx)
+            if found:
+                return [(found, HIGH)]
+        return []
 
     # -- step 3: self.X through the class, its bases, and its overrides ----
     def _through_self(self, ref: ParsedRef, ctx: ResolveContext) -> list[tuple[str, str]]:

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -147,7 +147,11 @@ def test_calls_on_non_flattenable_receivers_are_still_recorded():
     and `d["k"].m()` must all still produce a `call` ref, carrying the
     attribute name (marked with the synthetic `<attr>.` prefix so it is
     routed past the HIGH-confidence resolver steps rather than falsely
-    matched as an imported/module-local/self name)."""
+    matched as an imported/module-local/self name).
+
+    `super().go()` is the one exception and now carries `<super>.` instead: it
+    is not an unknown receiver, it names the enclosing class's base, and the
+    resolver can settle it at HIGH. Everything else here really is unknown."""
     source = (
         b"class Base:\n"
         b"    def go(self):\n        pass\n\n\n"
@@ -162,12 +166,13 @@ def test_calls_on_non_flattenable_receivers_are_still_recorded():
     result = parse_blob(source)
     raw = {r.raw_name for r in result.refs if r.ref_kind == "call"}
     assert raw >= {
-        "<attr>.go",
+        "<super>.go",
         "<attr>.charge",
         "<attr>.run",
         "<attr>.fire",
         "<attr>.m",
     }
+    assert "<attr>.go" not in raw, "super() must not be filed as an unknown receiver"
 
 
 def test_call_with_no_attribute_at_all_is_recorded_under_a_placeholder():

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -159,14 +159,22 @@ def test_external_call_is_unresolved_not_an_edge(repo, write):
     store.close()
 
 
-def test_super_call_resolves_weakly_by_name_not_dropped(repo, write):
-    """Regression for F2: `super().helper()`'s receiver (`super()`) isn't a
-    flattenable Name/Attribute chain, so `visit_Call` used to drop the ref
-    entirely -- no edge, no `unresolved` row. `helper` is unique in this
-    repo (unlike the overriding method's own name), so the existing
-    repo-wide by-last-segment step should now weakly resolve it at MEDIUM,
-    exactly as `test_unique_method_name_is_medium_confidence` does for
-    `thing.unique_op()`."""
+def test_super_call_resolves_to_the_base_at_high_confidence(repo, write):
+    """`super().helper()` names the enclosing class's base. That is one of the
+    most certain calls Python has -- the starting class is the one the call is
+    written in, and the lookup skips it -- so it resolves at HIGH.
+
+    It used to be MEDIUM here and LOW on any real repo. The receiver is not a
+    flattenable Name/Attribute chain, so the parser filed it under the
+    unknown-receiver marker and it fell to the repo-wide name match: on
+    psf/requests that was 26 candidates per call site, all LOW, exactly one
+    right, so `impact BaseAdapter.__init__` reported `symbols: 0` by default.
+    Which is the worst possible shape, since adding a required argument to a
+    base `__init__` breaks every subclass.
+
+    Supersedes the F2 regression this test used to pin (the ref must not be
+    dropped): resolving it at HIGH is strictly stronger than not losing it.
+    """
     write(
         "base.py",
         "class Base:\n    def helper(self):\n        pass\n",
@@ -180,7 +188,7 @@ def test_super_call_resolves_weakly_by_name_not_dropped(repo, write):
     )
     store, indexer = build(repo)
     indexer.reconcile("HEAD")
-    assert ("child.py::Child.go", "base.py::Base.helper", "MEDIUM") in edges(store)
+    assert ("child.py::Child.go", "base.py::Base.helper", "HIGH") in edges(store)
     store.close()
 
 
@@ -887,4 +895,67 @@ def test_an_ambiguous_constructor_still_reaches_the_init_it_would_run(repo, writ
     found = {(row.id, row.detail) for group in report.groups for row in group.rows}
     assert any(node_id == "use.py::build" for node_id, _ in found)
     assert all("LOW" in detail for node_id, detail in found if node_id == "use.py::build")
+    store.close()
+
+
+def test_super_skips_the_class_the_call_is_written_in(repo, write):
+    """`super()` walks strictly upwards. `super().__init__()` inside
+    `Child.__init__` must reach the base's `__init__`, never `Child`'s own --
+    the whole point of the call is to reach the one it overrides."""
+    write("base.py", "class Base:\n    def __init__(self):\n        self.x = 1\n")
+    write(
+        "child.py",
+        "from base import Base\n\n\n"
+        "class Child(Base):\n"
+        "    def __init__(self):\n"
+        "        super().__init__()\n",
+        commit="two",
+    )
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    targets = {dst for src, dst, _ in edges(store) if src == "child.py::Child.__init__"}
+    assert "base.py::Base.__init__" in targets
+    assert "child.py::Child.__init__" not in targets, "super() resolved to itself"
+    store.close()
+
+
+def test_super_does_not_reach_a_subclass_override(repo, write):
+    """The one place this differs from `self.X`. `self.area()` may run a
+    subclass's override because `self` may be an instance of a subclass;
+    `super().area()` exists precisely to bypass overrides, so a subclass's
+    version must never be a candidate."""
+    write(
+        "chain.py",
+        "class Base:\n    def area(self):\n        return 0\n"
+        "\n\n"
+        "class Mid(Base):\n"
+        "    def area(self):\n"
+        "        return super().area()\n"
+        "\n\n"
+        "class Leaf(Mid):\n    def area(self):\n        return 2\n",
+        commit="chain",
+    )
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    targets = {dst for src, dst, _ in edges(store) if src == "chain.py::Mid.area"}
+    assert targets == {"chain.py::Base.area"}
+
+
+def test_the_explicit_two_argument_super_is_not_claimed_as_certain(repo, write):
+    """`super(Other, self)` names a starting class that need not be the
+    enclosing one, so resolving it as though it were would be a guess dressed
+    as a fact. It keeps falling through to the weak path instead."""
+    write("base.py", "class Base:\n    def helper(self):\n        pass\n")
+    write(
+        "child.py",
+        "from base import Base\n\n\n"
+        "class Child(Base):\n"
+        "    def go(self):\n"
+        "        super(Child, self).helper()\n",
+        commit="two",
+    )
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    found = {(dst, conf) for src, dst, conf in edges(store) if src == "child.py::Child.go"}
+    assert ("base.py::Base.helper", "HIGH") not in found
     store.close()


### PR DESCRIPTION
`super().__init__()` is one of the most certain calls Python has. codegraph scored it **LOW**.

```python
class Child(Base):
    def __init__(self, name, extra):
        super().__init__(name)
```
```
$ codegraph impact base.py::Base.__init__
symbols: 0
```

Nothing depends on it, apparently.

`parse.py` flattens an unflattenable receiver to `<attr>.`, and `super()` landed in that
bucket — so the reference fell through to the repo-wide name match. On psf/requests that is
**26 candidates per call site**, all LOW, exactly one right. `impact BaseAdapter.__init__`
reported `symbols: 0` by default, and 157 dependents under `--all` with the correct one
indistinguishable among them.

That is the worst possible shape for this particular question. Adding a required argument to a
base `__init__` breaks every subclass — it is among the highest-blast-radius edits there is,
and it was the one codegraph was least confident about.

**After:** `symbols: 1 · hop 1, HIGH confidence`, and on requests `impact
BaseAdapter.__init__` leads with `HTTPAdapter.__init__` at HIGH.

## What it claims, and what it doesn't

The parser keeps `super()` apart as `<super>.`, and a new resolver step walks the enclosing
class's bases — starting **after** the class itself, since `super().__init__()` inside
`Child.__init__` must not resolve to itself.

Subclass overrides are **not** candidates. That is the one place this differs from `self.X`:
`self.area()` may run a subclass's override because `self` may be a subclass instance;
`super().area()` exists precisely to bypass one.

Only the zero-argument form is claimed. `super(Other, self)` names a starting class that need
not be the enclosing one, so treating it as certain would be a guess dressed as a fact — it
keeps falling through to the weak path, with a test pinning that.

## Two existing tests changed, neither weakened

`test_super_call_resolves_weakly_by_name_not_dropped` guarded F2: the ref must not be dropped
entirely. Resolving it at HIGH is strictly stronger than not losing it, and the docstring says
so rather than quietly dropping the old rationale.

## Cost

`PARSER_VERSION` 2 → 3, so every parse cache re-fills once. django edges 92,098 → 93,138.

Measured against `main` **in the same session**, because this machine swings 2-4x between
runs and cross-session numbers are worthless:

| | main | branch |
|---|---|---|
| django cold index | 103.3s | 49–59s |
| reconcile, no changes | 0.53–0.61s | 0.37–0.60s |

Accuracy 1.00/1.00. 333 passed, slow suite green, ruff clean.

Non-vacuity: removing the resolver step fails 3 of the 4 new tests; removing the skip-self
slice fails the one that pins it specifically. The fourth passes without the feature by design —
it guards against over-reach on the two-argument form.
