### PR TITLE
fix: follow a package re-export, so flask.Flask resolves at HIGH

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,11 +222,21 @@ order and stops at the first that matches.
 | step | tier | example |
 |---|---|---|
 | the name is imported | HIGH | `from pay import charge` then `charge()` |
+| ...through a package re-export | HIGH | `pkg.Thing` where `pkg/__init__.py` says `from .app import Thing` |
 | the name is defined in this module | HIGH | a module-local `def charge` |
 | `super().X()` | HIGH | resolved through the enclosing class's bases, skipping the class itself |
 | `self.X()` | HIGH + MEDIUM | the inherited method at HIGH, every subclass override at MEDIUM |
 | `Cls()` | inherits the class edge's tier | plus an edge to the `__init__` it would run, found up the MRO |
 | a bare name matched against the whole repository | MEDIUM if unique, else LOW | `item.save()` where nothing says what `item` is |
+
+A re-export is followed because it is the *same* evidence as the row above it,
+read in another file: `from .app import Thing` is a recorded fact about the
+source text, not an inference over it, so a chain of them is a conjunction of
+facts and depth does not weaken the claim. Two things are deliberately not
+followed, because they would be inferences: `from .app import *` (which names
+it binds depends on `__all__`, which real packages compute at runtime), and a
+chain longer than `REEXPORT_HOPS`. Neither produces a weaker edge — both
+produce no edge, and the reference falls to the last step below.
 
 The last step is the one to be suspicious of. It is a guess by construction, and
 on a large repository one name can match hundreds of definitions, so those
@@ -391,8 +401,19 @@ is unit-tested there (`tests/test_bench_scorer.py`).
 | suite traced | `test_utils.py`, `test_structures.py` (240 tests) | `tests/` (494 tests) |
 | traced call edges (judgeable) | 115 | 2683 |
 | **recall** | **0.79** | **0.29** |
