### PR TITLE
feat(orphans): a discovery command for the bug class islands cannot see

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ slower on a cold cache.
 | `codegraph effects <symbol> [--json]` | Report every side-effect kind reachable from a symbol, each with a witness chain down to the causing `file:line`. |
 | `codegraph impact <symbol> [--hops N] [--limit N] [--all] [--json]` | Report the ranked dependents of a symbol — everything a change to it could break. |
 | `codegraph islands [--rev REV] [--limit N] [--json]` | Report the connected components of the revision's `CALLS` edges, read as undirected: how many separate regions the codebase is in, how big each is, and which symbols anchor them, plus what the tool can say about why each one stands apart (implicit invocation, a `NETWORK` boundary, or nothing it recognises). An island of one is *not* a dead-code finding (see below). |
+| `codegraph orphans [--rev REV] [--limit N] [--include-public] [--include-decorated] [--json]` | Find functions whose every recorded caller is a test — defined, tested, and never invoked by the code that was supposed to invoke it. Such a function is *not* a one-symbol island, precisely because its test calls it, so `islands` structurally cannot surface it. Candidates are private by name, undecorated, defined outside the test tree, and never mentioned by name anywhere in the source text — that last filter has no off switch, because a static call graph cannot see a callback handed to a library. Not a dead-code report (see below). |
 | `codegraph diff [<base>..<head>] [--json]` | Report what changed between two revisions by content hash, never by line number: symbols added/removed/changed, plus any side effect newly reachable. Defaults to `merge-base(default branch, HEAD)..WORKTREE` — "what has this branch changed so far." |
 | `codegraph gc [--keep REV]` | Prune the Layer 1 parse cache down to what `HEAD`, the worktree, and any `--keep`-named revisions still reference. Never touches the graph itself, so it can only make a future answer slower to rebuild, never wrong. |
 | `codegraph init` | Make this repository's coding agents aware of codegraph: an `AGENTS.md` section, the `@AGENTS.md` bridge into an existing `CLAUDE.md`, and a commented `codegraph.toml` stub. Idempotent; never overwrites content it did not write; never touches `.git/`. |
@@ -161,13 +162,53 @@ had no incoming edge at all. Implying that edge (following the MRO for an
 inherited one) folded 18 of requests' 172 islands into the rest of the
 graph.
 
+### What `orphans` finds that nothing else can
+
+Every other query needs the symbol's name as input, which means already
+suspecting the bug. `orphans` asks a bug's *shape* instead: **which
+functions have callers, all of which are tests?** That is the signature of a
+helper that was written, tested, and then never wired up — `_get_mlx_info()`
+on a 948-file project, docstring'd "Surface MLX info in the doctor report",
+covered by `test_doctor_has_mlx_info`, and never reached by the command, so
+the feature silently did not exist and the test passed anyway (#37).
+
+`islands` cannot find that, structurally: the test's call is a real edge, so
+the function is not a one-symbol island. The thing that lets the bug survive
+review is the thing that hides it from the only global view.
+
+The filters are the command. On that project, "every caller is a test"
+alone answers **280** functions — a list nobody reads. Private by name and
+undecorated cuts it to **10**; "not mentioned by name anywhere in the source
+text" cuts it to **5**, of which **2 were real defects** (one is now merged
+upstream). 40% on a hand-reviewable list, in a repo with 19,960 tests.
+
+That last filter is not optional and has no flag, because a static call
+graph cannot see a function passed as a **value**. Without it the same
+project's list is headed by `_run_bash_sandbox.<locals>.preexec` (handed to
+`subprocess`'s `preexec_fn`) and `_handle_sigint` (registered through
+`signal.signal`), neither of which is dead. `blob_refs` cannot answer it —
+it records calls, not names used as values — so the filter is a documented
+grep over the revision's non-test source text, which over-matches on
+purpose: it can only remove a candidate, never invent one.
+
+**This is not a dead-code report, and no row says otherwise.** The claim is
+about codegraph's knowledge — no caller outside the test tree was recorded,
+and the name does not appear in the source text — and the blind spot is
+printed in the summary, with the rows, not left here. A name resolved at
+runtime (`getattr`, a registry, a `pyproject.toml` entry point, a template)
+leaves nothing for either half of this report to find. Three of those five
+survivors were deliberate: two documented back-compat shims and an import
+probe whose docstring says test-only is the point.
+
 `resolve`, `impact`, and `effects` share one exit-code convention for
 resolving `<symbol>` to a node id: `0` = a single unambiguous match, `1` =
 nothing matched, `2` = more than one match (every candidate is printed; pick
 the right one and re-run with the full node id).
 
-`islands` takes no symbol, so that convention does not apply to it: it
-exits `0` for a report and `1` only for a revision it cannot resolve.
+`islands` and `orphans` take no symbol, so that convention does not apply
+to either: they exit `0` for a report — an empty one included, since "nothing
+matched" is a real answer — and `1` only for a revision they cannot
+resolve.
 
 All commands accept `--path <dir>` to run against a different repository
 root (default: the current directory).

--- a/skills/codegraph/SKILL.md
+++ b/skills/codegraph/SKILL.md
@@ -93,16 +93,52 @@ stands apart, and each row carries the label:
   — called by users of the package and by the stdlib, neither of which is in
   the tree. **Do not read this bucket as dead code.**
 
