### PR TITLE
Effectiveness benchmark: score the graph against runtime traces (requests 0.93, flask 0.29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,8 +283,8 @@ implements. It is a regression guard wearing a benchmark's clothes.
 `bench/` is the real measurement (#35). It runs a target repository's **own
 test suite** under `sys.monitoring`, records every `(caller, callee)` pair that
 actually executed, and scores the static graph against it. A call the tests
-made is a call that exists, so a traced edge codegraph does not have is a real
-gap — no labelling judgement involved.
+made is a call that exists, so a traced edge missing from the static graph is a
+real gap — no labelling judgement involved.
 
 ```sh
 uv run python -m bench.run requests          # clones, or --source-root DIR to copy a clone
@@ -348,7 +348,7 @@ own tests. Unconditional precision is therefore not measurable this way, and
 the benchmark does not print a number for it. What is defensible: among static
 HIGH edges whose **two endpoints both executed at least once**, how many did
 the trace observe? 0.99 on requests, 0.86 on flask. That says the HIGH edges
-that could have been checked were taken; it does not say codegraph invents no
+that could have been checked were taken; it does not say the resolver invents no
 edges.
 
 ### The one filter that decides whether the number is honest

--- a/README.md
+++ b/README.md
@@ -273,6 +273,98 @@ are not in the same place:
   inputs, which is why a body-only edit is 3.7s rather than 9s, but a
   structural edit still pays it in full.
 
+## How good is the graph, honestly
+
+`tests/test_accuracy.py` reports precision 1.00 / recall 1.00, and that number
+means very little: it measures 10 hand-written call sites in a synthetic
+11-file repository, each authored to illustrate a rule the resolver already
+implements. It is a regression guard wearing a benchmark's clothes.
+
+`bench/` is the real measurement (#35). It runs a target repository's **own
+test suite** under `sys.monitoring`, records every `(caller, callee)` pair that
+actually executed, and scores the static graph against it. A call the tests
+made is a call that exists, so a traced edge codegraph does not have is a real
+gap — no labelling judgement involved.
+
+```sh
+uv run python -m bench.run requests          # clones, or --source-root DIR to copy a clone
+uv run python -m bench.run flask --json /tmp/flask.json
+uv run python -m bench.run requests --tests tests/test_utils.py   # narrow the suite
+```
+
+Each run copies the clone (an editable install writes into the tree, and the
+source clone must stay untouched), builds a venv, installs the target
+**editable** — a normal install copies the source into `site-packages`, where
+every in-repo frame is then filtered out as external and the trace comes back
+nearly empty, silently — traces the suite, indexes the same working tree, and
+scores. Nothing about it runs during `pytest -q`; only the scorer's arithmetic
+is unit-tested there (`tests/test_bench_scorer.py`).
+
+### What it measures
+
+| | psf/requests | pallets/flask |
+|---|---|---|
+| suite traced | `test_utils.py`, `test_structures.py` (240 tests) | `tests/` (494 tests) |
+| traced call edges (judgeable) | 115 | 2683 |
+| **recall** | **0.79** | **0.29** |
+| recall at HIGH/MEDIUM | 0.76 | 0.19 |
+| conditional precision | 0.99 (81/82) | 0.86 (206/239) |
+
+On `tests/test_utils.py` alone — the scope #35 recorded — requests is **0.93**
+recall, and all 6 misses are dunders invoked by syntax (`d[k]`, `for x in jar`,
+`len(f)`). Adding `test_structures.py`, which tests a mapping's dunders
+directly, drops it to 0.79: the same gap, weighted differently by which tests
+you run. **Recall is a property of the target repository and of the suite you
+trace, not a single number about codegraph.**
+
+flask is where a static resolver is supposed to do badly, and it does. Every
+miss is grouped by mechanism, and the grouping is the finding:
+
+| flask misses (1918 of 2683) | |
+|---|---|
+| target nested in another function (a view defined inside a test) | 564 |
+| reachable only through an out-of-repo frame | 552 |
+| target is decorated (`@app.route`, `@setupmethod`) | 523 |
+| target is a dunder, invoked by syntax or protocol | 223 |
+| target is a constructor — a real resolution gap | 21 |
+| target applied as a decorator by the source | 18 |
+| no implicit-invocation mechanism recognised | 15 |
+| call site attributed to another definition in the same file | 2 |
+
+The 552 "out-of-repo frame" misses are worth understanding before reading the
+0.29 as an indictment: those pairs are `test_x -> werkzeug's Client.get ->
+FlaskClient.open`, where **no call site anywhere in flask's text names the
+pair**. No static analysis of this repository could produce them, so they are
+counted apart rather than blamed on the resolver. Excluding them still leaves
+recall at 0.36. The honest summary is that on a framework, most of what runs is
+reached by decoration and dispatch, and a call-site-based graph sees about a
+third of it.
+
+### Why precision is reported as *conditional*
+
+A static edge the trace never saw is **not** thereby wrong — the suite may
+simply not cover it, and most of a library's surface is not exercised by its
+own tests. Unconditional precision is therefore not measurable this way, and
+the benchmark does not print a number for it. What is defensible: among static
+HIGH edges whose **two endpoints both executed at least once**, how many did
+the trace observe? 0.99 on requests, 0.86 on flask. That says the HIGH edges
+that could have been checked were taken; it does not say codegraph invents no
+edges.
+
+### The one filter that decides whether the number is honest
+
+`PY_START` fires when a **module body** or a **class body** starts executing —
+import time and definition time, not calls — and codegraph's CALLS edges do not
+model either (it has an `imports` table for the first). So a traced edge is
+judgeable only when its target is a *function or method* node. Without that
+filter requests measures 0.51, with a miss list full of `__init__.py::<module>
+-> api.py::<module>`: a wrong number that would send someone chasing a
+non-problem. Two neighbouring cases are counted separately rather than folded
+in, so that neither can quietly raise the score: a target that is a
+comprehension or lambda (never a node, since `nodes` holds definitions), and a
+target `nodes` does not contain at all (a hole in codegraph's own view, shown
+with examples).
+
 ## Why no MCP server
 
 MCP's main advantage is discoverability — the agent sees the tool without

--- a/bench/__init__.py
+++ b/bench/__init__.py
@@ -1,0 +1,9 @@
+"""Effectiveness benchmark: score the static graph against runtime traces (#35).
+
+Nothing here runs during `pytest -q`. A run needs a clone of a target
+repository, a virtualenv per target, and a full execution of that
+repository's test suite -- see `bench/run.py` and the README section
+"Effectiveness benchmark". The one part the default suite does exercise is
+`bench.score`, whose arithmetic and miss classification are pure functions
+over sets and are unit-tested in `tests/test_bench_scorer.py`.
+"""

--- a/bench/run.py
+++ b/bench/run.py
@@ -1,0 +1,228 @@
+"""Run the effectiveness benchmark end to end for one target repository (#35).
+
+    uv run python -m bench.run requests
+    uv run python -m bench.run flask --source-root /path/to/clones
+
+Per target: copy the clone, build a virtualenv, install the package
+**editable**, run its test suite under `bench/tracer.py`, index the same
+working tree with codegraph, and score one against the other.
+
+`-e` is not a preference. A normal install COPIES the source into
+site-packages, so `code.co_filename` points there, every in-repo frame is
+filtered out as external, and the trace comes back nearly empty -- with no
+error. The clone is copied rather than used in place for the same class of
+reason: an editable install writes into the target tree, and the benchmark
+must leave the source clone untouched.
+
+The revision indexed is WORKTREE, deliberately: the tracer executes the files
+on disk, so the graph has to be built from the files on disk. Indexing HEAD
+would score a graph of slightly different code whenever the clone is dirty.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from bench.score import Trace, format_report, read_static_graph, score
+from codegraph.indexer import GitTreeSource, Indexer
+from codegraph.store import WORKTREE, Store
+
+HERE = Path(__file__).resolve().parent
+
+
+@dataclass(frozen=True)
+class Target:
+    name: str
+    url: str
+    #: What to hand pytest. A subset, where the full suite needs network or
+    #: services -- the benchmark measures the resolver, and a flaky suite
+    #: measures the weather.
+    tests: tuple[str, ...]
+    #: Test-only dependencies the editable install does not pull in.
+    extra_deps: tuple[str, ...] = ()
+    note: str = ""
+
+
+TARGETS: dict[str, Target] = {
+    # The feasibility target from #35, kept at the same scope so the number
+    # stays comparable to the 0.93 recorded there. requests' full suite wants
+    # a live httpbin; test_utils.py + test_structures.py are pure-CPU.
+    "requests": Target(
+        name="requests",
+        url="https://github.com/psf/requests",
+        tests=("tests/test_utils.py", "tests/test_structures.py"),
+    ),
+    # The interesting one: decorators, framework dispatch, a context-local
+    # proxy object. A static resolver should do measurably worse here, and
+    # the point of the benchmark is to find out how much worse.
+    "flask": Target(
+        name="flask",
+        url="https://github.com/pallets/flask",
+        tests=("tests/",),
+        extra_deps=("pytest-asyncio", "python-dotenv", "asgiref", "greenlet"),
+        note="tests/ minus the ones needing extras; see --tests to narrow",
+    ),
+}
+
+
+def _run(command: list[str], cwd: Path | None = None, check: bool = True) -> int:
+    print(f"$ {' '.join(str(part) for part in command)}", flush=True)
+    completed = subprocess.run(command, cwd=cwd, check=False)
+    if check and completed.returncode != 0:
+        raise SystemExit(f"failed ({completed.returncode}): {' '.join(map(str, command))}")
+    return completed.returncode
+
+
+def prepare(target: Target, work: Path, source_root: Path | None) -> Path:
+    """Put a private, editable-installable copy of the target under `work`."""
+    repo = work / target.name
+    if repo.exists():
+        print(f"reusing {repo}")
+        return repo
+    work.mkdir(parents=True, exist_ok=True)
+    source = None if source_root is None else source_root / target.name
+    if source is not None and source.exists():
+        print(f"copying {source} -> {repo}")
+        shutil.copytree(source, repo, symlinks=True)
+    else:
+        _run(["git", "clone", "-q", "--depth", "50", target.url, str(repo)])
+    return repo
+
+
+def make_venv(target: Target, repo: Path, work: Path) -> Path:
+    """A venv OUTSIDE the target tree, so it is not mistaken for repo source."""
+    venv = work / f"{target.name}-venv"
+    python = venv / "bin" / "python"
+    if not python.exists():
+        _run(["uv", "venv", "--quiet", "--python", "3.12", str(venv)])
+        _run(
+            [
+                "uv",
+                "pip",
+                "install",
+                "--quiet",
+                "--python",
+                str(python),
+                "-e",
+                str(repo),
+                "pytest",
+                *target.extra_deps,
+            ]
+        )
+    return python
+
+
+def trace(python: Path, repo: Path, out: Path, tests: tuple[str, ...]) -> dict:
+    started = time.perf_counter()
+    _run(
+        [
+            str(python),
+            str(HERE / "tracer.py"),
+            "--root",
+            str(repo),
+            "--out",
+            str(out),
+            "--",
+            "-q",
+            "-p",
+            "no:cacheprovider",
+            *tests,
+        ],
+        cwd=repo,
+        check=False,  # a suite with failures still produced a real trace
+    )
+    print(f"traced in {time.perf_counter() - started:.1f}s")
+    return json.loads(out.read_text())
+
+
+def index(repo: Path) -> Store:
+    store = Store.open(repo)
+    started = time.perf_counter()
+    stats = Indexer(repo, store, GitTreeSource(repo)).reconcile(WORKTREE)
+    print(
+        f"indexed {stats.paths_total} paths in {time.perf_counter() - started:.1f}s"
+        f" ({stats.edges} edges, {stats.ambiguous} ambiguous refs)"
+    )
+    return store
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="python -m bench.run")
+    parser.add_argument("target", choices=sorted(TARGETS), help="Which repository to score")
+    parser.add_argument(
+        "--work",
+        default=str(Path(tempfile.gettempdir()) / "codegraph-bench"),
+        help="Where copies, venvs and traces live (reused across runs)",
+    )
+    parser.add_argument(
+        "--source-root",
+        default=None,
+        help="Directory holding existing clones named after the target; copied, never modified",
+    )
+    parser.add_argument(
+        "--tests", nargs="+", default=None, help="Override the target's pytest arguments"
+    )
+    parser.add_argument(
+        "--reuse-trace",
+        action="store_true",
+        help="Score the trace already on disk instead of re-running the suite",
+    )
+    parser.add_argument("--json", default=None, help="Also write the report as JSON here")
+    args = parser.parse_args(argv)
+
+    target = TARGETS[args.target]
+    work = Path(args.work)
+    source_root = None if args.source_root is None else Path(args.source_root)
+    tests = tuple(args.tests) if args.tests else target.tests
+
+    repo = prepare(target, work, source_root)
+    trace_path = work / f"{target.name}-trace.json"
+    if args.reuse_trace and trace_path.exists():
+        print(f"reusing {trace_path}")
+        traced = json.loads(trace_path.read_text())
+    else:
+        traced = trace(make_venv(target, repo, work), repo, trace_path, tests)
+
+    store = index(repo)
+    graph = read_static_graph(store, WORKTREE)
+    report = score(Trace.load(traced), graph)
+    store.close()
+
+    print()
+    print(format_report(f"{target.name}  ({' '.join(tests)})", report))
+    if args.json:
+        Path(args.json).write_text(
+            json.dumps(
+                {
+                    "target": target.name,
+                    "tests": list(tests),
+                    "traced_total": report.traced_total,
+                    "anonymous_target": report.anonymous_target,
+                    "body_execution": report.body_execution,
+                    "target_unknown": report.target_unknown,
+                    "judgeable": report.judgeable,
+                    "found": report.found,
+                    "recall": report.recall,
+                    "found_high_medium": report.found_high_medium,
+                    "recall_high_medium": report.recall_high_medium,
+                    "testable_high": report.testable_high,
+                    "observed_high": report.observed_high,
+                    "conditional_precision": report.conditional_precision,
+                    "misses": {label: edges for label, edges in report.miss_causes.items()},
+                },
+                indent=2,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/run.py
+++ b/bench/run.py
@@ -94,7 +94,29 @@ def prepare(target: Target, work: Path, source_root: Path | None) -> Path:
         shutil.copytree(source, repo, symlinks=True)
     else:
         _run(["git", "clone", "-q", "--depth", "50", target.url, str(repo)])
+    _warn_if_dirty(repo)
     return repo
+
+
+def _warn_if_dirty(repo: Path) -> None:
+    """Say so, loudly, when the tree about to be measured is not its HEAD.
+
+    The trace executes the files on disk and `index` reads the same worktree,
+    so the two always agree -- but a number quoted from a tree with somebody's
+    leftover edit in it is not reproducible, and this went unnoticed once
+    (a stray `_codegraph_probe` in a flask clone from earlier feasibility
+    work). Not fatal: `--source-root` may legitimately point at a repository
+    with work in progress.
+    """
+    dirty = subprocess.run(
+        ["git", "-C", str(repo), "status", "--porcelain"],
+        capture_output=True,
+        text=True,
+        check=False,
+    ).stdout.strip()
+    if dirty:
+        print(f"WARNING: {repo} is not clean; the score describes THIS tree, not HEAD:")
+        print(dirty)
 
 
 def make_venv(target: Target, repo: Path, work: Path) -> Path:

--- a/bench/score.py
+++ b/bench/score.py
@@ -1,0 +1,509 @@
+"""Score a static call graph against a runtime trace (#35).
+
+`read_static_graph` is the only part that touches the database; everything
+else is a pure function over sets, so `tests/test_bench_scorer.py` can check
+the arithmetic without a target repository anywhere near it.
+
+What is scored, and what is deliberately not:
+
+*Recall* is meaningful. A call the test suite made is a call that exists, so
+a traced edge codegraph does not have is a real gap.
+
+*Unconditional precision is not measurable this way and is not reported.* A
+static edge that never appears in a trace is not thereby wrong -- the suite
+may simply not cover it, and on a library most of the surface is not covered
+by its own tests. What is defensible is conditional: among static HIGH edges
+whose two endpoints BOTH executed at least once, how many did the trace
+observe? Both endpoints running is what makes "and yet the call never
+happened" evidence of anything at all. See `Report.conditional_precision`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from codegraph.ambiguity import Ambiguity, last_segment
+from codegraph.resolve import MODULE_SCOPE
+
+#: The node kinds `parse.py` gives to things that are called. `module` and
+#: `class` are the two it gives to things that are *executed* but not called
+#: -- see `JUDGEABLE_KINDS`' use in `partition`.
+CALLABLE_KINDS = frozenset({"function", "method"})
+
+CONFIDENCE_RANK = {"LOW": 1, "MEDIUM": 2, "HIGH": 3}
+
+#: Code objects CPython creates for a scope that has no `def` and therefore no
+#: node in `nodes`: `parse.py` records definitions, and a comprehension or a
+#: lambda is not one. PY_START fires for them all the same.
+ANONYMOUS_SCOPES = frozenset(
+    {"<genexpr>", "<listcomp>", "<setcomp>", "<dictcomp>", "<lambda>"}
+)
+
+#: Confidence attributed to an edge that exists only as a query-time
+#: expansion of an ambiguous reference. `resolve.py` writes no row for such a
+#: reference precisely because every candidate would be LOW (#25), so LOW is
+#: what it would have been.
+EXPANDED_CONFIDENCE = "LOW"
+
+
+def _qualname(node_id: str) -> str:
+    return node_id.partition("::")[2]
+
+
+def is_anonymous(node_id: str) -> bool:
+    """Is this an anonymous scope -- a comprehension or a lambda?"""
+    return last_segment(_qualname(node_id)) in ANONYMOUS_SCOPES
+
+
+def collapse_anonymous(node_id: str) -> str:
+    """`m.py::f.<locals>.<genexpr>` -> `m.py::f`, repeatedly.
+
+    A comprehension runs in its own code object, so the trace attributes a
+    call made inside one to `f.<locals>.<genexpr>`. codegraph attributes the
+    same call site to `f`, because `parse.py` walks the AST and a
+    comprehension is an expression inside `f`'s body, not a definition.
+    Without this the two describe the same call under two different names and
+    it scores as a miss -- a disagreement about node naming, not about the
+    call graph. Measured on requests: 1 of 25 misses was exactly this
+    (`_init.<locals>.<genexpr> -> _init.<locals>.doc`).
+
+    A comprehension at module scope collapses to the module node, which is
+    what `parse.py` attributes it to.
+    """
+    path, separator, qualname = node_id.partition("::")
+    parts = qualname.split(".")
+    while parts and parts[-1] in ANONYMOUS_SCOPES:
+        parts.pop()
+        if parts and parts[-1] == "<locals>":
+            parts.pop()
+    if not parts:
+        return f"{path}{separator}{MODULE_SCOPE}"
+    return f"{path}{separator}{'.'.join(parts)}"
+
+
+def _rename(traced: set[tuple[str, str]]) -> set[tuple[str, str]]:
+    """Rename each edge's endpoints the way `parse.py` would name them.
+
+    Only the anonymous-scope collapse; see `collapse_anonymous`, which is
+    applied to the SOURCE. A self-edge that results (a comprehension inside
+    `f` calling `f`) is dropped for the same reason the tracer drops
+    recursion: codegraph does not model it.
+    """
+    renamed = {(collapse_anonymous(src), dst) for src, dst in traced}
+    return {(src, dst) for src, dst in renamed if src != dst}
+
+
+@dataclass(frozen=True)
+class Trace:
+    """One run of `bench/tracer.py`, with endpoints named as `parse.py` names
+    them (see `collapse_anonymous`)."""
+
+    edges: set[tuple[str, str]]
+    #: Every in-repo function that ran, whether or not it has an in-repo
+    #: caller. A test function invoked by pytest is in here and in no edge.
+    executed: set[str]
+    #: The subset of `edges` observed only with an out-of-repo Python frame in
+    #: between -- `test_x` -> werkzeug's `Client.get` -> `FlaskClient.open`.
+    #: Real, and unreachable by any static analysis of this repository: no
+    #: call site in its text names the pair.
+    indirect: set[tuple[str, str]]
+
+    @classmethod
+    def load(cls, payload: dict) -> Trace:
+        """Build from the tracer's JSON, applying the anonymous-scope collapse
+        to every endpoint so both sides use one naming scheme."""
+        return cls(
+            edges=_rename({(src, dst) for src, dst in payload["edges"]}),
+            executed={collapse_anonymous(node) for node in payload["executed"]},
+            indirect=_rename({(src, dst) for src, dst in payload.get("indirect", ())}),
+        )
+
+
+@dataclass(frozen=True)
+class StaticGraph:
+    """The graph codegraph's *commands* answer from, for one revision.
+
+    That is `edges` PLUS the query-time expansion of ambiguous references.
+    Scoring `edges` alone grades the storage layer rather than the resolver:
+    an all-LOW fan-out is stored once in `unresolved` and expanded when a
+    query asks, so those targets are answers codegraph gives while being
+    rows it never wrote. `tests/test_accuracy.py` performs the same union
+    for the same reason.
+    """
+
+    #: (src, dst) -> the best confidence any source of that edge carries.
+    edges: dict[tuple[str, str], str]
+    #: node id -> kind ('function' | 'method' | 'class' | 'module').
+    kinds: dict[str, str]
+    #: node id -> comma-joined decorator names, for classifying misses.
+    decorators: dict[str, str] = field(default_factory=dict)
+    #: dst -> every src that reaches it, for the source-attribution cause in
+    #: `MISS_CAUSES`. Derived, not an input: rebuilding it per miss would be a
+    #: scan of `edges`, and flask's graph has 90k of them.
+    by_target: dict[str, set[str]] = field(init=False, default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for src, dst in self.edges:
+            self.by_target.setdefault(dst, set()).add(src)
+
+    def confidence(self, edge: tuple[str, str]) -> str | None:
+        return self.edges.get(edge)
+
+    def used_as_decorator(self, src: str, dst: str) -> bool:
+        """Does `src`, or anything nested in it, apply `dst` as a decorator?
+
+        `@with_appcontext` calls `with_appcontext` at definition time, and
+        `@app.cli.command()` calls `AppGroup.command` -- real calls with no
+        call expression in the body of anything. `nodes.decorators` records
+        the names, which is how `query/islands.py` already reasons about
+        implicit invocation (#27). The nested case is the common one on flask:
+        the decorator sits on a view function defined inside the test.
+        """
+        name = last_segment(_qualname(dst))
+        prefix = f"{src}."
+        for node_id, decorators in self.decorators.items():
+            if not decorators or (node_id != src and not node_id.startswith(prefix)):
+                continue
+            if any(last_segment(part) == name for part in decorators.split(",")):
+                return True
+        return False
+
+    def reached_from_elsewhere_in_file(self, src: str, dst: str) -> bool:
+        """Does some OTHER definition in `src`'s file statically call `dst`?"""
+        path = src.partition("::")[0]
+        return any(
+            other != src and other.startswith(f"{path}::")
+            for other in self.by_target.get(dst, ())
+        )
+
+
+@dataclass(frozen=True)
+class Report:
+    #: Traced edges after `collapse_anonymous`, which merges a few pairs that
+    #: differ only in which comprehension inside the caller made the call.
+    traced_total: int
+    #: Traced edges dropped because the target is an anonymous scope -- a
+    #: comprehension or a lambda. `nodes` holds definitions, so no node for
+    #: one can ever exist and no edge to one is judgeable. Kept apart from
+    #: `target_unknown` so a parse gap cannot hide among them.
+    anonymous_target: int
+    #: Traced edges dropped because the target is a module or class body:
+    #: import-time and definition-time execution, not a call. See `partition`.
+    body_execution: int
+    #: Traced edges dropped because the target is not in `nodes` at all.
+    #: Reported separately from `body_execution` because this one is NOT a
+    #: category error in the trace -- it is a hole in codegraph's own view of
+    #: the tree, and folding it into the "not a call" bucket would let a
+    #: parse failure quietly improve the score.
+    target_unknown: int
+    #: The denominator: traced edges whose target is a function or method.
+    judgeable: int
+    found: int
+    found_high_medium: int
+    misses: list[tuple[str, str]]
+    #: cause label -> the misses it explains, in the order `MISS_CAUSES` tries.
+    miss_causes: dict[str, list[tuple[str, str]]]
+    #: Static HIGH edges with both endpoints executed, and the observed subset.
+    testable_high: int
+    observed_high: int
+    #: Examples of `target_unknown`, so the number can be acted on.
+    unknown_examples: list[tuple[str, str]] = field(default_factory=list)
+
+    @property
+    def recall(self) -> float:
+        return self.found / self.judgeable if self.judgeable else 1.0
+
+    @property
+    def recall_high_medium(self) -> float:
+        return self.found_high_medium / self.judgeable if self.judgeable else 1.0
+
+    @property
+    def conditional_precision(self) -> float:
+        """Observed / testable among static HIGH edges. NOT precision.
+
+        1.0 here does not mean codegraph invents no edges; it means every
+        HIGH edge whose endpoints both ran was in fact taken. The edges whose
+        endpoints never both ran are unjudged, and there are usually more of
+        them than of these.
+        """
+        return self.observed_high / self.testable_high if self.testable_high else 1.0
+
+
+def read_static_graph(store, rev: str) -> StaticGraph:
+    """Read `edges` and the ambiguity expansion for `rev` into one graph."""
+    connection = store.connection
+    kinds: dict[str, str] = {}
+    decorators: dict[str, str] = {}
+    for row in connection.execute("SELECT id, kind, decorators FROM nodes WHERE rev=?", (rev,)):
+        kinds[row["id"]] = row["kind"]
+        decorators[row["id"]] = row["decorators"]
+
+    edges: dict[tuple[str, str], str] = {}
+
+    def offer(src: str, dst: str, confidence: str) -> None:
+        edge = (src, dst)
+        current = edges.get(edge)
+        if current is None or CONFIDENCE_RANK[confidence] > CONFIDENCE_RANK[current]:
+            edges[edge] = confidence
+
+    for row in connection.execute(
+        "SELECT src, dst, confidence FROM edges WHERE rev=? AND kind='CALLS'", (rev,)
+    ):
+        offer(row["src"], row["dst"], row["confidence"])
+
+    ambiguity = Ambiguity(store, rev)
+    # One expansion per (src, name), not per row: a function calling
+    # `item.save()` twice writes two `unresolved` rows for one relationship.
+    seen: set[tuple[str, str]] = set()
+    for row in connection.execute(
+        "SELECT src, raw_name FROM unresolved WHERE rev=? AND reason='ambiguous'"
+        " AND ref_kind='call'",
+        (rev,),
+    ):
+        key = (row["src"], last_segment(row["raw_name"]))
+        if key in seen:
+            continue
+        seen.add(key)
+        for candidate in ambiguity.candidates(row["raw_name"]):
+            offer(row["src"], candidate, EXPANDED_CONFIDENCE)
+
+    return StaticGraph(edges=edges, kinds=kinds, decorators=decorators)
+
+
+@dataclass(frozen=True)
+class Partition:
+    """Traced edges split by whether codegraph could ever have had them."""
+
+    judgeable: set[tuple[str, str]]
+    #: Target is a module or class body: import-time / definition-time
+    #: execution, not a call.
+    body: set[tuple[str, str]]
+    #: Target is a comprehension or lambda: no definition, so never a node.
+    anonymous: set[tuple[str, str]]
+    #: Target is a function codegraph does not know about at all.
+    unknown: set[tuple[str, str]]
+
+
+def partition(traced: set[tuple[str, str]], graph: StaticGraph) -> Partition:
+    """Split traced edges by whether codegraph's CALLS edges model them.
+
+    THIS FILTER IS THE BENCHMARK. Do not remove it, and do not widen it to
+    "target is any node".
+
+    `sys.monitoring`'s PY_START fires whenever a Python *code object* starts
+    executing, and a module body and a class body are code objects. So
+    importing `requests` traces `__init__.py::<module> -> api.py::<module>`,
+    and defining a class traces `mod.py::<module> -> mod.py::Cls`. Neither is
+    a call: the first is an import (codegraph has an `imports` table for it)
+    and the second is definition-time execution. codegraph's CALLS edges do
+    not model either, by design, so counting them as missed calls measures
+    nothing about the resolver.
+
+    Measured on psf/requests: with the filter, recall is 0.93 over 88
+    judgeable calls; without it, 0.51 over 172 -- and the miss list is
+    dominated by `<module> -> <module>` pairs. The 0.51 is not a worse honest
+    number, it is a wrong one, and it would send a reader chasing a
+    non-problem.
+
+    The filter is on the TARGET only. A module body is a legitimate *caller*
+    -- `app = create_app()` at import time is a call codegraph records, with
+    the synthetic `path::<module>` node as its `src`.
+
+    Two further cases are kept apart rather than folded in, so that neither
+    can quietly raise the score:
+
+    - the target is an anonymous scope (a comprehension, a lambda). `nodes`
+      holds definitions, so no such node exists at any revision.
+    - the target is a function `nodes` does not contain. That is a hole in
+      codegraph's view of the tree -- a parse failure or a naming
+      disagreement -- and it is reported with examples, not hidden.
+    """
+    result = Partition(judgeable=set(), body=set(), anonymous=set(), unknown=set())
+    for edge in traced:
+        kind = graph.kinds.get(edge[1])
+        if kind in CALLABLE_KINDS:
+            result.judgeable.add(edge)
+        elif is_anonymous(edge[1]):
+            result.anonymous.add(edge)
+        elif kind is None:
+            result.unknown.add(edge)
+        else:
+            result.body.add(edge)
+    return result
+
+
+def _is_dunder(node_id: str) -> bool:
+    name = last_segment(node_id.partition("::")[2])
+    return name.startswith("__") and name.endswith("__")
+
+
+#: (label, predicate) tried in order; the first match explains the miss.
+#: Every label says what KIND of thing is being missed, because "6 misses" is
+#: not actionable and "6 dunders invoked by syntax" is: on requests all six
+#: were `d[k]`, `d[k] = v`, `for x in jar` and `len(f)` -- one coherent gap
+#: (#27's islands cause 1, a real call with no call site in the text), not
+#: scattered noise.
+MISS_CAUSES: list[tuple[str, object]] = [
+    (
+        (
+            "reached through an out-of-repo frame: no call site in this repository"
+            " names the pair, so no static analysis of it could"
+        ),
+        lambda src, dst, graph, trace: (src, dst) in trace.indirect,
+    ),
+    (
+        (
+            "call runs at module scope but codegraph attributes it to a definition"
+            " in the same file (a decorator's arguments are the usual case)"
+        ),
+        lambda src, dst, graph, trace: _qualname(src) == MODULE_SCOPE
+        and graph.reached_from_elsewhere_in_file(src, dst),
+    ),
+    (
+        (
+            "target is a constructor: `Cls()` DOES have a call site, so this is a"
+            " resolution gap rather than implicit invocation"
+        ),
+        lambda src, dst, graph, trace: last_segment(_qualname(dst)) == "__init__",
+    ),
+    (
+        "target is a dunder: invoked by syntax or protocol, no call site in the text",
+        lambda src, dst, graph, trace: _is_dunder(dst),
+    ),
+    (
+        "target is decorated: the decorator may register, wrap or replace it",
+        lambda src, dst, graph, trace: bool(graph.decorators.get(dst)),
+    ),
+    (
+        "target is a test function: invoked by the test runner, not by repo code",
+        lambda src, dst, graph, trace: last_segment(dst.partition("::")[2]).startswith("test_"),
+    ),
+    (
+        "target is nested in another function: reached through a local variable",
+        lambda src, dst, graph, trace: "<locals>" in dst,
+    ),
+    (
+        (
+            "target is applied as a decorator by the source or something nested in"
+            " it: a call at definition time, with no call expression anywhere"
+        ),
+        lambda src, dst, graph, trace: graph.used_as_decorator(src, dst),
+    ),
+    (
+        "source node is absent from the graph: nothing could have been recorded",
+        lambda src, dst, graph, trace: src not in graph.kinds,
+    ),
+    (
+        "no implicit-invocation mechanism recognised",
+        lambda src, dst, graph, trace: True,
+    ),
+]
+
+
+def classify(
+    misses: set[tuple[str, str]], graph: StaticGraph, trace: Trace
+) -> dict[str, list[tuple[str, str]]]:
+    grouped: dict[str, list[tuple[str, str]]] = {}
+    for src, dst in sorted(misses):
+        for label, predicate in MISS_CAUSES:
+            if predicate(src, dst, graph, trace):  # type: ignore[operator]
+                grouped.setdefault(label, []).append((src, dst))
+                break
+    return grouped
+
+
+def score(trace: Trace, graph: StaticGraph) -> Report:
+    split = partition(trace.edges, graph)
+    judgeable = split.judgeable
+    found = {edge for edge in judgeable if graph.confidence(edge) is not None}
+    high_medium = {
+        edge for edge in found if CONFIDENCE_RANK[graph.edges[edge]] >= CONFIDENCE_RANK["MEDIUM"]
+    }
+    misses = judgeable - found
+
+    # Conditional precision. Restricted to function/method targets for the
+    # same reason `partition` is: a HIGH edge to a class node (`Cls()`
+    # resolves to the class, and `resolve.with_constructors` adds the
+    # `__init__` edge beside it) can never be traced, so leaving it in the
+    # denominator would penalise codegraph for an edge shape the trace
+    # cannot express.
+    ran = trace.executed
+    testable = {
+        edge
+        for edge, confidence in graph.edges.items()
+        if confidence == "HIGH"
+        and graph.kinds.get(edge[1]) in CALLABLE_KINDS
+        and edge[0] in ran
+        and edge[1] in ran
+    }
+    return Report(
+        traced_total=len(trace.edges),
+        anonymous_target=len(split.anonymous),
+        body_execution=len(split.body),
+        target_unknown=len(split.unknown),
+        judgeable=len(judgeable),
+        found=len(found),
+        found_high_medium=len(high_medium),
+        misses=sorted(misses),
+        miss_causes=classify(misses, graph, trace),
+        testable_high=len(testable),
+        observed_high=len(testable & trace.edges),
+        unknown_examples=sorted(split.unknown)[:5],
+    )
+
+
+def format_report(name: str, report: Report) -> str:
+    """The human-readable form. Full miss list, always: the point of the
+    benchmark is what is missed, and a truncated list turns a finding back
+    into a number."""
+    lines = [
+        f"=== {name}",
+        f"traced                        : {report.traced_total} edges",
+        (
+            f"  module/class body execution : {report.body_execution}"
+            "  (not calls; see partition())"
+        ),
+        f"  comprehension/lambda target : {report.anonymous_target}  (never a node)",
+        f"  target unknown to the graph : {report.target_unknown}",
+        f"  judgeable function calls    : {report.judgeable}",
+        f"  found                       : {report.found}   RECALL {report.recall:.2f}",
+        (
+            f"  found at HIGH/MEDIUM        : {report.found_high_medium}"
+            f"   ({report.recall_high_medium:.2f})"
+        ),
+        "",
+        "conditional precision (NOT precision: an untraced static edge is not",
+        "wrong, the suite may not cover it -- unconditional precision is not",
+        "measurable from a trace):",
+        f"  static HIGH edges with both endpoints executed : {report.testable_high}",
+        (
+            f"  of those, observed in the trace                : {report.observed_high}"
+            f"   ({report.conditional_precision:.2f})"
+        ),
+    ]
+    if report.unknown_examples:
+        lines += ["", "targets unknown to the graph (examples):"]
+        lines += [f"  {src} -> {dst}" for src, dst in report.unknown_examples]
+    lines += ["", f"misses by cause ({len(report.misses)}):"]
+    for label, edges in report.miss_causes.items():
+        lines.append(f"  [{len(edges)}] {label}")
+        lines += [f"      {src} -> {dst}" for src, dst in edges]
+    return "\n".join(lines)
+
+
+__all__ = [
+    "ANONYMOUS_SCOPES",
+    "CALLABLE_KINDS",
+    "MISS_CAUSES",
+    "Partition",
+    "Report",
+    "StaticGraph",
+    "Trace",
+    "classify",
+    "collapse_anonymous",
+    "format_report",
+    "is_anonymous",
+    "partition",
+    "read_static_graph",
+    "score",
+]

--- a/bench/tracer.py
+++ b/bench/tracer.py
@@ -1,0 +1,138 @@
+"""Record the call edges a test suite ACTUALLY makes, as ground truth (#35).
+
+Runs inside the *target* repository's virtualenv, so it imports nothing from
+codegraph and depends on nothing but the stdlib and pytest. Invoked by
+`bench/run.py`:
+
+    python bench/tracer.py --root <repo> --out edges.json -- <pytest args>
+
+Two things here were expensive to discover and must not be "simplified":
+
+- **`sys.setprofile` does not survive pytest.** It silently stops firing
+  after collection -- no error, no warning, just ~16 edges instead of ~170.
+  `sys.monitoring` (3.12+) keeps firing for the whole session and is much
+  cheaper. Do not swap it back.
+- **`PY_START` hands you `(code, offset)`, not a frame.** There is no
+  caller in the event, so the caller is found by walking
+  `sys._getframe(1).f_back` -- frame 1 being the monitored function's own
+  frame -- outward to the nearest ancestor whose code lives in the target
+  repository. Skipping the external frames in between is what makes
+  `test_x -> helper` come out as an edge even though pytest's own machinery
+  sits between them.
+
+Emitted node ids are codegraph's `path::qualname` form, with `path`
+repo-relative and POSIX-separated. `code.co_qualname` aligns with what
+`parse.py` records, `<locals>` segments for nested functions included.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+#: sys.monitoring tool ids 0-5 are reservable; 2 is "profiler" by convention
+#: and coverage.py takes it, so use a free one. Nothing else in a bench run
+#: monitors, but an id collision raises rather than silently losing events.
+TOOL_ID = 3
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="bench/tracer.py")
+    parser.add_argument("--root", required=True, help="Target repository root")
+    parser.add_argument("--out", required=True, help="Where to write the trace JSON")
+    parser.add_argument("pytest_args", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+
+    root = os.path.abspath(args.root) + os.sep
+    edges: set[tuple[str, str]] = set()
+    #: Edges where at least one out-of-repo Python frame sat between the
+    #: callee and the nearest in-repo ancestor: `test_x` -> werkzeug's
+    #: `Client.get` -> `FlaskClient.open`. The relationship is real, but there
+    #: is no call site anywhere in the repository's text that names it, so no
+    #: static analyser could have it. The scorer reports these apart from
+    #: resolution failures instead of blaming the resolver for them.
+    indirect: set[tuple[str, str]] = set()
+    #: The same pairs seen with no external frame in between. An edge in both
+    #: sets is a direct call, whatever else was also observed.
+    direct: set[tuple[str, str]] = set()
+    #: Every in-repo function that ran at least once, whether or not any
+    #: in-repo caller was found for it. A test function invoked by pytest
+    #: has no in-repo caller and so appears in no edge, but it did execute
+    #: -- and conditional precision is defined over what executed, so the
+    #: scorer needs this set rather than the endpoints of `edges`.
+    executed: set[str] = set()
+    #: code object -> node id (or None for out-of-repo). The callback runs on
+    #: every single call in the suite; without this, each one pays a relpath.
+    names: dict[object, str | None] = {}
+
+    def node_id(code) -> str | None:
+        if code in names:
+            return names[code]
+        path = code.co_filename
+        # Three exclusions, all of them needed:
+        #  - outside the repo: not this repository's code at all;
+        #  - site-packages: a venv placed inside the repo (run.py keeps it
+        #    outside, but a stray one must not become in-repo edges);
+        #  - not a .py file: Jinja compiles a template to a code object whose
+        #    co_filename is the template. Real execution, but codegraph
+        #    indexes Python, so `templates/mail.txt::root` can never be a
+        #    node. On flask's suite that is 23 edges.
+        if not path.startswith(root) or "site-packages" in path or not path.endswith(".py"):
+            names[code] = None
+            return None
+        relative = os.path.relpath(path, root).replace(os.sep, "/")
+        name = f"{relative}::{code.co_qualname}"
+        names[code] = name
+        return name
+
+    def on_start(code, offset):
+        me = node_id(code)
+        if me is None:
+            return
+        executed.add(me)
+        back = sys._getframe(1).f_back
+        skipped = False
+        while back is not None:  # nearest in-repo ancestor is the caller
+            caller = node_id(back.f_code)
+            if caller is not None:
+                if caller != me:  # recursion is not an edge codegraph models
+                    edges.add((caller, me))
+                    (indirect if skipped else direct).add((caller, me))
+                return
+            skipped = True
+            back = back.f_back
+
+    monitoring = sys.monitoring
+    monitoring.use_tool_id(TOOL_ID, "codegraph-bench")
+    monitoring.register_callback(TOOL_ID, monitoring.events.PY_START, on_start)
+    monitoring.set_events(TOOL_ID, monitoring.events.PY_START)
+    try:
+        import pytest
+
+        pytest_status = pytest.main([a for a in args.pytest_args if a != "--"])
+    finally:
+        monitoring.set_events(TOOL_ID, 0)
+        monitoring.free_tool_id(TOOL_ID)
+        with open(args.out, "w") as handle:
+            json.dump(
+                {
+                    "root": os.path.abspath(args.root),
+                    "edges": sorted(edges),
+                    "indirect": sorted(indirect - direct),
+                    "executed": sorted(executed),
+                },
+                handle,
+            )
+    print(
+        f"\ntraced {len(edges)} distinct call edges over {len(executed)} executed functions",
+        file=sys.stderr,
+    )
+    # The suite's own exit status is reported, not propagated: a target whose
+    # suite has some failing tests still produced a real trace, and the
+    # runner decides whether that is acceptable.
+    print(f"pytest exit status {int(pytest_status)}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bench_scorer.py
+++ b/tests/test_bench_scorer.py
@@ -1,0 +1,186 @@
+"""Unit tests for the runtime-trace scorer (`bench/score.py`, #35).
+
+The benchmark itself needs a target repository, a virtualenv and a full test
+suite run, and lives under `bench/` for that reason. Its arithmetic does not:
+`score` is a pure function over sets, and getting it wrong would mean
+publishing a wrong number about the resolver. So the arithmetic is checked
+here, with synthetic traces, in milliseconds.
+"""
+
+from bench.score import StaticGraph, Trace, classify, collapse_anonymous, read_static_graph, score
+
+from codegraph.indexer import GitTreeSource, Indexer
+from codegraph.store import Store
+
+
+def trace(edges, executed=(), indirect=()):
+    return Trace.load(
+        {
+            "edges": [list(edge) for edge in edges],
+            "indirect": [list(edge) for edge in indirect],
+            "executed": list(executed),
+        }
+    )
+
+
+def test_module_and_class_body_execution_is_not_counted_as_a_missed_call():
+    """The filter the whole benchmark rests on. PY_START fires for a module
+    body and a class body; neither is a call, and counting them dropped
+    requests' measured recall from 0.93 to 0.51 with a miss list full of
+    `<module> -> <module>`."""
+    graph = StaticGraph(
+        edges={("a.py::caller", "b.py::callee"): "HIGH"},
+        kinds={
+            "a.py::caller": "function",
+            "b.py::callee": "function",
+            "a.py::<module>": "module",
+            "b.py::<module>": "module",
+            "b.py::Cls": "class",
+        },
+    )
+    report = score(
+        trace(
+            [
+                ("a.py::caller", "b.py::callee"),
+                ("a.py::<module>", "b.py::<module>"),
+                ("b.py::<module>", "b.py::Cls"),
+            ]
+        ),
+        graph,
+    )
+    assert report.judgeable == 1
+    assert report.body_execution == 2
+    assert report.recall == 1.0
+
+
+def test_recall_at_high_medium_excludes_a_target_found_only_by_the_low_fan_out():
+    graph = StaticGraph(
+        edges={
+            ("a.py::caller", "b.py::sure"): "HIGH",
+            ("a.py::caller", "b.py::guess"): "LOW",
+        },
+        kinds={"a.py::caller": "function", "b.py::sure": "function", "b.py::guess": "function"},
+    )
+    report = score(
+        trace([("a.py::caller", "b.py::sure"), ("a.py::caller", "b.py::guess")]),
+        graph,
+    )
+    assert report.recall == 1.0
+    assert report.found_high_medium == 1
+    assert report.recall_high_medium == 0.5
+
+
+def test_a_target_the_graph_does_not_know_is_reported_rather_than_dropped_quietly():
+    """A traced call to a function absent from `nodes` is a hole in
+    codegraph's view of the tree. It is excluded from the denominator (nothing
+    could match it) but counted and shown, so a parse failure cannot raise the
+    score in silence."""
+    graph = StaticGraph(edges={}, kinds={"a.py::caller": "function"})
+    report = score(trace([("a.py::caller", "b.py::never_parsed")]), graph)
+    assert report.judgeable == 0
+    assert report.target_unknown == 1
+    assert report.unknown_examples == [("a.py::caller", "b.py::never_parsed")]
+
+
+def test_a_comprehension_is_attributed_to_the_definition_that_contains_it():
+    """codegraph records a call made inside a comprehension from the
+    enclosing definition, because a comprehension is not a definition. The
+    trace names it `f.<locals>.<genexpr>`; without collapsing that, the two
+    describe the same call under different names and it scores as a miss."""
+    assert collapse_anonymous("a.py::f.<locals>.<genexpr>") == "a.py::f"
+    assert collapse_anonymous("a.py::f.<locals>.g.<locals>.<listcomp>") == "a.py::f.<locals>.g"
+    assert collapse_anonymous("a.py::<lambda>") == "a.py::<module>"
+
+    graph = StaticGraph(
+        edges={("a.py::f", "b.py::callee"): "HIGH"},
+        kinds={"a.py::f": "function", "b.py::callee": "function"},
+    )
+    report = score(trace([("a.py::f.<locals>.<genexpr>", "b.py::callee")]), graph)
+    assert report.recall == 1.0
+
+
+def test_conditional_precision_ignores_static_edges_whose_endpoints_never_ran():
+    """The reason unconditional precision is not reported at all: an untraced
+    static edge is only evidence of anything if both its endpoints executed,
+    and most of a library's surface is not exercised by its own tests."""
+    graph = StaticGraph(
+        edges={
+            ("a.py::ran", "b.py::also_ran"): "HIGH",
+            ("a.py::ran", "b.py::never_ran"): "HIGH",
+            ("a.py::ran", "b.py::low_guess"): "LOW",
+        },
+        kinds={
+            "a.py::ran": "function",
+            "b.py::also_ran": "function",
+            "b.py::never_ran": "function",
+            "b.py::low_guess": "function",
+        },
+    )
+    report = score(trace([], executed=["a.py::ran", "b.py::also_ran", "b.py::low_guess"]), graph)
+    # Only the first edge is testable: the second has an endpoint that never
+    # ran, and the third is not HIGH.
+    assert report.testable_high == 1
+    assert report.observed_high == 0
+    assert report.conditional_precision == 0.0
+
+
+def test_each_miss_is_explained_by_the_first_cause_that_applies():
+    """A miss count is not actionable; a miss count per mechanism is. On
+    requests all six misses at recall 0.93 were dunders invoked by syntax."""
+    graph = StaticGraph(
+        edges={},
+        kinds={
+            "a.py::caller": "function",
+            "b.py::Cls.__getitem__": "method",
+            "b.py::handler": "function",
+            "b.py::outer.<locals>.inner": "function",
+        },
+        decorators={"b.py::handler": "app.route"},
+    )
+    misses = {
+        ("a.py::caller", "b.py::Cls.__getitem__"),
+        ("a.py::caller", "b.py::handler"),
+        ("a.py::caller", "b.py::outer.<locals>.inner"),
+        ("a.py::caller", "b.py::reached_via_library"),
+    }
+    grouped = classify(
+        misses, graph, trace([], indirect=[("a.py::caller", "b.py::reached_via_library")])
+    )
+    labels = {edge: label for label, edges in grouped.items() for edge in edges}
+    assert "dunder" in labels[("a.py::caller", "b.py::Cls.__getitem__")]
+    assert "decorated" in labels[("a.py::caller", "b.py::handler")]
+    assert "nested" in labels[("a.py::caller", "b.py::outer.<locals>.inner")]
+    # Out-of-repo frames win over every other cause: no call site in this
+    # repository names the pair, so it is not a resolution failure at all.
+    assert "out-of-repo" in labels[("a.py::caller", "b.py::reached_via_library")]
+    assert sum(len(edges) for edges in grouped.values()) == len(misses)
+
+
+def test_the_scored_graph_includes_the_query_time_ambiguity_expansion(repo, write):
+    """The property that keeps the benchmark honest about the resolver rather
+    than about the storage layer: an all-LOW fan-out is never written to
+    `edges` (#25), it is expanded when a query asks. `tests/test_accuracy.py`
+    unions the same two sources, and scoring `edges` alone would report a
+    target as missed while every real query returns it."""
+    write("box.py", "class One:\n    def save(self):\n        pass\n")
+    write("crate.py", "class Two:\n    def save(self):\n        pass\n")
+    write("use.py", "def go(item):\n    item.save()\n", commit="fan-out")
+
+    store = Store.open(repo)
+    Indexer(repo, store, GitTreeSource(repo)).reconcile("HEAD")
+    graph = read_static_graph(store, "HEAD")
+
+    materialized = {
+        (row["src"], row["dst"])
+        for row in store.connection.execute(
+            "SELECT src, dst FROM edges WHERE rev='HEAD' AND kind='CALLS'"
+        )
+    }
+    traced = [("use.py::go", "box.py::One.save"), ("use.py::go", "crate.py::Two.save")]
+    assert not any(edge in materialized for edge in traced)  # nothing was stored
+
+    report = score(trace(traced), graph)
+    assert report.judgeable == 2
+    assert report.found == 2
+    assert report.found_high_medium == 0  # the fan-out is LOW, as resolve.py would have written it
+    store.close()


### PR DESCRIPTION
Closes #35.

`tests/test_accuracy.py` reports precision 1.00 / recall 1.00 over 10 hand-written
call sites in a synthetic repo, each authored to illustrate a rule the resolver
already implements. This adds a measurement that codegraph cannot flatter: run a
real repository's own test suite under `sys.monitoring`, record every
`(caller, callee)` pair that actually executed, and score the static graph
against it. A call the tests made is a call that exists.

## What landed

- `bench/tracer.py` — runs in the target's venv, records distinct call edges as
  `path::qualname` node ids. `sys.monitoring` with `PY_START`, **not**
  `sys.setprofile`, which silently stops firing after pytest's collection phase
  (~16 edges instead of ~170, no error).
- `bench/score.py` — scores `edges` **union the query-time ambiguity expansion**,
  i.e. the graph the commands actually answer from (#25), the same union
  `test_accuracy.py` performs. Scoring `edges` alone would grade the storage layer.
- `bench/run.py` — copy clone, venv, **editable** install, trace, index, score.
  Editable is load-bearing: a normal install copies the source into
  `site-packages`, so `co_filename` points there and every in-repo edge is
  filtered out as external — silently.
- `tests/test_bench_scorer.py` — 7 fast tests over synthetic sets. Nothing else
  in `bench/` runs during `pytest -q`; the default run is 340 passed in 155s
  against 333 in 159s on `main`.

## The numbers

| | psf/requests | pallets/flask |
|---|---|---|
| suite traced | `test_utils.py` + `test_structures.py`, 240 tests | `tests/`, 494 tests |
| judgeable call edges | 115 | 2683 |
| **recall** | **0.79** | **0.29** |
| recall at HIGH/MEDIUM | 0.76 | 0.19 |
| conditional precision | 0.99 (81/82) | 0.86 (206/239) |

On `tests/test_utils.py` alone this reproduces #35 exactly: 172 traced edges, 89
judgeable, 83 found, **recall 0.93**, HIGH/MEDIUM 0.91, and all 6 misses dunders
invoked by syntax. Adding `test_structures.py` — which tests a mapping's dunders
directly — takes it to 0.79. Same gap, different weighting: **recall is a property
of the repository and of the suite you trace, not one number about codegraph.**

flask's 1918 misses, grouped by mechanism:

| | |
|---|---|
| target nested in another function (a view defined inside a test) | 564 |
| reachable only through an out-of-repo frame | 552 |
| target is decorated (`@app.route`, `@setupmethod`) | 523 |
| target is a dunder, invoked by syntax or protocol | 223 |
| target is a constructor — a real resolution gap | 21 |
| target applied as a decorator by the source | 18 |
| no implicit-invocation mechanism recognised | 15 |
| call site attributed to another definition in the same file | 2 |

The 552 "out-of-repo frame" misses are `test_x -> werkzeug's Client.get ->
FlaskClient.open`: no call site anywhere in flask's text names the pair, so no
static analysis of this repository could produce it. They are counted apart rather
than blamed on the resolver. Excluding them still leaves recall at 0.36.

## Two decisions that decide whether the number is honest

**The filter.** `PY_START` fires when a module body or a class body executes —
import time and definition time, not calls, and codegraph's CALLS edges do not
model either. So an edge is judgeable only when its target is a function or method
node. Without that filter requests reads **0.51** with a miss list full of
`__init__.py::<module> -> api.py::<module>`; that number is wrong and would send
someone chasing a non-problem. The reasoning is in `partition`'s docstring with a
"do not remove this" on it. Two neighbours are counted separately rather than
folded in, so neither can quietly raise the score: comprehension/lambda targets
(never a node — `nodes` holds definitions) and targets absent from `nodes` at all
(a hole in codegraph's own view, printed with examples).

**Precision is conditional and says so in words.** A static edge the trace never
saw is not thereby wrong; the suite may not cover it. No unconditional precision
number is printed. What is reported: among static HIGH edges whose two endpoints
both executed, how many the trace observed.

## Findings I did not fix

- **`test_accuracy.py`'s floors are not defensible as stated, and are best left
  alone in this PR.** `recall >= 0.90` holds on requests/`test_utils.py` (0.93) and
  fails on requests + `test_structures.py` (0.79) and on flask (0.29) — so the
  floor is really a floor on *the fixture*, not on the resolver, and the fixture
  has no dunder-heavy or decorator-heavy call sites. Raising or lowering it against
  a real number would need a target set agreed first; #35 already frames that as a
  follow-up.
- **Package re-exports are not followed, and it costs flask 218 references.**
  `class CustomFlask(flask.Flask)` in a test does not resolve to
  `src/flask/app.py::Flask` through `src/flask/__init__.py`'s `from .app import
  Flask`. It degrades to the bare-name step and becomes *ambiguous* only because an
  unrelated nested class in `tests/test_config.py` is also named `Flask`. 218 of
  flask's 1039 ambiguous refs are `flask.X` — the target package's own public API.
  This looks like the highest-value resolver fix flask exposes.
- **Constructors called through a class attribute.** 19 of the 21 constructor
  misses are the framework extension point: `self.session_class(...)`,
  `self.config_class(...)`, `cls.view_class(...)`.
- Django is not run. It is in `bench/`'s reach but needs its own settings harness,
  and two targets already show the shape of the answer.