-| recall at HIGH/MEDIUM | 0.76 | 0.19 |
-| conditional precision | 0.99 (81/82) | 0.86 (206/239) |
+| recall at HIGH/MEDIUM | 0.76 | 0.25 |
+| conditional precision | 0.99 (82/83) | 0.93 (455/490) |
+
+Worth reading those two rows together, because #38 (following a package
+re-export, so `flask.Flask` resolves instead of degrading to an ambiguous bare
+name) moved them and left **recall flat**: 765 -> 776 judgeable edges found, so
+0.29 both before and after. It could not move much. Recall counts an edge the
+LOW bare-name fan-out would produce, and the fan-out already contained the
+right answer — buried among the wrong ones. What changed is which tier the
+answer is claimed at: recall at HIGH/MEDIUM 0.19 -> 0.25 (507 -> 673 edges) and
+conditional precision 0.86 -> 0.93. That is the whole point of the fix, and it
+is invisible in the headline number, which is a property of this benchmark
+worth knowing: **recall does not distinguish a fact from a lucky guess.**
 
 On `tests/test_utils.py` alone — the scope #35 recorded — requests is **0.93**
 recall, and all 6 misses are dunders invoked by syntax (`d[k]`, `for x in jar`,
@@ -404,13 +425,13 @@ trace, not a single number about codegraph.**
 flask is where a static resolver is supposed to do badly, and it does. Every
 miss is grouped by mechanism, and the grouping is the finding:
 
-| flask misses (1918 of 2683) | |
+| flask misses (1907 of 2683) | |
 |---|---|
-| target nested in another function (a view defined inside a test) | 564 |
+| target nested in another function (a view defined inside a test) | 561 |
 | reachable only through an out-of-repo frame | 552 |
 | target is decorated (`@app.route`, `@setupmethod`) | 523 |
 | target is a dunder, invoked by syntax or protocol | 223 |
-| target is a constructor — a real resolution gap | 21 |
+| target is a constructor — a real resolution gap | 13 |
 | target applied as a decorator by the source | 18 |
 | no implicit-invocation mechanism recognised | 15 |
 | call site attributed to another definition in the same file | 2 |
@@ -431,7 +452,7 @@ simply not cover it, and most of a library's surface is not exercised by its
 own tests. Unconditional precision is therefore not measurable this way, and
 the benchmark does not print a number for it. What is defensible: among static
 HIGH edges whose **two endpoints both executed at least once**, how many did
-the trace observe? 0.99 on requests, 0.86 on flask. That says the HIGH edges
+the trace observe? 0.99 on requests, 0.93 on flask. That says the HIGH edges
 that could have been checked were taken; it does not say the resolver invents no
 edges.
 

--- a/src/codegraph/resolve.py
+++ b/src/codegraph/resolve.py
@@ -79,6 +79,18 @@ def is_builtin_call(ref: ParsedRef) -> bool:
 #: `src` for a reference made at module scope, which owns no node of its own.
 MODULE_SCOPE = "<module>"
 
+#: How many re-export hops `AstResolver._lookup_dotted` will follow.
+#:
+#: A chain is real -- `a/__init__.py` re-exports from `a/b.py`, which
+#: re-exports from `a/c.py` -- but short: flask's whole public API is one hop,
+#: and the deepest chain actually walked across the benchmark targets is two.
+#: This bound is a cost and sanity guard with room to spare, NOT the
+#: termination guarantee: that is the `seen` set in `_lookup_dotted`, since a
+#: cycle necessarily reproduces a dotted name already tried. Every other walk
+#: in this module (`breadth_first`, and `_mro`/`_descendants` on top of it) is
+#: cycle-safe the same way.
+REEXPORT_HOPS = 8
+
 
 def module_for_path(path: str, source_roots: tuple[str, ...]) -> str:
     """'src/pay/service.py' -> 'pay.service'; 'pay/__init__.py' -> 'pay'."""
@@ -136,6 +148,10 @@ class ResolveContext:
     qualname_index: dict[tuple[str, str], str]  # (path, qualname) -> node id, live only
     name_index: dict[str, list[str]]  # bare name -> node ids, live only
     import_map: dict[str, str]  # local alias -> dotted target
+    #: EVERY path's alias map, not just this file's. Following a package
+    #: re-export means reading what ANOTHER file imports: `flask.Flask` is
+    #: answered by `src/flask/__init__.py`'s `from .app import Flask`.
+    import_maps: dict[str, dict[str, str]]
     bases: dict[str, list[str]]  # class node id -> base class node ids
     enclosing_class: dict[str, str] = field(default_factory=dict)  # node id -> class node id
     subclasses: dict[str, list[str]] = field(default_factory=dict)  # inverse of `bases`
@@ -201,8 +217,64 @@ class AstResolver:
         node_id = self._lookup_dotted(dotted, ctx)
         return [(node_id, HIGH)] if node_id else []
 
+    @classmethod
+    def _lookup_dotted(cls, dotted: str, ctx: ResolveContext) -> str | None:
+        """A dotted name -> the definition it names, following re-exports.
+
+        A module attribute can be a name the module merely *imported*, and for
+        a package `__init__.py` that is the normal case: `flask.Flask` is not
+        defined in `src/flask/__init__.py`, it is bound there by
+        `from .app import Flask`. Looking only for a definition (step one
+        below) answered 218 of flask's 1039 ambiguous references with nothing
+        -- the package's entire public API, the most-written form of every
+        import a library user makes. See #38.
+
+        So each round does two things, in this order:
+
+        1. is the remaining qualname DEFINED in the module the prefix names?
+        2. if not, is it IMPORTED there? Rewrite the dotted name through that
+           import and go round again.
+
+        Definition first is what keeps a re-export from shadowing a real local
+        definition: an `__init__.py` that both defines `Foo` and imports a
+        different `Foo` resolves to the one a reader looking it up in that file
+        would find, which is the same rule `constructor_target` follows for a
+        method. (Python itself would give the later binding, but `nodes` holds
+        definitions, not assignment order, and preferring the definition is the
+        conservative half of that disagreement -- it never invents a target in
+        another file.)
+
+        The claim stays HIGH, because it is the same evidence step one already
+        claims HIGH for: `from .app import Flask` is an exact recorded fact
+        about the source text, not an inference over it. Nothing is guessed --
+        no MRO approximation, no instance type, no repo-wide name search -- and
+        a chain of hops is a conjunction of such facts, so depth does not
+        weaken it: three exact facts are not less certain than one. What could
+        still be wrong is that the module rebinds the name at runtime, and that
+        is exactly as true of the single-hop imported-name step which has been
+        HIGH since the start; this adds no new kind of doubt, it reads the same
+        kind of statement in a different file. The hop bound therefore never
+        produces a weaker answer: exhausting it produces NO answer, and the
+        reference falls through to the weak bare-name path it takes today.
+        """
+        seen = {dotted}
+        for _ in range(REEXPORT_HOPS + 1):
+            node_id = cls._lookup_defined(dotted, ctx)
+            if node_id:
+                return node_id
+            followed = cls._follow_reexport(dotted, ctx)
+            # `followed in seen` is the cycle guard: a re-export cycle
+            # (`a/__init__.py` imports X from `a.b`, `a/b.py` imports X from
+            # `a`) necessarily reproduces a dotted name already tried, so this
+            # terminates it before the hop bound does.
+            if followed is None or followed in seen:
+                return None
+            seen.add(followed)
+            dotted = followed
+        return None
+
     @staticmethod
-    def _lookup_dotted(dotted: str, ctx: ResolveContext) -> str | None:
+    def _lookup_defined(dotted: str, ctx: ResolveContext) -> str | None:
         """Split `a.b.c` at every module/qualname boundary, longest module first."""
         parts = dotted.split(".")
         for split in range(len(parts) - 1, 0, -1):
@@ -212,6 +284,44 @@ class AstResolver:
             node_id = ctx.qualname_index.get((path, ".".join(parts[split:])))
             if node_id:
                 return node_id
+        return None
+
+    @staticmethod
+    def _follow_reexport(dotted: str, ctx: ResolveContext) -> str | None:
+        """`flask.Flask.run` -> `flask.app.Flask.run`, via one import statement.
+
+        Same longest-module-prefix split as `_lookup_defined`, but the first
+        segment after the prefix is looked up in that module's *import* map
+        instead of its definitions, and any further segments ride along
+        untouched (`Flask.run` is `run` on whatever `Flask` turns out to be).
+
+        `from .x import *` is deliberately NOT followed. `build_import_maps`
+        records it under the literal name `*`, which no attribute access can
+        ever spell, so a star import simply contributes nothing here. Expanding
+        it would mean deciding which of the starred module's names are public,
+        and that is governed by `__all__` -- which this codebase does not
+        record and which real packages build at runtime
+        (`__all__ = [...] + other.__all__`). Guessing "every name not starting
+        with an underscore" would claim HIGH for names that may not be exported
+        at all, so a name reachable only through a star import keeps falling
+        through to the weak path, exactly as it does today.
+
+        `__all__` is otherwise irrelevant to this lookup, which is worth saying
+        because it looks like it should matter: `__all__` gates `from pkg
+        import *` and nothing else. `flask.Flask` reads a module attribute, and
+        the attribute is there because the import bound it, whether or not
+        `__all__` mentions it.
+        """
+        parts = dotted.split(".")
+        for split in range(len(parts) - 1, 0, -1):
+            path = ctx.module_to_path.get(".".join(parts[:split]))
+            if path is None:
+                continue
+            name, *tail = parts[split:]
+            target = ctx.import_maps.get(path, {}).get(name)
+            if target is None:
+                continue
+            return ".".join([target, *tail])
         return None
 
     # -- step 2: a name defined in the same module ------------------------
@@ -457,6 +567,7 @@ class _SymbolTable:
             qualname_index=self.qualname_index,
             name_index=self.name_index,
             import_map=self.import_maps[path],
+            import_maps=self.import_maps,
             bases=bases,
             enclosing_class=self.enclosing_class,
             subclasses=subclasses if subclasses is not None else {},

--- a/tests/fixtures/labelled_calls.json
+++ b/tests/fixtures/labelled_calls.json
@@ -11,7 +11,11 @@
     "pkg/duck_unique.py": "class Renderer:\n    def render(self):\n        return \"rendered\"\n\n\ndef show(widget):\n    return widget.render()\n",
     "pkg/duck_ambiguous.py": "class Document:\n    def save(self):\n        return \"document saved\"\n\n\nclass Settings:\n    def save(self):\n        return \"settings saved\"\n\n\ndef persist(item):\n    return item.save()\n",
     "pkg/shapes.py": "class Shape:\n    def area(self):\n        return 0\n\n    def describe(self):\n        return f\"area={self.area()}\"\n\n\nclass Square(Shape):\n    def __init__(self, side):\n        self.side = side\n\n    def area(self):\n        return self.side * self.side\n",
-    "pkg/construct.py": "from pkg.shapes import Square\n\n\nclass Vessel:\n    def __init__(self, size):\n        self.size = size\n\n\nclass Barrel(Vessel):\n    def capacity(self):\n        return self.size\n\n\ndef build_square():\n    return Square(2)\n\n\ndef build_barrel():\n    return Barrel(3)\n"
+    "pkg/construct.py": "from pkg.shapes import Square\n\n\nclass Vessel:\n    def __init__(self, size):\n        self.size = size\n\n\nclass Barrel(Vessel):\n    def capacity(self):\n        return self.size\n\n\ndef build_square():\n    return Square(2)\n\n\ndef build_barrel():\n    return Barrel(3)\n",
+    "pkg/api/__init__.py": "from pkg.api.impl import Engine\n",
+    "pkg/api/impl.py": "class Engine:\n    def __init__(self):\n        self.started = False\n",
+    "pkg/reexport.py": "import pkg.api\n\n\ndef build_engine():\n    return pkg.api.Engine()\n",
+    "pkg/other_engine.py": "class Engine:\n    def __init__(self):\n        self.kind = \"unrelated\"\n"
   },
   "calls": [
     {
@@ -76,6 +80,13 @@
       "expected": [
         "pkg/construct.py::Barrel",
         "pkg/construct.py::Vessel.__init__"
+      ]
+    },
+    {
+      "src": "pkg/reexport.py::build_engine",
+      "expected": [
+        "pkg/api/impl.py::Engine",
+        "pkg/api/impl.py::Engine.__init__"
       ]
     }
   ]

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -959,3 +959,195 @@ def test_the_explicit_two_argument_super_is_not_claimed_as_certain(repo, write):
     found = {(dst, conf) for src, dst, conf in edges(store) if src == "child.py::Child.go"}
     assert ("base.py::Base.helper", "HIGH") not in found
     store.close()