+`codegraph orphans` answers the one question every other command needs the
+answer to before you can ask it. `resolve`, `impact` and `effects` all take a
+symbol, so they need you to already suspect the bug. `orphans` takes none: it
+asks a bug's *shape* — **which functions have callers, all of which are
+tests?** That is a helper that was written, tested, and never wired up, so
+the feature silently does not exist while its test passes (#37). `islands`
+cannot find it: the test's call is a real edge, so the function is not a
+one-symbol island.
+
+Reach for it when asked "is there anything wrong in here", "is this dead",
+"what is not wired up", or after inheriting an unfamiliar repository. It is
+also the check to run after adding a helper and its test — if your new
+function appears, you forgot to call it.
+
+Candidates are additionally private by name, undecorated, defined outside
+the test tree, and **not mentioned by name anywhere in the source text**.
+That last filter has no off switch: a static call graph cannot see a
+function passed as a value, so without it a live `signal.signal` handler and
+a `subprocess` `preexec_fn` head the list. `--include-public` and
+`--include-decorated` relax the other two; the summary counts what each
+filter removed (`functions` → `test_callers_only` → `candidates` →
+`name_referenced` → `reported`), so you can see the funnel rather than trust
+it.
+
+**`orphans` is NOT a dead-code report, and neither its rows nor you should
+say it is.** Its claim is about codegraph's knowledge: no caller outside the
+test tree was recorded, and the name does not appear in the source text. A
+name resolved at runtime — `getattr`, a registry, a `pyproject.toml` entry
+point, a template — leaves nothing for either half of it to find, and the
+`caveat` field in every summary says so. On the project it was built for, 2
+of 5 rows were real defects and the other 3 were deliberate (two back-compat
+shims and an import probe that is meant to be test-only). Read the rows,
+then read the functions; never delete on the strength of a row. Like
+`islands` it takes no symbol, so it exits `0` for a report — including an
+empty one — and `1` only for a bad `--rev`.
+
 `codegraph diff [<base>..<head>]` reports what a branch actually changed —
 symbols added/removed/changed by content hash (never by line number) plus
 any side effect that newly became reachable. With no argument it diffs
 `merge-base(default branch, HEAD)` against the worktree, which is what you
 want when asked "what did this branch change".
 
-All of `resolve`, `impact`, `effects`, `islands`, and `diff` accept
-`--path <dir>` to run against a different repository root, and
-`impact`/`effects`/`islands`/`diff` accept `--json` for machine-readable
-output instead of the default text.
+All of `resolve`, `impact`, `effects`, `islands`, `orphans` and `diff`
+accept `--path <dir>` to run against a different repository root, and
+`impact`/`effects`/`islands`/`orphans`/`diff` accept `--json` for
+machine-readable output instead of the default text.
 
 ## The anti-pattern this displaces
 
@@ -132,7 +168,11 @@ the full set and how confident it is in each edge.
   to a number either: the strongest few are listed in their own
   `low_confidence` group, and `low_confidence_hidden` counts only the ones
   that did not fit. Pass `--all` to merge the whole set into the main
-  groups instead.
+  groups instead — which the summary now says out loud: a nonzero
+  `low_confidence_hidden` is printed with `show_hidden: --all` beside it,
+  because a count of what you cannot see is half an answer (#37). The count
+  stays an integer in `--json`; the hint is a separate field and appears
+  only when something is actually hidden.
 - Many of those `LOW` rows are not in the stored graph at all. A call like
   `item.save()` that names nothing importable, nothing module-local and
   nothing reachable through `self` matches every definition named `save`
@@ -180,6 +220,14 @@ the full set and how confident it is in each edge.
   and not about the symbol. `--limit N` (default 20) is a total budget
   across both groups, islands first, exactly as `impact` budgets dependents
   ahead of tests.
+- `orphans`' summary reads `functions: 812 · test_callers_only: 280 ·
+  candidates: 10 · name_referenced: 5 · reported: 5 · basis: ... ·
+  caveat: ...` — the funnel, in order, so each filter's work is visible.
+  `functions` counts the ones considered at all (outside the test tree,
+  under a source root); `name_referenced` is how many candidates the
+  source-text scan removed. Every row's `detail` names the tests that call
+  it, which is where to start reading: the test says what the function was
+  supposed to be for.
 - Each `effects` row's `detail` reads `<KIND> <CONFIDENCE> via <chain>` —
   the chain is the call path from the queried symbol down to the concrete
   call site; `location` is that call site's `file:line`, clickable evidence

--- a/src/codegraph/cli.py
+++ b/src/codegraph/cli.py
@@ -15,6 +15,7 @@ from codegraph.query.diff import MissingRevisionError, diff_report
 from codegraph.query.effects import effects_report
 from codegraph.query.impact import impact_report
 from codegraph.query.islands import islands_report
+from codegraph.query.orphans import orphans_report
 from codegraph.render import render_json, render_text
 from codegraph.resolve import find_symbol
 from codegraph.store import WORKTREE, Store
@@ -205,6 +206,41 @@ def _cmd_islands(args: argparse.Namespace) -> int:
             print(f"revision not found: {args.rev}", file=sys.stderr)
             return 1
         report = islands_report(store, args.rev, indexer.config, limit=args.limit)
+        print(render_json(report) if args.json else render_text(report))
+        return 0
+    finally:
+        store.close()
+
+
+def _cmd_orphans(args: argparse.Namespace) -> int:
+    """Report functions whose every recorded caller is a test.
+
+    Global like `islands`, so it shares `islands`' exit convention rather
+    than the `0`/`1`/`2` one the symbol-taking commands use: `0` on a report
+    (an empty one included -- "nothing matched the filters" is a real
+    answer), `1` only on a `--rev` that will not resolve.
+
+    The indexer's tree source is passed straight through, because the last
+    filter reads the revision's source text: see `query/orphans.py` for why
+    that filter is not optional and has no flag.
+    """
+    root = Path(args.path).resolve()
+    store, indexer = open_workspace(root)
+    try:
+        try:
+            indexer.reconcile(args.rev)
+        except gitio.GitError:
+            print(f"revision not found: {args.rev}", file=sys.stderr)
+            return 1
+        report = orphans_report(
+            store,
+            args.rev,
+            indexer.source,
+            indexer.config,
+            limit=args.limit,
+            include_public=args.include_public,
+            include_decorated=args.include_decorated,
+        )
         print(render_json(report) if args.json else render_text(report))
         return 0
     finally:
@@ -421,6 +457,47 @@ def build_parser() -> argparse.ArgumentParser:
     )
     islands_parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
     islands_parser.set_defaults(handler=_cmd_islands)
+
+    orphans_parser = subparsers.add_parser(
+        "orphans",
+        help="Report functions whose every recorded caller is a test",
+        description=(
+            "Find the shape of a bug the other commands cannot: a function that is"
+            " defined, tested, and never called by anything outside the test tree."
+            " Such a function is NOT a one-symbol island -- its test calls it -- so"
+            " `islands` structurally cannot surface it. Candidates are private by"
+            " name, undecorated, defined outside the test tree, and never mentioned"
+            " by name anywhere in the source text; that last filter is what keeps a"
+            " callback handed to a library out of the list, and it has no off"
+            " switch. This is NOT a dead-code report: a name resolved at runtime"
+            " leaves nothing for either half of it to find. Read the rows, then read"
+            " the functions."
+        ),
+    )
+    orphans_parser.add_argument("--path", default=".", help="Repository root (default: cwd)")
+    orphans_parser.add_argument("--rev", default=WORKTREE, help="Revision to query")
+    orphans_parser.add_argument(
+        "--limit", type=int, default=20, help="Maximum rows to keep (default: 20)"
+    )
+    orphans_parser.add_argument(
+        "--include-public",
+        action="store_true",
+        help=(
+            "Keep functions without a leading underscore. Off by default: a public"
+            " function called only by tests is usually the package's own surface,"
+            " called by code that is not in this repository"
+        ),
+    )
+    orphans_parser.add_argument(
+        "--include-decorated",
+        action="store_true",
+        help=(
+            "Keep decorated functions. Off by default: a decorator can register or"
+            " replace what it decorates, so the call site is inside the framework"
+        ),
+    )
+    orphans_parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    orphans_parser.set_defaults(handler=_cmd_orphans)
 
     diff_parser = subparsers.add_parser(
         "diff", help="Report what changed between two revisions"

--- a/src/codegraph/guide.md
+++ b/src/codegraph/guide.md
@@ -88,16 +88,52 @@ stands apart, and each row carries the label:
   — called by users of the package and by the stdlib, neither of which is in
   the tree. **Do not read this bucket as dead code.**
 
+`codegraph orphans` answers the one question every other command needs the
+answer to before you can ask it. `resolve`, `impact` and `effects` all take a
+symbol, so they need you to already suspect the bug. `orphans` takes none: it
+asks a bug's *shape* — **which functions have callers, all of which are
+tests?** That is a helper that was written, tested, and never wired up, so
+the feature silently does not exist while its test passes (#37). `islands`
+cannot find it: the test's call is a real edge, so the function is not a
+one-symbol island.
+
+Reach for it when asked "is there anything wrong in here", "is this dead",
+"what is not wired up", or after inheriting an unfamiliar repository. It is
+also the check to run after adding a helper and its test — if your new
+function appears, you forgot to call it.
+
+Candidates are additionally private by name, undecorated, defined outside
+the test tree, and **not mentioned by name anywhere in the source text**.
+That last filter has no off switch: a static call graph cannot see a
+function passed as a value, so without it a live `signal.signal` handler and
+a `subprocess` `preexec_fn` head the list. `--include-public` and
+`--include-decorated` relax the other two; the summary counts what each
+filter removed (`functions` → `test_callers_only` → `candidates` →
+`name_referenced` → `reported`), so you can see the funnel rather than trust
+it.
+
+**`orphans` is NOT a dead-code report, and neither its rows nor you should
+say it is.** Its claim is about codegraph's knowledge: no caller outside the
+test tree was recorded, and the name does not appear in the source text. A
+name resolved at runtime — `getattr`, a registry, a `pyproject.toml` entry
+point, a template — leaves nothing for either half of it to find, and the
+`caveat` field in every summary says so. On the project it was built for, 2
+of 5 rows were real defects and the other 3 were deliberate (two back-compat
+shims and an import probe that is meant to be test-only). Read the rows,
+then read the functions; never delete on the strength of a row. Like
+`islands` it takes no symbol, so it exits `0` for a report — including an
+empty one — and `1` only for a bad `--rev`.
+
 `codegraph diff [<base>..<head>]` reports what a branch actually changed —
 symbols added/removed/changed by content hash (never by line number) plus
 any side effect that newly became reachable. With no argument it diffs
 `merge-base(default branch, HEAD)` against the worktree, which is what you
 want when asked "what did this branch change".
 
-All of `resolve`, `impact`, `effects`, `islands`, and `diff` accept
-`--path <dir>` to run against a different repository root, and
-`impact`/`effects`/`islands`/`diff` accept `--json` for machine-readable
-output instead of the default text.
+All of `resolve`, `impact`, `effects`, `islands`, `orphans` and `diff`
+accept `--path <dir>` to run against a different repository root, and
+`impact`/`effects`/`islands`/`orphans`/`diff` accept `--json` for
+machine-readable output instead of the default text.
 
 ## The anti-pattern this displaces
 
@@ -127,7 +163,11 @@ the full set and how confident it is in each edge.
   to a number either: the strongest few are listed in their own
   `low_confidence` group, and `low_confidence_hidden` counts only the ones
   that did not fit. Pass `--all` to merge the whole set into the main
-  groups instead.
+  groups instead — which the summary now says out loud: a nonzero
+  `low_confidence_hidden` is printed with `show_hidden: --all` beside it,
+  because a count of what you cannot see is half an answer (#37). The count
+  stays an integer in `--json`; the hint is a separate field and appears
+  only when something is actually hidden.
 - Many of those `LOW` rows are not in the stored graph at all. A call like
   `item.save()` that names nothing importable, nothing module-local and
   nothing reachable through `self` matches every definition named `save`
@@ -175,6 +215,14 @@ the full set and how confident it is in each edge.
   and not about the symbol. `--limit N` (default 20) is a total budget
   across both groups, islands first, exactly as `impact` budgets dependents
   ahead of tests.
+- `orphans`' summary reads `functions: 812 · test_callers_only: 280 ·
+  candidates: 10 · name_referenced: 5 · reported: 5 · basis: ... ·
+  caveat: ...` — the funnel, in order, so each filter's work is visible.
+  `functions` counts the ones considered at all (outside the test tree,
+  under a source root); `name_referenced` is how many candidates the
+  source-text scan removed. Every row's `detail` names the tests that call
+  it, which is where to start reading: the test says what the function was
+  supposed to be for.
 - Each `effects` row's `detail` reads `<KIND> <CONFIDENCE> via <chain>` —
   the chain is the call path from the queried symbol down to the concrete
   call site; `location` is that call site's `file:line`, clickable evidence

--- a/src/codegraph/query/impact.py
+++ b/src/codegraph/query/impact.py
@@ -28,7 +28,9 @@ simply have said. So the strongest few are printed, in a group labelled
 for what they are, on a budget of their own that cannot eat into the
 production callers'. `low_confidence_hidden` now counts only what is
 genuinely not on the page, and `--all` (`include_low`) still merges the
-whole set into the main groups. See #25.
+whole set into the main groups. See #25. A nonzero count carries
+`show_hidden: --all` beside it, because a count with no way to see what it
+counts is the same footgun one level down (#37).
 
 The LOW set itself is not read from `edges`. The bare-name fan-out is
 never materialized (see `ambiguity.py`); it is expanded here, at
@@ -231,6 +233,21 @@ def impact_report(
         # strongest of them, so 0 here now means "all of them are listed",
         # not "there were none" -- the group's presence says which.
         "low_confidence_hidden": low_confidence_hidden,
+        # ...and, when there IS something hidden, how to see it. A count of
+        # what is missing with no way to look at it is the footgun #37 names:
+        # answering "is anything still depending on this?" requires already
+        # knowing that `--all` exists, and the likeliest reader of a nonzero
+        # count here is the one who does not.
+        #
+        # Conditional, and spliced in right beside the count rather than
+        # appended: the summary line is dense enough that a permanent field
+        # for a number that is usually 0 would cost every other reader, and a
+        # hint that renders three fields away from the count it explains is
+        # not next to it in any sense the reader cares about. A separate
+        # string field rather than folding the flag into the value
+        # ("235 (--all)") because `low_confidence_hidden` is an int in
+        # `--json`, and machine-readable output is entitled to stay so.
+        **({"show_hidden": "--all"} if low_confidence_hidden else {}),
         "effects_reachable": effects_reachable,
     }
 

--- a/src/codegraph/query/islands.py
+++ b/src/codegraph/query/islands.py
@@ -185,6 +185,50 @@ def _is_dunder(leaf: str) -> bool:
     return len(leaf) > 4 and leaf.startswith("__") and leaf.endswith("__")
 
 
+#: Directory names that mean "everything below here is the test tree".
+#: `tests/` is the common one, `test/` the other spelling, and both are
+#: matched at ANY depth so a package-internal `src/pkg/tests/` subpackage
+#: counts too.
+_TEST_DIRS = ("tests", "test")
+
+
+def _is_test_module(stem: str) -> bool:
+    """pytest's default `python_files = test_*.py *_test.py`, on a file stem.
+
+    The one place that rule is spelled out. `_is_test_entry_point` and
+    `is_test_path` are both built on it so they cannot come to disagree
+    about what a test file is -- they differ only in how much MORE than the
+    stem each accepts, which is the part that is actually a judgement call.
+    """
+    return stem.startswith("test_") or stem.endswith("_test")
+
+
+def is_test_path(path: str) -> bool:
+    """Is this file part of the test tree?
+
+    Broader than `_is_test_entry_point` on purpose, and the two answer
+    different questions. That one asks "would pytest COLLECT this symbol",
+    which has to be strict because over-matching there explains away every
+    unreferenced helper in the test tree. This one asks "is this FILE test
+    code", where a fixture in `conftest.py` and a plain helper in
+    `tests/support.py` are as much test code as a collected `test_foo`, and
+    none of them is a production caller.
+
+    Four shapes, because four are in the wild: pytest's own file stems
+    (shared with `_is_test_entry_point` through `_is_test_module`),
+    `conftest.py`, and a `tests/` or `test/` directory at any depth --
+    which covers both a top-level test tree and a package-internal `tests`
+    subpackage. `query/orphans.py` reads this to decide whether a caller is
+    a test; it is deliberately NOT what splits `impact`'s report groups
+    (`impact._is_test`), which is presentation rather than a claim.
+    """
+    directories, _, filename = path.rpartition("/")
+    stem = filename.removesuffix(".py")
+    if stem == "conftest" or _is_test_module(stem):
+        return True
+    return any(part in _TEST_DIRS for part in directories.split("/"))
+
+
 def _is_test_entry_point(path: str, qualname: str) -> bool:
     """Would pytest collect this under its default configuration?
 
@@ -192,13 +236,12 @@ def _is_test_entry_point(path: str, qualname: str) -> bool:
     `python_functions = test*`, and collection only reaches module-level
     functions and the methods of a collected class -- so the qualname has
     to be one or two segments and a `<locals>` definition never qualifies.
-    Spelling the rule out rather than reusing `impact._is_test` is
-    deliberate: that one splits report groups and is happy to over-match on
-    any `tests/` path, whereas over-matching here would silently explain
-    away every unreferenced helper in the test tree.
+    Being stricter than `is_test_path` above is deliberate: over-matching
+    here would silently explain away every unreferenced helper in the test
+    tree.
     """
     stem = path.rpartition("/")[2].removesuffix(".py")
-    if not (stem.startswith("test_") or stem.endswith("_test")):
+    if not _is_test_module(stem):
         return False
     parts = qualname.split(".")
     if len(parts) == 1:
@@ -437,4 +480,4 @@ def islands_report(
     return Report(summary=summary, groups=groups, truncated=truncated)
 
 
-__all__ = ["islands_report"]
+__all__ = ["is_test_path", "islands_report"]

--- a/src/codegraph/query/orphans.py
+++ b/src/codegraph/query/orphans.py
@@ -1,0 +1,413 @@
+"""The `orphans` report: functions the graph can only see being called from
+the test tree.
+
+Every other symbol-taking query needs the answer as its input. `resolve`,
+`impact` and `effects` all start from a name, which means starting from a
+suspicion. `islands` is the only global command, and it structurally cannot
+find the bug class this one is for: a helper that is defined, tested, and
+never invoked by the code that is supposed to invoke it. **A tested helper
+is not a one-symbol island precisely because its test calls it** -- the
+thing that lets the bug survive review is the thing that hides it from the
+only view of the whole graph. (#37, found on a 948-file project where
+`_get_mlx_info` was docstring'd "Surface MLX info in the doctor report",
+covered by `test_doctor_has_mlx_info`, and never reached by `doctor`. The
+test imported it and called it directly, so it passed either way.)
+
+So this report asks the shape of that bug rather than its name: *which
+functions have callers, all of which are tests?* On the same project that
+question alone answers 280 functions -- a list nobody reads -- and three
+further filters cut it to 5, of which 2 were real defects. The filters are
+the report, not an option on it.
+
+## The filters, and why each one earns its place
+
+*Defined outside the test tree, under a source root.* A helper in
+`tests/support.py` called only from tests is a fixture doing its job. Test
+membership is `islands.is_test_path`, deliberately the same predicate that
+decides whether a CALLER is a test, so the two halves of "test-only" cannot
+disagree about what a test is.
+
+*Every recorded caller is a test, and there is at least one.* The "at least
+one" is what makes this report disjoint from `islands`: a function with no
+recorded caller at all is a singleton island, `islands` already reports it,
+and it is the case where a static call graph is weakest. A function whose
+callers are all tests is a much stronger position -- something DOES call
+it, codegraph found the call sites, and every one of them is a test.
+Callers include the bare-name fan-out (`ambiguity.py`), because a
+production reference the resolver could not pin down is still counter-
+evidence and must not be discarded for being LOW.
+
+*Private by name.* A public function called only by tests is very often the
+package's public surface, called by code that is not in this repository at
+all -- exactly the misreading of `islands`' `unexplained` bucket the README
+warns about. A leading underscore is the author saying "no external caller
+is supposed to exist", which is what makes the absence of an internal one
+interesting. Dunders are excluded outright: `__init__` and `__delitem__`
+are invoked by syntax, not by name, so nothing about their absence from the
+source text is informative. `--include-public` relaxes this.
+
+*Undecorated.* A decorator runs at definition time and can register, wrap
+or replace what it decorates -- `@app.route`, `@pytest.fixture`,
+`@singledispatch.register`. The call site is inside the framework and is
+not in this tree at all. `--include-decorated` relaxes this.
+
+*No bare-name reference anywhere in the source text.* This one is not
+optional and there is no flag to turn it off, because without it the report
+is actively harmful. A static call graph cannot see a function passed as a
+VALUE: on the project above the raw query surfaced
+`_run_bash_sandbox.<locals>.preexec` (handed to `subprocess`'s
+`preexec_fn`) and `_handle_sigint` (registered through `signal.signal`).
+Neither is dead, and a report that re-imports that hazard for every user
+who runs it is worse than no report at all.
+
+`blob_refs` cannot answer this: it records `call`, `base` and `global`
+references, and a name used as a value is none of the three. `imports`
+cannot either -- it would catch `from m import _helper` and miss both
+examples above, which name the function from inside the file that defines
+it. What IS available is the source text: the revision's tree is in `tree`,
+and the same `TreeSource` the indexer reads blobs through will hand them
+back. So the last filter is a deliberate, admitted grep -- `\\w+` tokens of
+every non-test source file, intersected with the candidate names. It
+over-matches by construction (a mention in a comment, a docstring or a
+string literal counts as a reference) and over-matching is the safe
+direction here: it can only remove a candidate, never invent one.
+
+## What a row does NOT claim
+
+Not that the function is dead, unused, or safe to delete. The graph's
+knowledge is the subject of every sentence this report prints: *no caller
+outside the test tree was recorded, and the name does not appear in the
+source text.* Three of the five survivors on that project were deliberate
+-- two documented back-compat shims and one import probe whose docstring
+says test-only is the point. And a name assembled at runtime (`getattr`, a
+registry keyed by string fragments, a plugin table, a `pyproject.toml`
+entry point, a template) leaves nothing for either half of this report to
+find. That caveat is therefore in the summary, on the page, above the rows,
+rather than in prose the reader has to have already gone looking for.
+
+What a row does claim is that a human should read the function, and that on
+the repository this was built for, 2 of 5 such reads found a real defect in
+a codebase with 19,960 tests.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from typing import Protocol
+
+from codegraph.ambiguity import Ambiguity
+from codegraph.config import Config
+from codegraph.query.islands import is_test_path
+from codegraph.render import Group, Report, Row, budget
+from codegraph.store import Store
+
+#: How many of a candidate's test callers a row names before falling back to
+#: a count. The reviewer's first move is to open the test and see what it
+#: thinks the function is for, so the row hands over somewhere to start.
+_CALLERS_PER_ROW = 2
+
+#: Identifier-ish runs of the source text. Deliberately `\w+` rather than a
+#: real tokenizer: this is a grep, it is documented as a grep, and the only
+#: direction it can be wrong in is dropping a candidate. `\w` is
+#: Unicode-aware for `str` patterns, so a non-ASCII identifier tokenizes the
+#: way the parser reads it.
+_WORD = re.compile(r"\w+")
+
+#: What the summary says the report was computed from, in the same slot
+#: `islands` puts its `basis`. Both exist so a row reads as a statement
+#: about codegraph's knowledge and never as a verdict on the code.
+BASIS = "recorded callers plus a name scan of the source text"
+
+#: The blind spot, printed on every report, including an empty one. See the
+#: module docstring: this is the sentence that has to survive being the only
+#: line a hurried reader reads.
+CAVEAT = (
+    "a name resolved at runtime (getattr, a registry, an entry point) leaves"
+    " no call site and no mention to find, so this is a list to review, not"
+    " a list to delete"
+)
+
+
+class TreeSource(Protocol):
+    """The one method this report needs of `indexer.TreeSource`.
+
+    Narrowed to `read` on purpose: the revision's tree comes from the `tree`
+    table, which `reconcile` has just written and which is exactly what the
+    rest of the graph was built from, so re-asking the source for a tree
+    would risk scanning a different one than the edges describe.
+    """
+
+    def read(self, shas: Iterable[str]) -> Iterable[tuple[str, bytes]]: ...
+
+
+def _plural(count: int, noun: str) -> str:
+    return f"{count} {noun}" if count == 1 else f"{count} {noun}s"
+
+
+def _is_dunder(leaf: str) -> bool:
+    """`__init__` yes, `_private` no. Invoked by syntax rather than by name,
+    so its absence from the source text says nothing at all."""
+    return len(leaf) > 4 and leaf.startswith("__") and leaf.endswith("__")
+
+
+def _under_source_root(path: str, source_roots: tuple[str, ...]) -> bool:
+    """Is this file under one of the configured source roots?
+
+    With the default roots (`""` and `"src"`) the `""` entry matches
+    everything, so on a default configuration the discriminating half of
+    "defined in source" is the test-path exclusion the caller applies next.
+    A project that narrows `source_roots` to `["src"]` gets a stricter
+    report for free -- scripts, examples and benchmarks stop being
+    candidates -- which is why this reads the config instead of hardcoding a
+    prefix.
+    """
+    return any(not root or path.startswith(f"{root}/") for root in source_roots)
+
+
+def _recorded_callers(store: Store, rev: str) -> dict[str, set[str]]:
+    """dst -> every distinct node id with a recorded CALLS edge into it,
+    self-calls excluded.
+
+    One pass over the revision's edges, never a query per node, for the
+    reason `islands` gives: on a 2,930-file repository this is ~395k rows and
+    a lookup inside the loop would be the whole cost of the command.
+
+    A recursive call is not a caller for this report's purpose. `_helper`
+    calling itself would otherwise be a non-test caller of itself, hiding
+    every recursive helper from the report while saying nothing whatever
+    about who enters the recursion.
+    """
+    callers: dict[str, set[str]] = {}
+    for row in store.connection.execute(
+        "SELECT DISTINCT src, dst FROM edges WHERE rev=? AND kind='CALLS'", (rev,)
+    ):
+        if row["src"] != row["dst"]:
+            callers.setdefault(row["dst"], set()).add(row["src"])
+    return callers
+
+
+def _source_tree(store: Store, rev: str, source_roots: tuple[str, ...]) -> dict[str, str]:
+    """path -> blob sha for the revision's non-test source files.
+
+    Read from `tree` rather than from the `TreeSource`: this has to be the
+    same tree the edges were resolved against, and it is also the half of
+    the tree the scan needs -- excluding the test tree here is what makes a
+    mention *from a test* not count as a reference.
+    """
+    return {
+        row["path"]: row["blob_sha"]
+        for row in store.connection.execute("SELECT path, blob_sha FROM tree WHERE rev=?", (rev,))
+        if not is_test_path(row["path"]) and _under_source_root(row["path"], source_roots)
+    }
+
+
+def _referenced_names(
+    source: TreeSource,
+    tree: dict[str, str],
+    ranges: dict[str, list[tuple[str, int, int]]],
+) -> set[str]:
+    """Which of `ranges`' names appear as a word somewhere in `tree`'s source
+    text, other than inside their own definitions.
+
+    `ranges[name]` is every candidate definition of that name, as
+    `(path, line_start, line_end)`. Those spans are what is discounted: a
+    name's own `def` line, its docstring and any self-call in its own body
+    are not references to it. Everything else in a non-test source file is
+    -- including a mention in a comment or a string, which is the
+    over-matching the module docstring promises.
+
+    Two passes, because line numbers are only ever needed for a handful of
+    files. The first tokenizes each file once into a set and intersects with
+    the names: a hit in a file that does not define the name settles it
+    immediately. Only a name whose sole hits are in files that DO define it
+    reaches the second pass, which re-reads those files line by line. On a
+    large tree the first pass is the whole cost, and it is one
+    `set(findall)` per file.
+    """
+    names = set(ranges)
+    if not names:
+        return set()
+
+    paths_by_sha: dict[str, list[str]] = {}
+    for path, sha in tree.items():
+        paths_by_sha.setdefault(sha, []).append(path)
+    defining = {path for spans in ranges.values() for path, _, _ in spans}
+
+    referenced: set[str] = set()
+    # path -> the names hit in a file that defines them, for the line pass.
+    undecided: dict[str, set[str]] = {}
+    texts: dict[str, str] = {}
+    for sha, payload in source.read(sorted(paths_by_sha)):
+        # A blob is source, so a decode error is a broken file rather than
+        # binary data; `replace` keeps the scan going on the rest of the
+        # tree instead of failing the whole report over one file.
+        text = payload.decode("utf-8", errors="replace")
+        hits = set(_WORD.findall(text)) & names
+        if not hits:
+            continue
+        for path in paths_by_sha[sha]:
+            if path in defining:
+                texts[path] = text
+            for name in hits:
+                if any(spanned == path for spanned, _, _ in ranges[name]):
+                    undecided.setdefault(path, set()).add(name)
+                else:
+                    referenced.add(name)
+
+    for path, hit_names in undecided.items():
+        pending = hit_names - referenced
+        text = texts.get(path)
+        if text is None:
+            # The source refused to hand this blob back, so the first pass'
+            # hit cannot be attributed to a line. Treat it as a reference:
+            # the safe direction is dropping the candidate.
+            referenced |= pending
+            continue
+        spans = {
+            name: [(start, end) for spanned, start, end in ranges[name] if spanned == path]
+            for name in pending
+        }
+        for number, line in enumerate(text.splitlines(), 1):
+            pending -= referenced
+            if not pending:
+                break
+            words: set[str] | None = None
+            for name in pending:
+                if any(start <= number <= end for start, end in spans[name]):
+                    continue
+                if words is None:
+                    words = set(_WORD.findall(line))
+                if name in words:
+                    referenced.add(name)
+    return referenced
+
+
+def orphans_report(
+    store: Store,
+    rev: str,
+    source: TreeSource,
+    config: Config | None = None,
+    limit: int = 20,
+    include_public: bool = False,
+    include_decorated: bool = False,
+) -> Report:
+    """Functions defined outside the test tree whose every recorded caller is
+    a test, cut down to a list a human can actually review.
+
+    `source` has no default. The last filter needs the source text, and a
+    report that quietly skipped it because nobody passed a source would be
+    the one shape of this command that must not exist -- see the module
+    docstring.
+    """
+    connection = store.connection
+    source_roots = (config or Config()).source_roots
+
+    callers = _recorded_callers(store, rev)
+    ambiguity = Ambiguity(store, rev)
+
+    # Every node's path, for classifying callers. Includes the synthetic
+    # `path::<module>` nodes: a module-scope call is a real reference, and
+    # its test-ness is its file's.
+    paths: dict[str, str] = {}
+    definitions: list[tuple[str, str, str, int, int, bool]] = []
+    for row in connection.execute(
+        "SELECT id, path, qualname, kind, line_start, line_end, decorators FROM nodes WHERE rev=?",
+        (rev,),
+    ):
+        paths[row["id"]] = row["path"]
+        if row["kind"] not in ("function", "method"):
+            continue
+        if is_test_path(row["path"]) or not _under_source_root(row["path"], source_roots):
+            continue
+        leaf = row["qualname"].rpartition(".")[2]
+        definitions.append(
+            (
+                row["id"],
+                row["path"],
+                leaf,
+                row["line_start"],
+                row["line_end"],
+                bool(row["decorators"]),
+            )
+        )
+
+    # The report's own question, asked of every function before the name
+    # filters narrow anything, so `test_callers_only` in the summary is the
+    # size of the list a user would otherwise have been handed.
+    test_callers_only = 0
+    candidates: list[tuple[str, str, str, int, int, list[str]]] = []
+    for node_id, path, leaf, line_start, line_end, decorated in definitions:
+        found = set(callers.get(node_id, ()))
+        found.update(src for src in ambiguity.callers(node_id) if src != node_id)
+        if not found:
+            # No recorded caller at all: a singleton island, which `islands`
+            # already reports and which is the case a call graph is weakest
+            # on. This report is deliberately disjoint from it.
+            continue
+        if not all(is_test_path(paths.get(src, src.partition("::")[0])) for src in found):
+            continue
+        test_callers_only += 1
+        if _is_dunder(leaf) or (not include_public and not leaf.startswith("_")):
+            continue
+        if decorated and not include_decorated:
+            continue
+        candidates.append((node_id, path, leaf, line_start, line_end, sorted(found)))
+
+    ranges: dict[str, list[tuple[str, int, int]]] = {}
+    for _, path, leaf, line_start, line_end, _ in candidates:
+        ranges.setdefault(leaf, []).append((path, line_start, line_end))
+    referenced = _referenced_names(source, _source_tree(store, rev, source_roots), ranges)
+
+    rows: list[Row] = []
+    for node_id, path, leaf, line_start, _, test_callers in candidates:
+        if leaf in referenced:
+            continue
+        named = test_callers[:_CALLERS_PER_ROW]
+        detail = (
+            f"{_plural(len(test_callers), 'test caller')}, none recorded outside the"
+            f" test tree; name not mentioned in the source text; called from"
+            f" {', '.join(named)}"
+        )
+        if len(test_callers) > len(named):
+            detail += f" (+{len(test_callers) - len(named)} more)"
+        rows.append(
+            Row(
+                id=node_id,
+                location=f"{path}:{line_start}",
+                detail=detail,
+                score=float(len(test_callers)),
+            )
+        )
+
+    # `budget` sorts by score (the number of tests exercising the function)
+    # and is stable, so sorting by id first is what makes ties deterministic
+    # -- and on a real repository most candidates have exactly one test, so
+    # most of the report is a tie. Two runs of one command must print the
+    # same rows in the same order.
+    rows.sort(key=lambda row: row.id)
+    kept, truncated = budget(rows, limit)
+
+    summary = {
+        "functions": len(definitions),
+        # The bare query, before any of the name filters: the 280 on Soup.
+        "test_callers_only": test_callers_only,
+        # After the private/undecorated filters (whatever the flags left of
+        # them): the 10.
+        "candidates": len(candidates),
+        # What the source-text scan removed, reported rather than hidden --
+        # it is the filter that keeps a callback out of the report, and a
+        # reader should be able to see it working.
+        "name_referenced": len(candidates) - len(rows),
+        "reported": len(rows),
+        "basis": BASIS,
+        "caveat": CAVEAT,
+    }
+    return Report(
+        summary=summary,
+        groups=[Group("orphans", kept)] if kept else [],
+        truncated=truncated,
+    )
+
+
+__all__ = ["BASIS", "CAVEAT", "orphans_report"]

--- a/tests/test_impact.py
+++ b/tests/test_impact.py
@@ -3,6 +3,7 @@ import pytest
 from codegraph.indexer import GitTreeSource, Indexer
 from codegraph.query.impact import impact_report
 from codegraph.query.rank import salience, score
+from codegraph.render import render_text
 from codegraph.store import Store
 
 
@@ -109,6 +110,35 @@ def test_more_low_confidence_callers_than_the_sample_are_counted_as_hidden(repo,
     shown = group(report, "low_confidence")
     assert len(shown) == 5
     assert report.summary["low_confidence_hidden"] == 12 - 5
+    store.close()
+
+
+def test_a_hidden_count_says_how_to_see_what_it_is_hiding(repo, write):
+    """The second footgun #37 found: for a "is anything still depending on
+    this?" question the reader must remember `--all`, or the LOW dependents
+    sit in a group of their own and a hasty reader concludes there are none.
+
+    `low_confidence_hidden: 7` was the right instinct and half an answer --
+    it says something is missing and not how to look at it. The flag now
+    rides along with the count, and only with a NONZERO count: the summary
+    line is dense already, and a permanent extra field for a number that is
+    usually 0 would cost every other reader something.
+    """
+    for i in range(12):
+        write(f"c{i}.py", f"def go{i}(thing):\n    thing.shared()\n", commit=f"c{i}")
+    write("one.py", "class One:\n    def shared(self):\n        pass\n", commit="1")
+    write("two.py", "class Two:\n    def shared(self):\n        pass\n", commit="2")
+    store = build(repo)
+    report = impact_report(store, "HEAD", "one.py::One.shared")
+    assert report.summary["low_confidence_hidden"] == 7
+    assert report.summary["show_hidden"] == "--all"
+    assert "low_confidence_hidden: 7 \u00b7 show_hidden: --all" in render_text(report)
+
+    # Nothing hidden, nothing to say. The count stays, so 0 keeps meaning
+    # "all of them are listed"; the hint does not linger next to it.
+    everything = impact_report(store, "HEAD", "one.py::One.shared", include_low=True)
+    assert everything.summary["low_confidence_hidden"] == 0
+    assert "show_hidden" not in everything.summary
     store.close()
 
 

--- a/tests/test_orphans.py
+++ b/tests/test_orphans.py
@@ -1,0 +1,362 @@
+"""`orphans`: functions whose every recorded caller is a test.
+
+The bug class (#37) is a helper that is defined, tested, and never invoked
+by the code that was supposed to invoke it -- and the reason it needs its
+own command is that it is invisible to every other one. `impact` needs the
+symbol's name, which is the thing the reader does not have yet, and
+`islands` cannot see it at all: the test's call is a real edge, so the
+function is not a one-symbol island.
+
+Each test below pins one filter, because the filters are what make the
+output reviewable rather than a second 5,000-row list. The ones that pin an
+exclusion assert on the summary counter for the filter under test as well
+as on the rows, so a test that "passes because something else also excluded
+it" fails instead.
+"""
+
+import json
+
+from codegraph.cli import main
+from codegraph.indexer import GitTreeSource, Indexer
+from codegraph.query.islands import is_test_path
+from codegraph.query.orphans import orphans_report
+from codegraph.render import render_text
+from codegraph.store import Store
+
+
+def build(repo):
+    """Reconcile HEAD and hand back the store plus the tree source.
+
+    The source is not optional: the last filter reads the revision's source
+    text, and every caller of `orphans_report` has to supply a way to.
+    """
+    store = Store.open(repo)
+    source = GitTreeSource(repo)
+    Indexer(repo, store, source).reconcile("HEAD")
+    return store, source
+
+
+def report(repo, **kwargs):
+    store, source = build(repo)
+    try:
+        return orphans_report(store, "HEAD", source, **kwargs)
+    finally:
+        store.close()
+
+
+def ids(result):
+    return {row.id for group in result.groups for row in group.rows}
+
+
+def detail_for(result, node_id):
+    for group in result.groups:
+        for row in group.rows:
+            if row.id == node_id:
+                return row.detail
+    raise AssertionError(f"{node_id} not in report: {sorted(ids(result))}")
+
+
+CALLED_BY_A_TEST = "from a import _looks_like_jsonl\n\n\ndef test_it():\n    assert _looks_like_jsonl('{}')\n"
+
+
+def test_a_function_only_its_test_calls_is_the_whole_point(repo, write):
+    """The finding the command exists for, in its smallest form.
+
+    `_looks_like_jsonl` on the project in #37 was born dead in the same
+    commit that added a comment claiming it was invoked; its test called it
+    directly, so the test passed and the call graph recorded a real caller.
+    That caller being a test is the entire signal.
+    """
+    write("a.py", "def _looks_like_jsonl(line):\n    return line.startswith('{')\n")
+    write("tests/test_a.py", CALLED_BY_A_TEST, commit="tested helper")
+    result = report(repo)
+    assert ids(result) == {"a.py::_looks_like_jsonl"}
+    assert result.summary["test_callers_only"] == 1
+    assert result.summary["candidates"] == 1
+    assert result.summary["reported"] == 1
+    assert "1 test caller" in detail_for(result, "a.py::_looks_like_jsonl")
+    assert "tests/test_a.py::test_it" in detail_for(result, "a.py::_looks_like_jsonl")
+
+
+def test_a_function_production_also_calls_is_not_reported(repo, write):
+    """The other half of the question, and the half that keeps the report
+    from being `islands` with extra steps: a helper the application itself
+    calls is doing its job, however many tests also call it.
+
+    Asserted on `test_callers_only` rather than only on the rows, because
+    the row would also have been removed by the name scan (a call site IS a
+    textual mention). Pinning the counter is what makes this a test of the
+    caller filter specifically.
+    """
+    write(
+        "a.py",
+        "def _helper():\n    return 1\n\n\ndef run():\n    return _helper()\n",
+    )
+    write(
+        "tests/test_a.py",
+        "from a import _helper\n\n\ndef test_it():\n    assert _helper() == 1\n",
+        commit="both",
+    )
+    result = report(repo)
+    assert result.summary["test_callers_only"] == 0
+    assert ids(result) == set()
+
+
+def test_a_function_nothing_calls_at_all_is_left_to_islands(repo, write):
+    """Deliberately disjoint from `islands`, which already reports this as a
+    one-symbol island -- and the case a static call graph is weakest on, since
+    "no caller anywhere" is exactly what framework dispatch looks like.
+
+    A recorded test caller is the stronger position and the one this command
+    is willing to stand behind: something DOES call it, codegraph found the
+    call site, and it is a test.
+    """
+    write("a.py", "def _never_called():\n    return 1\n", commit="orphan")
+    result = report(repo)
+    assert result.summary["functions"] == 1
+    assert result.summary["test_callers_only"] == 0
+    assert ids(result) == set()
+
+
+def test_a_name_the_source_passes_as_a_value_is_not_reported(repo, write):
+    """The filter that is not optional, and has no flag (#37).
+
+    A static call graph cannot see a function handed over as a value:
+    `signal.signal(SIGINT, _handle_sigint)` records a call to
+    `signal.signal` and nothing at all about `_handle_sigint`, whose only
+    recorded caller is therefore its test. Shipping this query without the
+    source-text scan would put a live signal handler at the top of a list
+    users read as "delete these".
+    """
+    write(
+        "a.py",
+        "import signal\n\n\ndef _handle_sigint(signum, frame):\n    return signum\n\n\n"
+        "def install():\n    signal.signal(signal.SIGINT, _handle_sigint)\n",
+    )
+    write(
+        "tests/test_a.py",
+        "from a import _handle_sigint\n\n\ndef test_it():\n"
+        "    assert _handle_sigint(2, None) == 2\n",
+        commit="callback",
+    )
+    result = report(repo)
+    assert result.summary["test_callers_only"] == 1
+    assert result.summary["candidates"] == 1
+    assert result.summary["name_referenced"] == 1
+    assert result.summary["reported"] == 0
+    assert ids(result) == set()
+
+
+def test_a_functions_own_body_and_docstring_do_not_count_as_a_reference(repo, write):
+    """The other side of that scan: the name is guaranteed to appear in the
+    file that defines it -- on the `def` line, in its docstring, and in its
+    own recursive call -- and none of that is evidence anything reaches it.
+
+    So the scan discounts the definition's own line span, and a self-call is
+    not a caller. Without both, the filter would reject every candidate and
+    the command would always report nothing, which is the failure mode that
+    looks exactly like a clean repository.
+    """
+    write(
+        "a.py",
+        "def _countdown(n):\n"
+        '    """_countdown calls _countdown."""\n'
+        "    if n <= 0:\n        return 0\n    return _countdown(n - 1)\n",
+    )
+    write(
+        "tests/test_a.py",
+        "from a import _countdown\n\n\ndef test_it():\n    assert _countdown(3) == 0\n",
+        commit="recursive",
+    )
+    result = report(repo)
+    assert ids(result) == {"a.py::_countdown"}
+
+
+def test_a_decorated_function_is_not_reported_unless_asked_for(repo, write):
+    """A decorator runs at definition time and can register, wrap or replace
+    what it decorates, so the call site can be inside a framework that is not
+    in this tree -- the same counter-evidence `islands` labels an island
+    with. `--include-decorated` is there for a reader who knows the
+    decorator in their own repository is inert.
+    """
+    write(
+        "a.py",
+        "def register(fn):\n    return fn\n\n\n@register\ndef _handler():\n    return 1\n",
+    )
+    write(
+        "tests/test_a.py",
+        "from a import _handler\n\n\ndef test_it():\n    assert _handler() == 1\n",
+        commit="decorated",
+    )
+    result = report(repo)
+    assert result.summary["test_callers_only"] == 1
+    assert result.summary["candidates"] == 0
+    assert ids(result) == set()
+
+    relaxed = report(repo, include_decorated=True)
+    assert ids(relaxed) == {"a.py::_handler"}
+
+
+def test_a_dunder_is_never_reported(repo, write):
+    """`Thing(1)` in a test is a recorded call to `Thing.__init__` and often
+    the only one in the tree, so a dunder would otherwise head the report.
+
+    It is invoked by syntax rather than by name, which also makes the
+    source-text scan meaningless for it: nothing anywhere spells
+    `__init__`. Excluded outright rather than by flag.
+    """
+    write("a.py", "class Thing:\n    def __init__(self, value):\n        self.value = value\n")
+    write(
+        "tests/test_a.py",
+        "from a import Thing\n\n\ndef test_it():\n    assert Thing(1).value == 1\n",
+        commit="dunder",
+    )
+    result = report(repo)
+    assert result.summary["test_callers_only"] == 1
+    assert "a.py::Thing.__init__" not in ids(result)
+    assert ids(result) == set()
+
+
+def test_a_public_function_is_not_reported_unless_asked_for(repo, write):
+    """Pinned to EXCLUDED by default, because the likeliest explanation for
+    a public function whose only caller is a test is a caller that is not in
+    this repository at all -- a library's own surface. That is the exact
+    misreading of `islands`' unexplained bucket the README warns about, and
+    a report that led with it would earn the same disclaimer.
+
+    A leading underscore is the author stating that no external caller is
+    supposed to exist, which is what makes the absence of an internal one
+    worth a reader's time. `--include-public` is the way to ask anyway.
+    """
+    write("a.py", "def looks_like_jsonl(line):\n    return line.startswith('{')\n")
+    write(
+        "tests/test_a.py",
+        "from a import looks_like_jsonl\n\n\ndef test_it():\n"
+        "    assert looks_like_jsonl('{}')\n",
+        commit="public",
+    )
+    result = report(repo)
+    assert result.summary["test_callers_only"] == 1
+    assert result.summary["candidates"] == 0
+    assert ids(result) == set()
+
+    relaxed = report(repo, include_public=True)
+    assert ids(relaxed) == {"a.py::looks_like_jsonl"}
+
+
+def test_a_helper_in_the_test_tree_is_a_test_caller_not_a_candidate(repo, write):
+    """"Is this a test?" is a file-level question here, not a
+    pytest-collection one: a fixture in `conftest.py` and a plain helper in
+    `tests/support.py` are as much test code as a collected `test_foo`, and
+    neither is a production caller.
+
+    Both directions are pinned. `tests/support.py::call_it` counts as a
+    test caller of `_helper` (so `_helper` is reported), and `call_it`
+    itself is not a candidate however few things call it -- a helper in the
+    test tree called only from the test tree is a fixture doing its job.
+    """
+    write("a.py", "def _helper():\n    return 1\n")
+    write("tests/support.py", "from a import _helper\n\n\ndef call_it():\n    return _helper()\n")
+    write(
+        "tests/test_a.py",
+        "from tests.support import call_it\n\n\ndef test_it():\n    assert call_it() == 1\n",
+        commit="support",
+    )
+    result = report(repo)
+    assert ids(result) == {"a.py::_helper"}
+    assert result.summary["functions"] == 1  # nothing under tests/ was even considered
+
+
+def test_every_test_tree_spelling_counts(repo, write):
+    """Soup uses `tests/`; the projects this will next be pointed at use
+    `test/`, `*_test.py`, `conftest.py`, or a package-internal `tests`
+    subpackage. All four are one predicate, `islands.is_test_path`, shared
+    with the mechanism `islands` labels an island `test` with -- so the two
+    commands cannot come to disagree about what a test is.
+    """
+    assert is_test_path("tests/test_a.py")
+    assert is_test_path("test/helpers.py")
+    assert is_test_path("a/b_test.py")
+    assert is_test_path("conftest.py")
+    assert is_test_path("src/pkg/tests/support.py")
+    assert not is_test_path("src/pkg/latest/thing.py")
+    assert not is_test_path("src/pkg/contest.py")
+
+    write("a.py", "def _one():\n    return 1\n\n\ndef _two():\n    return 2\n")
+    write("pkg_test.py", "from a import _one\n\n\ndef test_one():\n    assert _one() == 1\n")
+    write(
+        "conftest.py",
+        "import pytest\nfrom a import _two\n\n\n@pytest.fixture\ndef two():\n    return _two()\n",
+        commit="spellings",
+    )
+    result = report(repo)
+    assert ids(result) == {"a.py::_one", "a.py::_two"}
+
+
+def test_no_row_says_dead_unused_or_unreachable(repo, write):
+    """The discipline `islands` established and this command inherits. Three
+    of the five survivors on the project in #37 were deliberate -- two
+    documented back-compat shims and one import probe whose docstring says
+    test-only is the point -- and a user who deletes one on this tool's say-so
+    must not be able to point at its wording.
+
+    The strongest available claim is about codegraph's knowledge: no caller
+    outside the test tree was recorded, and the name is not in the source
+    text. The blind spot rides in the summary, where the rows are, rather
+    than in prose in a README the reader may never have opened.
+    """
+    write("a.py", "def _looks_like_jsonl(line):\n    return line.startswith('{')\n")
+    write("tests/test_a.py", CALLED_BY_A_TEST, commit="wording")
+    result = report(repo)
+    text = render_text(result).lower()
+    for word in ("dead", "unused", "unreachable", "orphaned", "safe to delete"):
+        assert word not in text
+    assert "getattr" in text  # the callback caveat, on the page with the rows
+    assert "list to review, not a list to delete" in text
+    assert result.summary["basis"] == "recorded callers plus a name scan of the source text"
+
+
+def test_the_caveat_is_printed_even_when_nothing_matched(repo, write):
+    """An empty report is the one most likely to be read as "there is nothing
+    here", so it carries the same caveat as a full one. `basis` and `caveat`
+    are summary fields, not row decoration, for exactly that reason."""
+    write("b.py", "def beta():\n    return 2\n", commit="empty")
+    result = report(repo)
+    assert result.groups == []
+    assert result.summary["reported"] == 0
+    assert "getattr" in render_text(result)
+
+
+def test_limit_budgets_the_rows_and_flags_truncation(repo, write):
+    """Same `budget` contract as every other report: `--limit` bounds the
+    page and `truncated` says the page is not the whole answer."""
+    source = "".join(f"def _helper{n}():\n    return {n}\n\n\n" for n in range(4))
+    calls = "".join(f"    assert _helper{n}() == {n}\n" for n in range(4))
+    imports = ", ".join(f"_helper{n}" for n in range(4))
+    write("a.py", source)
+    write("tests/test_a.py", f"from a import {imports}\n\n\ndef test_all():\n{calls}", commit="many")
+    result = report(repo, limit=2)
+    assert result.summary["reported"] == 4
+    assert len(ids(result)) == 2
+    assert result.truncated
+
+
+def test_orphans_command_reports_and_exits_zero(repo, write, capsys):
+    """Global like `islands`, so it shares `islands`' exit convention rather
+    than the 0/1/2 one the symbol-taking commands use for resolving a name:
+    a report is exit 0, and only an unresolvable `--rev` is 1."""
+    write("a.py", "def _looks_like_jsonl(line):\n    return line.startswith('{')\n")
+    write("tests/test_a.py", CALLED_BY_A_TEST, commit="cli")
+    assert main(["orphans", "--path", str(repo), "--rev", "HEAD"]) == 0
+    out = capsys.readouterr().out
+    assert "a.py::_looks_like_jsonl" in out
+    assert "reported: 1" in out
+
+    assert main(["orphans", "--path", str(repo), "--rev", "HEAD", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"]["reported"] == 1
+    assert payload["groups"][0]["title"] == "orphans"
+    assert payload["summary"]["caveat"]
+
+    assert main(["orphans", "--path", str(repo), "--rev", "nope"]) == 1
+    assert "revision not found" in capsys.readouterr().err

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -30,7 +30,13 @@ def test_skill_has_frontmatter_and_covers_triggers():
 
 def test_skill_documents_every_shipped_command():
     text = (ROOT / "skills" / "codegraph" / "SKILL.md").read_text()
-    for command in ["codegraph resolve", "codegraph impact", "codegraph effects", "codegraph diff"]:
+    for command in [
+        "codegraph resolve",
+        "codegraph impact",
+        "codegraph effects",
+        "codegraph orphans",
+        "codegraph diff",
+    ]:
         assert command in text
 
 


### PR DESCRIPTION
Closes #37.

## The gap

Every existing query needs the symbol's name as input, which means already suspecting the bug. `islands` is the only global command, and it structurally cannot find the class #37 is about: a helper that is defined, tested, and never wired up. **Such a function is not a one-symbol island precisely because its test calls it** — the thing that lets the bug survive review is the thing that hides it from the only global view.

## `codegraph orphans`

Asks the *shape* of the bug instead of its name: which functions have callers, all of which are tests? Then four more filters, because the bare question answers 345 functions on `MakazhanAlpamys/Soup` and a 345-row list is another dead end. Real output on that clone (which now carries the upstream `_get_mlx_info` fix, so it is correctly absent):

```
functions: 4709 · test_callers_only: 345 · candidates: 10 · name_referenced: 7 · reported: 3 ·
basis: recorded callers plus a name scan of the source text ·
caveat: a name resolved at runtime (getattr, a registry, an entry point) leaves no call site and
no mention to find, so this is a list to review, not a list to delete
orphans
  src/soup_cli/commands/push.py::_generate_model_card        push.py:327        4 test callers, ...
  src/soup_cli/commands/migrate.py::_looks_like_jsonl        migrate.py:144     3 test callers, ...
  src/soup_cli/utils/cmaes_merge.py::_default_cmaes_scorer   cmaes_merge.py:584 1 test caller, ...
```

Three rows: the defect #37 names (`_looks_like_jsonl`, born dead in the commit that added a comment claiming it was invoked) and two shims whose own docstrings say "legacy, kept for backward compat" and "remains for direct / back-compat callers". The funnel is in the summary so each filter's work is visible rather than trusted.

**The source-text filter is not optional and has no flag.** A static call graph cannot see a function passed as a value, and `blob_refs` records `call`/`base`/`global` references — a name used as a value is none of the three. `imports` would catch `from m import _helper` and miss both of #37's examples, which name the function from inside the file that defines it. What is available is the source text: the tree is in `tree` and the indexer's `TreeSource` hands back blobs. So the filter is a documented grep — `\w+` tokens per non-test source file, intersected with the candidate names, discounting each definition's own line span (its `def` line, its docstring, its own recursion). It over-matches by construction, which is the safe direction: it can only remove a candidate, never invent one. On Soup it removes 7 of 10, including exactly the hazards #37 predicted:

```
_handle_sigint   graceful_save.py:38   signal.signal(signal.SIGINT, self._handle_sigint)
_default_train_fn  local_rl.py:532     runner = train_fn if train_fn is not None else _default_train_fn
_hf_repo_metadata  hubs.py:322         fetch = metadata_fn or _hf_repo_metadata
```

**No row says dead, unused or unreachable**, and there is a test pinning it, as there is for `islands`. The claim is about codegraph's knowledge, and the callback blind spot is a `caveat` field printed with the rows — including on an empty report, which is the one most likely to be read as "there is nothing here".

`--include-public` and `--include-decorated` relax the other two filters. Public is off by default for the reason the README already gives about `islands`' unexplained bucket, and both other repos prove it: `psf/requests` and `pallets/flask` report **nothing** by default, and with `--include-public --include-decorated` they report their own public API (`extract_zipped_paths`, `Config.from_file`, `FlaskClient.session_transaction`) — called by users of the package, which is not in the tree.

`is_test_path` is one predicate, built on the same file-stem rule as `islands`' pytest-collection heuristic so the two cannot come to disagree: pytest's stems, `conftest.py`, and a `tests/`/`test/` directory at any depth (a package-internal subpackage included).

## The second footgun

`impact`'s `low_confidence_hidden` now carries `show_hidden: --all` beside it when nonzero. A count of what you cannot see is half an answer, and the reader likeliest to need it is the one who does not know the flag exists. Conditional and spliced next to the count, so the dense summary line pays nothing when nothing is hidden; the count stays an integer for `--json`.

## Weaknesses, stated plainly

- The name scan is leaf-name based, so two functions sharing a private name shield each other. On Soup this cost one candidate (`_selfcheck`, which also exists in `build_dag.py`) — a false negative, in the direction that loses findings rather than invents them.
- A mention in a comment counts (`_is_backward` was dropped by a comment about the old check). Deliberate, same direction.
- Nothing outside `.py` is scanned: a name referenced only from a template, a `pyproject.toml` entry point or a data file would be missed by the filter and could reach a row.
- Cost is one pass over the revision's non-test source text: 17s cold on 948 files, 1–3s on requests/flask, and `pytest -q` is unchanged (355 passed, 187s).

## Gates

`ruff check` clean; `pytest -q` 355 passed; `pytest -q -m slow` 3 passed. Every new test was verified non-vacuous by breaking the implementation and watching that named test fail (16 mutations: each filter, the own-span discount, the self-call exclusion, the test-path predicate, the caveat, the budget, the group title, the caller names in `detail`, and both halves of the `show_hidden` behaviour).