+
+
+# -- #38: package re-exports ---------------------------------------------------
+
+
+def test_package_reexport_resolves_to_where_the_name_is_defined(repo, write):
+    """`pkg.Thing` where `pkg/__init__.py` says `from .app import Thing`.
+
+    This is the shape of almost every public API in Python, and it used to
+    resolve to nothing: `_lookup_dotted` found the module `pkg`, looked for a
+    qualname `Thing` defined in `__init__.py`, did not find one, and gave up.
+    The reference then fell to the repo-wide bare-name step -- LOW, and hidden
+    from `impact` by default -- so the part of a framework's graph codegraph
+    was least confident about was its entry points. See #38.
+
+    HIGH, because `from .app import Thing` is an exact recorded fact about the
+    source text: it is the same evidence the single-hop imported-name step has
+    always claimed HIGH for, read in another file.
+    """
+    write("pkg/__init__.py", "from .app import Thing\n")
+    write("pkg/app.py", "class Thing:\n    def run(self):\n        pass\n")
+    write("use.py", "import pkg\n\n\ndef go():\n    pkg.Thing()\n", commit="reexport")
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    assert ("use.py::go", "pkg/app.py::Thing", "HIGH") in edges(store)
+    store.close()
+
+
+def test_reexported_class_is_an_inherits_edge_at_high(repo, write):
+    """The reported case verbatim: `class CustomFlask(flask.Flask)`.
+
+    A base reference goes through the same resolver, so the fix has to show up
+    as a HIGH INHERITS edge -- which matters twice over, because only HIGH
+    INHERITS links feed the MRO walk that resolves `self.X` in every subclass.
+    """
+    write("flask/__init__.py", "from .app import Flask\n")
+    write("flask/app.py", "class Flask:\n    def run(self):\n        pass\n")
+    write("use.py", "import flask\n\n\nclass CustomFlask(flask.Flask):\n    pass\n", commit="base")
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    rows = {
+        tuple(row)
+        for row in store.connection.execute(
+            "SELECT src, dst, confidence FROM edges WHERE rev='HEAD' AND kind='INHERITS'"
+        )
+    }
+    assert ("use.py::CustomFlask", "flask/app.py::Flask", "HIGH") in rows
+    store.close()
+
+
+def test_reexport_under_an_alias_is_followed(repo, write):
+    """`from .app import Thing as Widget` binds `pkg.Widget`, and the import
+    map already records the alias, so the rewrite has to go through the alias's
+    target rather than through the name as written at the call site."""
+    write("pkg/__init__.py", "from .app import Thing as Widget\n")
+    write("pkg/app.py", "def thing():\n    pass\n\n\nclass Thing:\n    pass\n")
+    write("use.py", "import pkg\n\n\ndef go():\n    pkg.Widget()\n", commit="alias")
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    assert ("use.py::go", "pkg/app.py::Thing", "HIGH") in edges(store)
+    store.close()
+
+
+def test_a_two_hop_reexport_chain_is_followed(repo, write):
+    """`pkg/__init__.py` re-exports from `pkg/middle.py`, which re-exports from
+    `pkg/deep.py`. Each hop is an exact recorded import, so the conjunction is
+    one too and the tier does not decay with depth."""
+    write("pkg/__init__.py", "from .middle import Thing\n")
+    write("pkg/middle.py", "from .deep import Thing\n")
+    write("pkg/deep.py", "class Thing:\n    pass\n")
+    write("use.py", "import pkg\n\n\ndef go():\n    pkg.Thing()\n", commit="chain")
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    assert ("use.py::go", "pkg/deep.py::Thing", "HIGH") in edges(store)
+    store.close()
+
+
+def test_a_reexport_cycle_terminates(repo, write):
+    """`pkg/__init__.py` imports `Thing` from `pkg.other`, which imports
+    `Thing` back from `pkg`. Nothing defines it, so the honest answer is no
+    edge -- the point of the test is that the walk returns at all.
+
+    The `seen` set is what guarantees that: a cycle necessarily reproduces a
+    dotted name already tried. `REEXPORT_HOPS` is a second, looser guard.
+    """
+    write("pkg/__init__.py", "from .other import Thing\n")
+    write("pkg/other.py", "from pkg import Thing\n")
+    write("use.py", "import pkg\n\n\ndef go():\n    pkg.Thing()\n", commit="cycle")
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    assert not [edge for edge in edges(store) if edge[0] == "use.py::go"]
+    store.close()
+
+
+def test_a_local_definition_beats_a_reexport_of_the_same_name(repo, write):
+    """`pkg/__init__.py` both imports a `Thing` and defines its own.
+
+    The definition in the file is what a reader looking `pkg.Thing` up would
+    find, so it wins -- the same rule `constructor_target` applies to a method
+    declared on a class and on its base. A re-export must never shadow a real
+    local definition, or the fix would trade one wrong answer for another.
+    """
+    write("pkg/__init__.py", "from .app import Thing\n\n\nclass Thing:\n    pass\n")
+    write("pkg/app.py", "class Thing:\n    pass\n")
+    write("use.py", "import pkg\n\n\ndef go():\n    pkg.Thing()\n", commit="shadow")
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    targets = {dst for src, dst, _ in edges(store) if src == "use.py::go"}
+    assert "pkg/__init__.py::Thing" in targets
+    assert "pkg/app.py::Thing" not in targets
+    store.close()
+
+
+def test_a_name_the_package_does_not_reexport_is_not_invented(repo, write):
+    """`pkg.Thing` where `pkg/__init__.py` neither defines nor imports `Thing`.
+
+    Following an import is only sound because the import is written down. When
+    it is not, there is nothing to follow, and the reference must keep falling
+    through to the weak bare-name path exactly as it does today -- one
+    plausible definition elsewhere in the repo is a MEDIUM guess, not a HIGH
+    fact, and the fix must not launder it into one.
+    """
+    write("pkg/__init__.py", "from .app import Other\n")
+    write("pkg/app.py", "class Other:\n    pass\n")
+    write("elsewhere.py", "class Thing:\n    pass\n")
+    write("use.py", "import pkg\n\n\ndef go():\n    pkg.Thing()\n", commit="missing")
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    found = {(dst, conf) for src, dst, conf in edges(store) if src == "use.py::go"}
+    assert ("elsewhere.py::Thing", "HIGH") not in found
+    assert ("elsewhere.py::Thing", "MEDIUM") in found, "the weak path must still see it"
+    store.close()
+
+
+def test_a_star_import_is_not_followed(repo, write):
+    """`from .app import *` is deliberately not expanded.
+
+    Which names it binds depends on `__all__`, which is not recorded and which
+    real packages compute at runtime (`__all__ = [...] + other.__all__`).
+    Guessing "everything without a leading underscore" would claim HIGH for
+    names that may not be exported at all, so a name reachable only through a
+    star import keeps falling through to the weak path. Over-claiming here is
+    worse than not handling it.
+    """
+    write("pkg/__init__.py", "from .app import *\n")
+    write("pkg/app.py", "class Thing:\n    pass\n")
+    write("use.py", "import pkg\n\n\ndef go():\n    pkg.Thing()\n", commit="star")
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    found = {(dst, conf) for src, dst, conf in edges(store) if src == "use.py::go"}
+    assert ("pkg/app.py::Thing", "HIGH") not in found
+    # Not dropped either: the bare-name step still sees the one `Thing`.
+    assert ("pkg/app.py::Thing", "MEDIUM") in found
+    store.close()
+
+
+def test_the_qualname_after_a_reexported_name_rides_along(repo, write):
+    """`pkg.Thing.run()` where `pkg/__init__.py` says `from .app import Thing`.
+
+    The rewrite has to carry the segments AFTER the re-exported name: `Thing`
+    becomes `pkg.app.Thing`, and `run` is still `run` on whatever `Thing`
+    turned out to be. Dropping the tail resolves the call to the class instead
+    of to the method on it -- a confidently wrong edge, which is worse than the
+    LOW guess it replaces. (An earlier version of this test used
+    `pkg.helpers.build()` through a re-exported submodule and was VACUOUS: the
+    ordinary longest-module-prefix lookup answers that one before the re-export
+    step ever runs, so dropping the tail did not fail it.)
+    """
+    write("pkg/__init__.py", "from .app import Thing\n")
+    write("pkg/app.py", "class Thing:\n    @staticmethod\n    def run():\n        pass\n")
+    write("use.py", "import pkg\n\n\ndef go():\n    pkg.Thing.run()\n", commit="tail")
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    targets = {(dst, conf) for src, dst, conf in edges(store) if src == "use.py::go"}
+    assert ("pkg/app.py::Thing.run", "HIGH") in targets
+    assert not any(dst == "pkg/app.py::Thing" for dst, _ in targets), "the tail was dropped"
+    store.close()
+
+
+def test_from_package_import_name_also_follows_the_reexport(repo, write):
+    """`from pkg import Thing` is the other half of the same gap, and by volume
+    the bigger one: the alias map records the target as `pkg.Thing`, which is
+    the identical dotted name `pkg.Thing` at a call site produces, so both
+    forms were unresolvable for the same reason and both are fixed by the same
+    step."""
+    write("pkg/__init__.py", "from .app import Thing\n")
+    write("pkg/app.py", "class Thing:\n    pass\n")
+    write("use.py", "from pkg import Thing\n\n\ndef go():\n    Thing()\n", commit="fromimport")
+    store, indexer = build(repo)
+    indexer.reconcile("HEAD")
+    assert ("use.py::go", "pkg/app.py::Thing", "HIGH") in edges(store)
+    store.close()


### PR DESCRIPTION
Closes #38.

`class CustomFlask(flask.Flask)` resolved to nothing. `src/flask/__init__.py`
says `from .app import Flask`, but `_lookup_dotted` only looked for a name
DEFINED in the module a dotted prefix names: it found the module `flask`, looked
for a qualname `Flask` in `__init__.py`, did not find one, and gave up. The
reference then fell to the repo-wide bare-name step and came out *ambiguous* —
with exactly 2 candidates, only because a nested class in
`tests/test_config.py` is also called `Flask`.

218 of flask's 1039 ambiguous references were `flask.X`: the package's entire
public API. A category, not a quirk — almost every real Python package
re-exports its API from `__init__.py`, so this fired on the most-written form of
every import a library user makes. And it degraded to LOW, which `impact` hides
by default, so the public API of a framework was the part of the graph codegraph
was least confident about. The same inversion #34 fixed for `super()`.

## What changed

`AstResolver._lookup_dotted` now alternates two steps, bounded and
cycle-guarded:

1. is the remaining qualname **defined** in the module the prefix names?
2. if not, is it **imported** there? Rewrite the dotted name through that import
   and go round again.

`blob_imports` already recorded `module`/`level`/`name`/`alias` per blob and
`build_import_maps` already expanded relative imports, so no new data is
collected and there is **no `PARSER_VERSION` bump**. `ResolveContext` just
carries every path's alias map instead of only the current file's.

Files touched: `src/codegraph/resolve.py`, `tests/test_resolve.py`,
`tests/fixtures/labelled_calls.json`, `README.md`. Nothing else.

## The design calls

**Confidence: HIGH, and HIGH at any depth.** `from .app import Flask` is an
exact recorded fact about the source text — the same fact the single-hop
imported-name step has claimed HIGH since the beginning, read in another file.
Nothing is guessed: no MRO approximation, no instance type, no repo-wide name
search. A chain is a *conjunction* of such facts, so three of them are not less
certain than one; there is no per-hop probability to multiply. What can still be
wrong is a module rebinding the name at runtime, and that is exactly as true of
the existing HIGH step — this adds no new kind of doubt, it reads the same kind
of statement in a different file. Critically, the hop bound never yields a
*weaker* answer: exhausting it yields **no** answer, and the reference falls
through to the same weak path it takes today.

**Chain depth: bounded at 8 (`REEXPORT_HOPS`), termination guaranteed by a
`seen` set.** A re-export cycle necessarily reproduces a dotted name already
tried, so the `seen` set stops it before the bound does; the bound is a cost and
sanity guard with room to spare. Same discipline as `breadth_first`, `_mro` and
`_descendants`. Real chains are short — flask's whole public API is one hop.

**`import *`: not followed.** `build_import_maps` files it under the literal
name `*`, which no attribute access can spell, so a star import contributes
nothing here. Expanding it would mean deciding which of the starred module's
names are public, which `__all__` governs and which real packages compute at
runtime (`__all__ = [...] + other.__all__`). Guessing "everything without a
leading underscore" would claim HIGH for names that may not be exported at all.
Over-claiming here is worse than not handling it, so such a name keeps falling
to the weak path — exactly as it does today.

**`__all__`: deliberately ignored, and that is not an omission.** `__all__`
gates `from pkg import *` and nothing else. `flask.Flask` reads a module
attribute, and the attribute is there because the import bound it, whether or
not `__all__` mentions it.

**A local definition wins.** Definition-first ordering means an `__init__.py`
that both defines `Foo` and imports a different `Foo` resolves to the one a
reader looking it up in that file would find — the same rule
`constructor_target` applies to a method. Python itself would give the later
binding; `nodes` holds definitions, not assignment order, and preferring the
definition is the conservative half of that disagreement, because it never
invents a target in another file. Tested.

## Measured

One session, both sides on identical clean trees, trace reused, `--work`
database deleted between sides (the reconcile fingerprint does not cover the
resolver, so a rerun on an unchanged tree would otherwise score the stale
graph — see "Found but not fixed").

**pallets/flask** (`tests/`, 2683 judgeable traced edges):

| | before | after |
|---|---|---|
| recall | 0.29 | **0.29** |
| recall at HIGH/MEDIUM | 0.19 | **0.25** |
| conditional precision | 0.86 (206/239) | **0.93** (455/490) |
| edges | 1464 | 1893 |
| ambiguous refs | 1039 | 787 |
| `flask.X` ambiguous refs | **218** | **34** |
| constructor misses | 21 | 13 |

**psf/requests** (`test_utils.py`, `test_structures.py`): recall 0.79 → 0.79, at
HIGH/MEDIUM 0.76 → 0.76, conditional precision 0.99 → 0.99 (81/82 → 82/83);
edges 1343 → 1469, ambiguous refs 410 → 287.

### Recall did not move, and that is the honest headline

765 → 776 edges found, 0.29 both sides. It could not move much: recall counts an
edge the LOW bare-name fan-out would produce, and the fan-out already contained
the right answer — buried among the wrong ones. What moved is the **tier** the
answer is claimed at, which is what the issue was actually about, since `impact`
hides LOW by default and a right answer at LOW is one a reader never sees. The
README's benchmark section now says this instead of quoting the old numbers,
because it is a property of the benchmark worth knowing: **recall does not
distinguish a fact from a lucky guess.**

The reported case is fixed and verifiable directly: all 8 `class X(flask.Flask)`
declarations in flask's suite are now HIGH `INHERITS` edges to
`src/flask/app.py::Flask`, where before only `FlaskProxy` (which imports the
class directly, not through the package) had one.

The 34 surviving `flask.X` ambiguous references are all `flask.g.*` and
`flask.session.*` — context-local proxy objects bound by module-level
assignment, which `nodes` does not hold, so there is nothing to follow the
import *to*. Correctly not claimed.

Timing is not reported: this machine swings up to 4.6x from background load and
nothing here is on a hot path that a same-session A/B would have resolved
meaningfully. flask's index moved 0.5s → 2.7s in these two runs, which is within
that noise band and is not offered as a measurement.

## Tests

10 new tests in `tests/test_resolve.py`. **No existing test was changed,
weakened or removed** — 355 → 365 passing, `-m slow` 3 passing, accuracy
1.00/1.00, `ruff check` clean.

Every one was verified non-vacuous by breaking the implementation and watching
the named test fail (commit first, then probe):

| break | test that failed |
|---|---|
| don't follow at all | the plain re-export, the `class CustomFlask(flask.Flask)` INHERITS case, the alias, the two-hop chain, `from pkg import Thing` (5) |
| try the import before the definition | local definition beats a same-named re-export |
| rewrite through the name as written, not the import's target | the aliased re-export |
| drop the qualname after the followed name | `pkg.Thing.run` reaches the method, not the class |
| `REEXPORT_HOPS = 1` | the two-hop chain (single-hop test still passed) |
| expand `from .app import *` | the star-import test (it became a HIGH edge) |
| guess from the name index at HIGH once hops are exhausted | the not-re-exported test |
| remove **both** the `seen` guard and the hop bound | the cycle test — did not terminate in 240s |

Two notes on that table, in the interest of not overselling it. The cycle test
only fails when **both** guards are removed; with either one present the walk
terminates, so what it pins is termination, not the `seen` set specifically. And
my first attempt at the tail test was **vacuous**: it used `pkg.helpers.build()`
through a re-exported submodule, which the ordinary longest-module-prefix lookup
answers before the re-export step ever runs, so dropping the tail did not fail
it. It was replaced with `pkg.Thing.run()`, which does require the follow, and
the replacement's docstring records why.

`tests/fixtures/labelled_calls.json` gains four files and one label. **Added,
not changed** — no existing file's source and no existing label is touched. The
label is `pkg/reexport.py::build_engine -> pkg/api/impl.py::Engine` plus the
`__init__` it runs, with a second unrelated `Engine` in the fixture so the
bare-name fallback cannot answer it by uniqueness, which is flask's real
situation. It is non-vacuous: with the fix disabled the same fixture scores
precision 0.89 / recall 1.00 (recall stays 1.00 for the same reason flask's
does).

`src/codegraph/guide.md` and the generated `skills/codegraph/SKILL.md` are
unchanged: no command's output shape or documented behaviour changes, only which
tier an edge is recorded at. `README.md`'s confidence table gains the re-export
row and the two refusals stated explicitly.

## Found but not fixed

- **A resolver-only change does not invalidate the reconcile fingerprint.**
  `Indexer._fingerprint` pins `PARSER_VERSION`, the effect catalog and
  `source_roots` — not the resolver. So re-indexing an unchanged tree after
  editing `resolve.py` silently keeps the old edges, and a benchmark rerun in
  the same `--work` directory scores the graph you were trying to replace. I
  worked around it by deleting the database between sides; a `RESOLVER_VERSION`
  in that digest, or `bench.run` passing `--rebuild`, would remove the trap.
  Not fixed here because it changes cache-invalidation behaviour for every user
  and belongs in its own change.
- **Module-level bindings are still invisible.** `flask.g` and `flask.session`
  are `LocalProxy` instances created by assignment; `nodes` holds definitions,
  so following the import lands nowhere. That is the whole of the surviving
  `flask.X` ambiguity (34 refs).
- **The class-in-a-class-attribute gap from the issue's closing note is
  untouched.** `self.session_class(...)` / `cls.view_class(...)` accounted for
  19 of flask's 21 constructor misses; this change happened to fix 8 of the 21
  (a re-exported class named directly), leaving 13. Different mechanism, worth
  its own issue.
- **`ruff format` is not clean on `main`** (17 files would be reformatted), so
  it is not treated as a gate here and `resolve.py` is left in the house style
  of the file it edits.
